### PR TITLE
provides functionality of login using github token

### DIFF
--- a/api/authenticate.go
+++ b/api/authenticate.go
@@ -184,7 +184,7 @@ func AuthenticateCLI(c *gin.Context) {
 	}
 
 	// register user with OAuth application
-	newUser, err := source.FromContext(c).LoginCLI(input.GetUsername(), input.GetPassword(), input.GetOTP())
+	newUser, err := source.FromContext(c).LoginCLI(input.GetUsername(), input.GetPassword(), input.GetOTP(), input.GetToken())
 	if err != nil {
 		retErr := fmt.Errorf("unable to login user: %w", err)
 

--- a/api/authenticate.go
+++ b/api/authenticate.go
@@ -184,7 +184,8 @@ func AuthenticateCLI(c *gin.Context) {
 	}
 
 	// register user with OAuth application
-	newUser, err := source.FromContext(c).LoginCLI(input.GetUsername(), input.GetPassword(), input.GetOTP(), input.GetToken())
+	newUser, err := source.FromContext(c).LoginCLI(input.GetUsername(), input.GetPassword(), input.GetOTP(),
+		input.GetToken())
 	if err != nil {
 		retErr := fmt.Errorf("unable to login user: %w", err)
 

--- a/source/source.go
+++ b/source/source.go
@@ -27,7 +27,7 @@ type Service interface {
 	Login(http.ResponseWriter, *http.Request) (string, error)
 	// LoginCLI defines a function that begins
 	// the OAuth workflow for the session.
-	LoginCLI(string, string, string) (*library.User, error)
+	LoginCLI(string, string, string, string) (*library.User, error)
 
 	// Access Source Interface Functions
 


### PR DESCRIPTION
It only replaces that rather than getting the `authorization token` from the credentials provided, if we just pass the `token`, then we can eliminate the process of getting the token first and getting info. Just use the token provided and get the info from that token. 