### PR TITLE
fix: webhook race condition on build creation v2

### DIFF
--- a/api/webhook.go
+++ b/api/webhook.go
@@ -337,7 +337,7 @@ func PostWebhook(c *gin.Context) {
 	// variable to store pipeline
 	var p *pipeline.Build
 	// number of times to retry
-	retryLimit := 5
+	retryLimit := 3
 
 	// iterate through with a retryLimit
 	for i := 0; i < retryLimit; i++ {

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -437,7 +437,14 @@ func PostWebhook(c *gin.Context) {
 	}
 
 	// send API call to capture the triggered build
-	b, _ = database.FromContext(c).GetBuild(b.GetNumber(), r)
+	b, err = database.FromContext(c).GetBuild(b.GetNumber(), r)
+	if err != nil {
+		retErr := fmt.Errorf("%s: failed to get new build %s/%d: %v", baseErr, r.GetFullName(), b.GetNumber(), err)
+		util.HandleError(c, http.StatusInternalServerError, retErr)
+
+		h.SetStatus(constants.StatusFailure)
+		h.SetError(retErr.Error())
+	}
 
 	// set the BuildID field
 	h.SetBuildID(b.GetID())

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -402,12 +402,6 @@ func PostWebhook(c *gin.Context) {
 			// log the error for traceability
 			logrus.Error(err.Error())
 
-			// check if the retry limit has been exceeded
-			if i < retryLimit {
-				// continue to the next iteration of the loop
-				continue
-			}
-
 			retErr := fmt.Errorf("%s: %v", baseErr, err)
 			util.HandleError(c, http.StatusInternalServerError, retErr)
 


### PR DESCRIPTION
More context and information can be found with https://github.com/go-vela/server/pull/186

This is intended to fix a few consequential side effects from the previous change (above linked PR):

* decrease the retry limit from `5` to `3`
* skip retrying the compilation of the pipeline on failures
* add extra error handling after creating the build in the database

More information on each change is described below 👍 

## Retry Limit

Currently, the webhook process has a retry loop that has a limit of `5` and incrementally sleeps between each iteration.

However, the amount of time spent sleeping between the iterations grows to where it exceeds timeouts for the source provider.

As an example, GitHub currently has a timeout of ~ `10s` of waiting for a response from the webhook.

Since the retry limit is set to `5`, this means we can wait for a potential maximum of `10s` between the retries:

```
0s (iteration 1) + 1s (iteration 2) + 2s (iteration 3) + 3s (iteration 4) + 4s (iteration 5) = 10s
```

By decreasing the retry limit to `3`, this should bring us to a more manageable potential maximum of `3s` between retries:

```
0s (iteration 1) + 1s (iteration 2) + 2s (iteration 3) = 3s
```

## Skip Compilation Retry

Currently, the webhook process will attempt to recompile the pipeline on every iteration of the loop.

If there is a failure when compiling the pipeline, we then log the error message and continue to the next iteration.

The issue this causes is that if the pipeline has invalid syntax, the pipeline will always fail regardless of the logic we retry.

To address this, Vela will not continue to the next iteration if there is a failure when compiling the pipeline.

## Extra Error Handling

Currently, the webhook process assumes the build exists in the database right before pushing it to the queue.

This change is at the end of the webhook process and is designed to be a catch-all.

This will perform a hard stop on the webhook processing if the newly created build can't be found in the database.