### PR TITLE
fix(postgres): update favorites column in user table to 5000

### DIFF
--- a/database/ddl/postgres/user.go
+++ b/database/ddl/postgres/user.go
@@ -15,7 +15,7 @@ users (
 	name      VARCHAR(250),
 	token     VARCHAR(500),
 	hash      VARCHAR(500),
-	favorites VARCHAR(1000),
+	favorites VARCHAR(5000),
 	active    BOOLEAN,
 	admin     BOOLEAN,
 	UNIQUE(name)


### PR DESCRIPTION
This PR updates the size of the `favorites` column in the `users` table to `5000`.

It previously was `1000` which allowed for ~ 30 repos to be favorited depending on the size of the repo names.

As an example, a user/team who favorites repos that are named like this:

* superCrazyLongOrgName/superCrazyLongRepoName

are going to fill up that `favorites` column a lot faster than a user/team who favorites repos that are named like this:

* shortOrg/shortRepo