### PR TITLE
fix(hooks): account for multiple hooks in repo disable

### DIFF
--- a/api/repo.go
+++ b/api/repo.go
@@ -454,6 +454,21 @@ func RepairRepo(c *gin.Context) {
 		return
 	}
 
+	// if the repo was previously inactive, mark it as active
+	if !r.GetActive() {
+		r.SetActive(true)
+
+		// send API call to update the repo
+		err = database.FromContext(c).UpdateRepo(r)
+		if err != nil {
+			retErr := fmt.Errorf("unable to set repo %s to active: %w", r.GetFullName(), err)
+
+			util.HandleError(c, http.StatusInternalServerError, retErr)
+
+			return
+		}
+	}
+
 	c.JSON(http.StatusOK, fmt.Sprintf("Repo %s repaired", r.GetFullName()))
 }
 

--- a/source/github/testdata/hooks_multi.json
+++ b/source/github/testdata/hooks_multi.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": 1,
+    "url": "https://api.github.com/repos/foo/bar/hooks/1",
+    "test_url": "https://api.github.com/repos/foo/bar/hooks/1/test",
+    "ping_url": "https://api.github.com/repos/foo/bar/hooks/1/pings",
+    "name": "web",
+    "events": [
+      "push",
+      "pull_request",
+      "deployment"
+    ],
+    "active": true,
+    "config": {
+      "url": "https://foo.bar.com/webhook",
+      "content_type": "form"
+    },
+    "updated_at": "2011-09-06T20:39:23Z",
+    "created_at": "2011-09-06T17:26:27Z"
+  },
+  {
+    "id": 2,
+    "url": "https://api.github.com/repos/foo/bar/hooks/2",
+    "test_url": "https://api.github.com/repos/foo/bar/hooks/2/test",
+    "ping_url": "https://api.github.com/repos/foo/bar/hooks/2/pings",
+    "name": "web",
+    "events": [
+      "push",
+      "pull_request",
+      "deployment"
+    ],
+    "active": true,
+    "config": {
+      "url": "https://foo.bar.com/webhook",
+      "content_type": "form"
+    },
+    "updated_at": "2011-09-06T20:39:23Z",
+    "created_at": "2011-09-06T17:26:27Z"
+  },
+  {
+    "id": 3,
+    "url": "https://api.github.com/repos/foo/bar/hooks/3",
+    "test_url": "https://api.github.com/repos/foo/bar/hooks/3/test",
+    "ping_url": "https://api.github.com/repos/foo/bar/hooks/3/pings",
+    "name": "web",
+    "events": [
+      "push",
+      "pull_request",
+      "deployment"
+    ],
+    "active": true,
+    "config": {
+      "url": "https://not.foo.bar.com/webhook",
+      "content_type": "form"
+    },
+    "updated_at": "2011-09-06T20:39:23Z",
+    "created_at": "2011-09-06T17:26:27Z"
+  }
+]


### PR DESCRIPTION
there are various scenarios where repositories might end up with multiple hooks for the same vela installation. this change will correct issues when trying to disable or repair repos with this scenario.

also sets the repo to active after a successful repair operation.