### PR TITLE
refactor(source): use TrimPrefix() over Replace()

### DIFF
--- a/source/github/webhook.go
+++ b/source/github/webhook.go
@@ -98,7 +98,7 @@ func processPushEvent(h *library.Hook, payload *github.PushEvent) (*types.Webhoo
 	b.SetSender(payload.GetSender().GetLogin())
 	b.SetAuthor(payload.GetHeadCommit().GetAuthor().GetLogin())
 	b.SetEmail(payload.GetHeadCommit().GetAuthor().GetEmail())
-	b.SetBranch(strings.Replace(payload.GetRef(), "refs/heads/", "", -1))
+	b.SetBranch(strings.TrimPrefix(payload.GetRef(), "refs/heads/"))
 	b.SetRef(payload.GetRef())
 	b.SetBaseRef(payload.GetBaseRef())
 
@@ -133,7 +133,7 @@ func processPushEvent(h *library.Hook, payload *github.PushEvent) (*types.Webhoo
 
 		// set the proper branch from the base ref
 		if strings.HasPrefix(payload.GetBaseRef(), "refs/heads/") {
-			b.SetBranch(strings.Replace(payload.GetBaseRef(), "refs/heads/", "", -1))
+			b.SetBranch(strings.TrimPrefix(payload.GetBaseRef(), "refs/heads/"))
 		}
 	}
 


### PR DESCRIPTION
This PR is based off of https://github.com/go-vela/compiler/pull/54 👍 

The thought is that `TrimPrefix()` is easier to read and understand what the code is doing.

Also, it's a more proper fit for the functionality we're trying to accomplish.

Thanks @wass3r 🎉 