### PR TITLE
fix(build): restart on build without changeset

### DIFF
--- a/api/build.go
+++ b/api/build.go
@@ -172,6 +172,7 @@ func CreateBuild(c *gin.Context) {
 		// capture number from build
 		number, err := getPRNumberFromBuild(input)
 		if err != nil {
+			// nolint:lll // long log message
 			retErr := fmt.Errorf("unable to create build: failed to get pull_request number for %s: %w", r.GetFullName(), err)
 
 			util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -518,6 +519,7 @@ func RestartBuild(c *gin.Context) {
 		// capture number from build
 		number, err := getPRNumberFromBuild(b)
 		if err != nil {
+			// nolint:lll // long log message
 			retErr := fmt.Errorf("unable to restart build: failed to get pull_request number for %s: %w", r.GetFullName(), err)
 
 			util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -815,6 +817,7 @@ func getPRNumberFromBuild(b *library.Build) (int, error) {
 	}
 
 	// just being safe to avoid out of range index errors
+	// nolint:gomnd // magic number of 3 used once
 	if len(parts) < 3 {
 		return 0, fmt.Errorf("invalid ref: %s", b.GetRef())
 	}

--- a/api/build.go
+++ b/api/build.go
@@ -169,7 +169,7 @@ func CreateBuild(c *gin.Context) {
 
 	// handle getting changeset from a pull_request
 	if strings.EqualFold(input.GetEvent(), constants.EventPull) {
-		// capture number by converting from string
+		// capture number from build
 		number, err := getPRNumberFromBuild(input)
 		if err != nil {
 			retErr := fmt.Errorf("unable to create build: failed to get pull_request number for %s: %w", r.GetFullName(), err)
@@ -515,6 +515,7 @@ func RestartBuild(c *gin.Context) {
 
 	// handle getting changeset from a pull_request
 	if strings.EqualFold(b.GetEvent(), constants.EventPull) {
+		// capture number from build
 		number, err := getPRNumberFromBuild(b)
 		if err != nil {
 			retErr := fmt.Errorf("unable to restart build: failed to get pull_request number for %s: %w", r.GetFullName(), err)


### PR DESCRIPTION
fixes https://github.com/go-vela/community/issues/116

we have applied a similar fix in https://github.com/go-vela/server/pull/166 and missed a couple of instances. applied it in `RestartBuild` and then also noticed it in `CreateBuild`.