### PR TITLE
Adopt official mattn/goveralls integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,11 @@ jobs:
 
     - name: test
       run: |
-        go test -covermode=count -coverprofile=coverage.out ./...
+        go test -race -covermode=atomic -coverprofile=coverage.out ./...
 
     - name: coveralls
+      env:
+        COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
       run: |
         # https://github.com/mattn/goveralls#goveralls
-        $GOPATH/bin/goveralls -service=actions -coverprofile=coverage.out -repotoken=${{ secrets.COVERALLS_TOKEN }}
+        $(go env GOPATH)/bin/goveralls -service=github -coverprofile=coverage.out

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: coveralls
       env:
-        COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         # https://github.com/mattn/goveralls#goveralls
         $(go env GOPATH)/bin/goveralls -service=github -coverprofile=coverage.out


### PR DESCRIPTION
This follows the officially documented [goveralls](https://github.com/mattn/goveralls) integration with [Actions](https://github.com/features/actions):

https://github.com/mattn/goveralls#github-actions

Note that we are required to use the Github token instead of the Coveralls token:

https://github.com/mattn/goveralls/pull/144#discussion_r342997287

Might also help with fork PR runs?

https://github.com/mattn/goveralls/pull/144#discussion_r343013930