### PR TITLE
fix(secrets): allow secret images to be set to none

### DIFF
--- a/api/secret.go
+++ b/api/secret.go
@@ -225,8 +225,7 @@ func UpdateSecret(c *gin.Context) {
 		input.SetImages(unique(input.GetImages()))
 	}
 
-	if input.Events != nil {
-		// update events if set
+	if len(input.GetEvents()) > 0 {
 		input.SetEvents(unique(input.GetEvents()))
 	}
 

--- a/api/secret.go
+++ b/api/secret.go
@@ -220,11 +220,13 @@ func UpdateSecret(c *gin.Context) {
 	input.SetRepo(n)
 	input.SetType(t)
 
-	if len(input.GetImages()) > 0 {
+	if input.Images != nil {
+		// update images if set
 		input.SetImages(unique(input.GetImages()))
 	}
 
-	if len(input.GetEvents()) > 0 {
+	if input.Events != nil {
+		// update events if set
 		input.SetEvents(unique(input.GetEvents()))
 	}
 


### PR DESCRIPTION
example: current implementation does not allow `[ "library/node" ]` to be updated to `[]`