### PR TITLE
fix: duplicate http.Request for webhook validation

### DIFF
--- a/api/webhook.go
+++ b/api/webhook.go
@@ -54,7 +54,11 @@ func PostWebhook(c *gin.Context) {
 	// This code is required due to a known bug:
 	//
 	// * https://github.com/golang/go/issues/36095
+
+	// create buffer for reading request body
 	var buf bytes.Buffer
+
+	// read the request body for duplication
 	_, err := buf.ReadFrom(c.Request.Body)
 	if err != nil {
 		retErr := fmt.Errorf("unable to read webhook body: %v", err)


### PR DESCRIPTION
## Part 1

I previously had attempted to fix this bug by duplicating the `gin.Context`:

https://github.com/go-vela/server/pull/98

Unfortunately, this didn't resolve the bug because the `http.Request` in that duplicated context always had an empty body.

To resolve this, we're now going to clone the request in the `gin.Context`, and pass that along to [where we call the VerifyWebhook()](https://github.com/go-vela/server/blob/eb0e218542c96fce173f834595457b6cfe0efa12/api/webhook.go#L110-L119) function.

Context:

I can't say with 100% certainty that this change is the golden fix, but it is at least still better.

I verified that we're now seeing the `http.Request` we pass to the [VerifyWebhook()](https://github.com/go-vela/server/blob/eb0e218542c96fce173f834595457b6cfe0efa12/source/github/webhook.go#L60-L69) function actually contains a body.

To see this, I dropped some `fmt.Println` statements outputting the body and payload length in that same `VerifyWebhook()` function before I made this change and I saw the following output:

```sh
Body Length:  0
Payload Length:  0
```

After making this change, I'm now seeing the following output from the same webhook being posted:

```sh
Body Length:  15441
Payload Length:  9619
```

## Part 2

I moved where we call the `VerifyWebhook()` function so that we actually create the received webhook in the Vela database. Previously, it was failing to verify the webhook **BEFORE** we created the hook in our database so it wasn't a great troubleshooting experience.