### PR TITLE
chore(docker): publish alpine images

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -37,3 +37,13 @@ jobs:
         tag_names: true
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: publish-alpine
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: target/vela-server
+        cache: true
+        tags: "${{ env.GITHUB_TAG }}-alpine"
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        dockerfile: Dockerfile-alpine

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,3 +30,13 @@ jobs:
         cache: true
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: publish-alpine
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: target/vela-server
+        cache: true
+        tags: "latest-alpine"
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        dockerfile: Dockerfile-alpine

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+#
+# Use of this source code is governed by the LICENSE file in this repository.
+
+FROM alpine
+
+RUN apk add --update --no-cache ca-certificates
+
+EXPOSE 8080
+
+ENV GODEBUG=netdns=go
+
+ADD release/vela-server /bin/
+
+CMD ["/bin/vela-server"]


### PR DESCRIPTION
Adding another `Dockerfile` based on alpine since I unfortunately need access to some image with a shell to allow me to modify the environment variables before the binary is started. My specific use case involves needing to generate the `VELA_DATABASE_CONFIG` and `VELA_QUEUE_CONFIG` environment variables utilizing others that are injected at run time.

## changes

- Add `Dockerfile-alpine` file to utilize alpine as base image instead of scratch
- Update `.github/workflows/publish.yml` to publish `latest-alpine` image
- Update `.github/workflows/prerelease.yml` to publish `${GITHUB_TAG}-latest` image
