### PR TITLE
feat(source): set build status for deployments

### DIFF
--- a/source/github/repo_test.go
+++ b/source/github/repo_test.go
@@ -5,6 +5,7 @@
 package github
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -478,6 +479,51 @@ func TestGithub_Enable(t *testing.T) {
 
 	if err != nil {
 		t.Errorf("Enable returned err: %v", err)
+	}
+}
+
+func TestGithub_Status_Deployment(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	resp := httptest.NewRecorder()
+	_, engine := gin.CreateTestContext(resp)
+
+	// setup mock server
+	engine.POST("/api/v3/repos/:org/:repo/deployments/:deployment/statuses", func(c *gin.Context) {
+		c.Header("Content-Type", "application/json")
+		c.Status(http.StatusOK)
+		c.File("testdata/status.json")
+	})
+
+	s := httptest.NewServer(engine)
+	defer s.Close()
+
+	// setup types
+	u := new(library.User)
+	u.SetName("foo")
+	u.SetToken("bar")
+
+	b := new(library.Build)
+	b.SetID(1)
+	b.SetRepoID(1)
+	b.SetNumber(1)
+	b.SetEvent(constants.EventDeploy)
+	b.SetStatus(constants.StatusRunning)
+	b.SetCommit("abcd1234")
+	b.SetSource(fmt.Sprintf("%s/%s/%s/deployments/1", s.URL, "foo", "bar"))
+
+	client, _ := NewTest(s.URL)
+
+	// run test
+	err := client.Status(u, b, "foo", "bar")
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
+	}
+
+	if err != nil {
+		t.Errorf("Status returned err: %v", err)
 	}
 }
 


### PR DESCRIPTION
closes https://github.com/go-vela/community/issues/67

GitHub has a completely different endpoint for setting a status for a deployment:

https://developer.github.com/v3/repos/deployments/#create-a-deployment-status

In order to use this endpoint, we need to know the deployment ID we're dealing with thats tracked in the `build.Source` field 👍 

This PR adds the functionality to capture the deployment ID from the `build.Source` field.

Using that information, we're then able to create a status on the deployment so they're no longer marked as "abandoned".

Also contained in this PR is a new test to ensure the code written works 😄 