### PR TITLE
fix: webhook race condition on build creation

### DIFF
--- a/api/build.go
+++ b/api/build.go
@@ -832,11 +832,12 @@ func DeleteBuild(c *gin.Context) {
 // and services, for the build in the configured backend.
 func planBuild(database database.Service, p *pipeline.Build, b *library.Build, r *library.Repo) error {
 	// update fields in build object
-	b.SetEnqueued(time.Now().UTC().Unix())
+	b.SetCreated(time.Now().UTC().Unix())
 
 	// send API call to create the build
 	err := database.CreateBuild(b)
 	if err != nil {
+		// clean up the objects from the pipeline in the database
 		cleanBuild(database, b, nil, nil)
 
 		return fmt.Errorf("unable to create new build for %s: %v", r.GetFullName(), err)
@@ -848,6 +849,7 @@ func planBuild(database database.Service, p *pipeline.Build, b *library.Build, r
 	// plan all services for the build
 	services, err := planServices(database, p, b)
 	if err != nil {
+		// clean up the objects from the pipeline in the database
 		cleanBuild(database, b, services, nil)
 
 		return err
@@ -856,6 +858,7 @@ func planBuild(database database.Service, p *pipeline.Build, b *library.Build, r
 	// plan all steps for the build
 	steps, err := planSteps(database, p, b)
 	if err != nil {
+		// clean up the objects from the pipeline in the database
 		cleanBuild(database, b, services, steps)
 
 		return err

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -263,6 +263,11 @@ func PostWebhook(c *gin.Context) {
 		return
 	}
 
+	// update fields in build object
+	b.SetNumber(1)
+	b.SetParent(b.GetNumber())
+	b.SetStatus(constants.StatusPending)
+
 	// if this is a comment on a pull_request event
 	if strings.EqualFold(b.GetEvent(), constants.EventComment) && webhook.PRNumber > 0 {
 		commit, branch, baseref, headref, err := source.FromContext(c).GetPullRequest(u, r, webhook.PRNumber)
@@ -280,38 +285,6 @@ func PostWebhook(c *gin.Context) {
 		b.SetBranch(strings.Replace(branch, "refs/heads/", "", -1))
 		b.SetBaseRef(baseref)
 		b.SetHeadRef(headref)
-	}
-
-	// send API call to capture the last build for the repo
-	lastBuild, err := database.FromContext(c).GetLastBuild(r)
-	if err != nil {
-		retErr := fmt.Errorf("%s: failed to get last build for %s: %v", baseErr, r.GetFullName(), err)
-		util.HandleError(c, http.StatusInternalServerError, retErr)
-
-		h.SetStatus(constants.StatusFailure)
-		h.SetError(retErr.Error())
-
-		return
-	}
-
-	// update fields in build object
-	b.SetNumber(1)
-	b.SetParent(b.GetNumber())
-	b.SetStatus(constants.StatusPending)
-	b.SetCreated(time.Now().UTC().Unix())
-
-	if lastBuild != nil {
-		b.SetNumber(
-			lastBuild.GetNumber() + 1,
-		)
-		b.SetParent(lastBuild.GetNumber())
-	}
-
-	// populate the build link if a web address is provided
-	if len(m.Vela.WebAddress) > 0 {
-		b.SetLink(
-			fmt.Sprintf("%s/%s/%d", m.Vela.WebAddress, r.GetFullName(), b.GetNumber()),
-		)
 	}
 
 	// variable to store changeset files
@@ -361,34 +334,112 @@ func PostWebhook(c *gin.Context) {
 		return
 	}
 
-	// parse and compile the pipeline configuration file
-	p, err := compiler.FromContext(c).
-		WithBuild(b).
-		WithComment(webhook.Comment).
-		WithFiles(files).
-		WithMetadata(m).
-		WithRepo(r).
-		WithUser(u).
-		Compile(config)
-	if err != nil {
-		retErr := fmt.Errorf("%s: failed to compile pipeline configuration for %s: %v", baseErr, r.GetFullName(), err)
-		util.HandleError(c, http.StatusInternalServerError, retErr)
+	// variable to store pipeline
+	var p *pipeline.Build
+	// number of times to retry
+	retryLimit := 5
 
-		h.SetStatus(constants.StatusFailure)
-		h.SetError(retErr.Error())
+	// iterate through with a retryLimit
+	for i := 0; i < retryLimit; i++ {
+		// check if we're on the first iteration of the loop
+		if i > 0 {
+			// incrementally sleep in between retries
+			time.Sleep(time.Duration(i) * time.Second)
+		}
 
-		return
-	}
+		// send API call to capture the last build for the repo
+		lastBuild, err := database.FromContext(c).GetLastBuild(r)
+		if err != nil {
+			// format the error message with extra information
+			err = fmt.Errorf("unable to get last build for %s: %v", r.GetFullName(), err)
 
-	// create the objects from the pipeline in the database
-	err = planBuild(database.FromContext(c), p, b, r)
-	if err != nil {
-		util.HandleError(c, http.StatusInternalServerError, err)
+			// log the error for traceability
+			logrus.Error(err.Error())
 
-		h.SetStatus(constants.StatusFailure)
-		h.SetError(err.Error())
+			// check if the retry limit has been exceeded
+			if i < retryLimit {
+				// continue to the next iteration of the loop
+				continue
+			}
 
-		return
+			retErr := fmt.Errorf("%s: %v", baseErr, err)
+			util.HandleError(c, http.StatusInternalServerError, retErr)
+
+			h.SetStatus(constants.StatusFailure)
+			h.SetError(retErr.Error())
+
+			return
+		}
+
+		// populate the build numbers based off the last build
+		if lastBuild != nil {
+			b.SetNumber(
+				lastBuild.GetNumber() + 1,
+			)
+			b.SetParent(lastBuild.GetNumber())
+		}
+
+		// populate the build link if a web address is provided
+		if len(m.Vela.WebAddress) > 0 {
+			b.SetLink(
+				fmt.Sprintf("%s/%s/%d", m.Vela.WebAddress, r.GetFullName(), b.GetNumber()),
+			)
+		}
+
+		// parse and compile the pipeline configuration file
+		p, err = compiler.FromContext(c).
+			WithBuild(b).
+			WithComment(webhook.Comment).
+			WithFiles(files).
+			WithMetadata(m).
+			WithRepo(r).
+			WithUser(u).
+			Compile(config)
+		if err != nil {
+			// format the error message with extra information
+			err = fmt.Errorf("unable to compile pipeline configuration for %s: %v", r.GetFullName(), err)
+
+			// log the error for traceability
+			logrus.Error(err.Error())
+
+			// check if the retry limit has been exceeded
+			if i < retryLimit {
+				// continue to the next iteration of the loop
+				continue
+			}
+
+			retErr := fmt.Errorf("%s: %v", baseErr, err)
+			util.HandleError(c, http.StatusInternalServerError, retErr)
+
+			h.SetStatus(constants.StatusFailure)
+			h.SetError(retErr.Error())
+
+			return
+		}
+
+		// create the objects from the pipeline in the database
+		err = planBuild(database.FromContext(c), p, b, r)
+		if err != nil {
+			// log the error for traceability
+			logrus.Error(err.Error())
+
+			// check if the retry limit has been exceeded
+			if i < retryLimit {
+				// continue to the next iteration of the loop
+				continue
+			}
+
+			retErr := fmt.Errorf("%s: %v", baseErr, err)
+			util.HandleError(c, http.StatusInternalServerError, retErr)
+
+			h.SetStatus(constants.StatusFailure)
+			h.SetError(retErr.Error())
+
+			return
+		}
+
+		// break the loop because everything was successful
+		break
 	}
 
 	// send API call to capture the triggered build
@@ -418,6 +469,9 @@ func PostWebhook(c *gin.Context) {
 // publishToQueue is a helper function that creates
 // a build item and publishes it to the queue.
 func publishToQueue(queue queue.Service, p *pipeline.Build, b *library.Build, r *library.Repo, u *library.User) {
+	// update fields in build object
+	b.SetEnqueued(time.Now().UTC().Unix())
+
 	item := types.ToItem(p, b, r, u)
 
 	logrus.Infof("Converting queue item to json for build %d for %s", b.GetNumber(), r.GetFullName())


### PR DESCRIPTION
Currently, there is a pesky bug that our users experience when Vela processes a webhook:

```sql
unable to create new build for <org>/<repo>: pq: duplicate key value violates unique constraint "builds_repo_id_number_key"
```

This error is displayed when we attempt to create a build in the database that contains the same build `number` and `repo_id`.

This attempts to resolve that issue by creating a retry loop with backoff that will repeat the following operations:

* capture the last build for the repo
* set fields on the new build object to be created in the database
* compile the pipeline with the new build object
* create the pipeline objects (i.e. build, services, steps) in the database

## Background

The source of the error message can be found in our webhook workflow, where at the very end we call `planBuild()`:

* [go-vela/server/api/webhook.go](https://github.com/go-vela/server/blob/master/api/webhook.go#L383-L392)

The `planBuild()` function is responsible for creating all pipeline objects in the database (i.e. build, services, steps):

* [go-vela/server/api/build.go](https://github.com/go-vela/server/blob/master/api/build.go#L830-L865)

In case it's unclear, here is the exact line where that error message is produced:

* [go-vela/server/api/build.go](https://github.com/go-vela/server/blob/master/api/build.go#L841)

## Details

We've covered where the bug and error is coming from but we haven't exactly covered **WHY** the error is being displayed.

When a commit is pushed to a repo, that has Vela enabled, this will typically prompt GitHub to fire a `push` webhook to Vela.

However, if you are committing to a `branch` of the repo that already has an open pull request, then GitHub will also fire a `pull_request` webhook to Vela.

This leads to a potential race condition where the individual webhooks being processed for each event leads to them attempting to reference the same last build number for the repo.

This in turn, leads to Vela attempting to create a build for each event with the same build number, rather than incrementally building off each other.