### PR TITLE
fix(api): setting active flag for repo

### DIFF
--- a/api/repo.go
+++ b/api/repo.go
@@ -96,7 +96,7 @@ func CreateRepo(c *gin.Context) {
 	// update fields in repo object
 	input.SetUserID(u.GetID())
 
-	if input.Active != nil {
+	if input.Active == nil {
 		input.SetActive(true)
 	}
 

--- a/api/repo.go
+++ b/api/repo.go
@@ -96,7 +96,7 @@ func CreateRepo(c *gin.Context) {
 	// update fields in repo object
 	input.SetUserID(u.GetID())
 
-	if !input.GetActive() {
+	if input.Active != nil {
 		input.SetActive(true)
 	}
 


### PR DESCRIPTION
See https://github.com/go-vela/cli/pull/163 for more information.

This PR updates the `active` flag to have a default value of `true` **only** if it hasn't been provided in the request body 👍 