### PR TITLE
fix(source_repos): reverting source repos 'already-active' filter

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -224,20 +224,6 @@ func GetUserSourceRepos(c *gin.Context) {
 		output[srepo.GetOrg()] = append(output[srepo.GetOrg()], repo)
 	}
 
-	// remove already enabled repos from the result set
-	// TODO: clean this up
-	for _, drepo := range dbRepos {
-		if lrepos, ok := output[drepo.GetOrg()]; ok {
-			for i, outputRepo := range lrepos {
-				if outputRepo.GetName() == drepo.GetName() {
-					if drepo.GetActive() {
-						output[drepo.GetOrg()] = append(output[drepo.GetOrg()][:i], output[drepo.GetOrg()][i+1:]...)
-					}
-				}
-			}
-		}
-	}
-
 	c.JSON(http.StatusOK, output)
 }
 


### PR DESCRIPTION
For the UI to work with Favorites, we need to let the user see repos that have already been activated.
This way, they can add those repos to their favorites from the Add Repos page based on the Source Repos they have access to, even if someone else has already activated it.