### PR TITLE
fix(secrets): properly set default value for allow_command

### DIFF
--- a/api/secret.go
+++ b/api/secret.go
@@ -120,7 +120,7 @@ func CreateSecret(c *gin.Context) {
 		input.SetEvents(defaultEvents)
 	}
 
-	if !input.GetAllowCommand() {
+	if input.AllowCommand == nil {
 		input.SetAllowCommand(true)
 	}
 

--- a/secret/vault/vault.go
+++ b/secret/vault/vault.go
@@ -147,6 +147,15 @@ func secretFromVault(vault *api.Secret) *library.Secret {
 		}
 	}
 
+	// set allow_command if found in Vault secret
+	v, ok = data["allow_command"]
+	if ok {
+		command, ok := v.(bool)
+		if ok {
+			s.SetAllowCommand(command)
+		}
+	}
+
 	return s
 }
 
@@ -193,6 +202,11 @@ func vaultFromSecret(s *library.Secret) *api.Secret {
 	// set value if found in Database secret
 	if len(s.GetValue()) > 0 {
 		vault.Data["value"] = s.GetValue()
+	}
+
+	// set allow_command if found in Database secret
+	if s.AllowCommand != nil {
+		vault.Data["allow_command"] = s.GetAllowCommand()
 	}
 
 	return vault

--- a/secret/vault/vault_test.go
+++ b/secret/vault/vault_test.go
@@ -85,6 +85,7 @@ func TestVault_secretFromVault(t *testing.T) {
 			"team":   "foob",
 			"type":   "org",
 			"value":  "baz",
+			"allow_command": true,
 		},
 	}
 
@@ -99,6 +100,7 @@ func TestVault_secretFromVault(t *testing.T) {
 				"team":   "foob",
 				"type":   "org",
 				"value":  "baz",
+				"allow_command": true,
 			},
 		},
 	}
@@ -110,6 +112,7 @@ func TestVault_secretFromVault(t *testing.T) {
 	value := "baz"
 	typee := "org"
 	arr := []string{"foo", "bar"}
+	commands := true
 	want := &library.Secret{
 		Org:    &org,
 		Repo:   &repo,
@@ -119,6 +122,7 @@ func TestVault_secretFromVault(t *testing.T) {
 		Type:   &typee,
 		Images: &arr,
 		Events: &arr,
+		AllowCommand: &commands,
 	}
 
 	type args struct {
@@ -151,6 +155,7 @@ func TestVault_vaultFromSecret(t *testing.T) {
 	value := "baz"
 	typee := "org"
 	arr := []string{"foo", "bar"}
+	commands := true
 	s := &library.Secret{
 		Org:    &org,
 		Repo:   &repo,
@@ -160,6 +165,7 @@ func TestVault_vaultFromSecret(t *testing.T) {
 		Type:   &typee,
 		Images: &arr,
 		Events: &arr,
+		AllowCommand: &commands,
 	}
 
 	want := &api.Secret{
@@ -172,6 +178,7 @@ func TestVault_vaultFromSecret(t *testing.T) {
 			"team":   "foob",
 			"type":   "org",
 			"value":  "baz",
+			"allow_command": true,
 		},
 	}
 

--- a/secret/vault/vault_test.go
+++ b/secret/vault/vault_test.go
@@ -77,14 +77,14 @@ func TestVault_secretFromVault(t *testing.T) {
 	// setup types
 	inputV1 := &api.Secret{
 		Data: map[string]interface{}{
-			"events": []interface{}{"foo", "bar"},
-			"images": []interface{}{"foo", "bar"},
-			"name":   "bar",
-			"org":    "foo",
-			"repo":   "*",
-			"team":   "foob",
-			"type":   "org",
-			"value":  "baz",
+			"events":        []interface{}{"foo", "bar"},
+			"images":        []interface{}{"foo", "bar"},
+			"name":          "bar",
+			"org":           "foo",
+			"repo":          "*",
+			"team":          "foob",
+			"type":          "org",
+			"value":         "baz",
 			"allow_command": true,
 		},
 	}
@@ -92,14 +92,14 @@ func TestVault_secretFromVault(t *testing.T) {
 	inputV2 := &api.Secret{
 		Data: map[string]interface{}{
 			"data": map[string]interface{}{
-				"events": []interface{}{"foo", "bar"},
-				"images": []interface{}{"foo", "bar"},
-				"name":   "bar",
-				"org":    "foo",
-				"repo":   "*",
-				"team":   "foob",
-				"type":   "org",
-				"value":  "baz",
+				"events":        []interface{}{"foo", "bar"},
+				"images":        []interface{}{"foo", "bar"},
+				"name":          "bar",
+				"org":           "foo",
+				"repo":          "*",
+				"team":          "foob",
+				"type":          "org",
+				"value":         "baz",
 				"allow_command": true,
 			},
 		},
@@ -114,14 +114,14 @@ func TestVault_secretFromVault(t *testing.T) {
 	arr := []string{"foo", "bar"}
 	commands := true
 	want := &library.Secret{
-		Org:    &org,
-		Repo:   &repo,
-		Team:   &team,
-		Name:   &name,
-		Value:  &value,
-		Type:   &typee,
-		Images: &arr,
-		Events: &arr,
+		Org:          &org,
+		Repo:         &repo,
+		Team:         &team,
+		Name:         &name,
+		Value:        &value,
+		Type:         &typee,
+		Images:       &arr,
+		Events:       &arr,
 		AllowCommand: &commands,
 	}
 
@@ -157,27 +157,27 @@ func TestVault_vaultFromSecret(t *testing.T) {
 	arr := []string{"foo", "bar"}
 	commands := true
 	s := &library.Secret{
-		Org:    &org,
-		Repo:   &repo,
-		Team:   &team,
-		Name:   &name,
-		Value:  &value,
-		Type:   &typee,
-		Images: &arr,
-		Events: &arr,
+		Org:          &org,
+		Repo:         &repo,
+		Team:         &team,
+		Name:         &name,
+		Value:        &value,
+		Type:         &typee,
+		Images:       &arr,
+		Events:       &arr,
 		AllowCommand: &commands,
 	}
 
 	want := &api.Secret{
 		Data: map[string]interface{}{
-			"events": []string{"foo", "bar"},
-			"images": []string{"foo", "bar"},
-			"name":   "bar",
-			"org":    "foo",
-			"repo":   "*",
-			"team":   "foob",
-			"type":   "org",
-			"value":  "baz",
+			"events":        []string{"foo", "bar"},
+			"images":        []string{"foo", "bar"},
+			"name":          "bar",
+			"org":           "foo",
+			"repo":          "*",
+			"team":          "foob",
+			"type":          "org",
+			"value":         "baz",
 			"allow_command": true,
 		},
 	}


### PR DESCRIPTION
The current implementation will incorrectly update the `AllowCommand` to be `true` even if the user supplies `false`. For example: 

```
vela add secret --secret.engine vault --secret.type repo --org JordanSussman --repo vela-local-test --name test --value bar --event comment --event deployment --event pull_request --event push --event tag --commands=false
{
	AllowCommand: true,
	Events: [comment deployment pull_request push tag],
	ID: 0,
	Images: [],
	Name: test,
	Org: JordanSussman,
	Repo: vela-local-test,
	Team: ,
	Type: repo,
	Value: [secure],
}
```