### PR TITLE
enhancement: add flag for disabling webhook validation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,6 +64,9 @@ echo "VELA_SOURCE_CLIENT=<Github Client ID>" >> secrets.env
 
 # Add Github Client Secret to local secrets file for `docker-compose`
 echo "VELA_SOURCE_SECRET=<Github Client Secret>" >> secrets.env
+
+# Disable webhook validation
+echo "VELA_DISABLE_WEBHOOK_VALIDATION=true" >> secrets.env
 ```
 
 ### Running Locally

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,9 +64,6 @@ echo "VELA_SOURCE_CLIENT=<Github Client ID>" >> secrets.env
 
 # Add Github Client Secret to local secrets file for `docker-compose`
 echo "VELA_SOURCE_SECRET=<Github Client Secret>" >> secrets.env
-
-# Disable webhook validation
-echo "VELA_DISABLE_WEBHOOK_VALIDATION=true" >> secrets.env
 ```
 
 ### Running Locally

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -107,6 +107,8 @@ make rebuild
 docker-compose -f docker-compose.yml build
 ```
 
+* Accessing the Web UI: http://localhost:8888
+
 ### Development
 
 **Please see our [local development documentation](DOCS.md) for more information.**

--- a/api/repo.go
+++ b/api/repo.go
@@ -162,31 +162,33 @@ func CreateRepo(c *gin.Context) {
 	}
 
 	// send API call to create the webhook
-	url, err := source.FromContext(c).Enable(u, input.GetOrg(), input.GetName(), input.GetHash())
-	if err != nil {
-		retErr := fmt.Errorf("unable to create webhook for %s: %w", r.GetFullName(), err)
+	if c.Value("webhookvalidation").(bool) {
+		url, err := source.FromContext(c).Enable(u, input.GetOrg(), input.GetName(), input.GetHash())
+		if err != nil {
+			retErr := fmt.Errorf("unable to create webhook for %s: %w", r.GetFullName(), err)
 
-		switch err.Error() {
-		case "Repo already enabled":
-			util.HandleError(c, http.StatusConflict, retErr)
-			return
-		case "Repo not found":
-			util.HandleError(c, http.StatusNotFound, retErr)
+			switch err.Error() {
+			case "Repo already enabled":
+				util.HandleError(c, http.StatusConflict, retErr)
+				return
+			case "Repo not found":
+				util.HandleError(c, http.StatusNotFound, retErr)
+				return
+			}
+
+			util.HandleError(c, http.StatusInternalServerError, retErr)
+
 			return
 		}
 
-		util.HandleError(c, http.StatusInternalServerError, retErr)
+		// TODO: build these from the source client
+		if len(input.GetLink()) == 0 {
+			input.SetLink(url)
+		}
 
-		return
-	}
-
-	// TODO: build these from the source client
-	if len(input.GetLink()) == 0 {
-		input.SetLink(url)
-	}
-
-	if len(input.GetClone()) == 0 {
-		input.SetClone(fmt.Sprintf("%s.git", url))
+		if len(input.GetClone()) == 0 {
+			input.SetClone(fmt.Sprintf("%s.git", url))
+		}
 	}
 
 	if len(r.GetOrg()) > 0 && !r.GetActive() {

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -203,15 +203,17 @@ func PostWebhook(c *gin.Context) {
 	h, _ = database.FromContext(c).GetHook(h.GetNumber(), r)
 
 	// verify the webhook from the source control provider
-	err = source.FromContext(c).VerifyWebhook(dupRequest, r)
-	if err != nil {
-		retErr := fmt.Errorf("unable to verify webhook: %v", err)
-		util.HandleError(c, http.StatusUnauthorized, retErr)
+	if c.Value("webhookvalidation").(bool) {
+		err = source.FromContext(c).VerifyWebhook(dupRequest, r)
+		if err != nil {
+			retErr := fmt.Errorf("unable to verify webhook: %v", err)
+			util.HandleError(c, http.StatusUnauthorized, retErr)
 
-		h.SetStatus(constants.StatusFailure)
-		h.SetError(retErr.Error())
+			h.SetStatus(constants.StatusFailure)
+			h.SetError(retErr.Error())
 
-		return
+			return
+		}
 	}
 
 	// check if the repo is active

--- a/cmd/vela-server/main.go
+++ b/cmd/vela-server/main.go
@@ -53,6 +53,12 @@ func main() {
 			Usage:   "allowlist is used to limit which repos can be activated within the system",
 			Value:   &cli.StringSlice{},
 		},
+		&cli.BoolFlag{
+			EnvVars: []string{"VELA_DISABLE_WEBHOOK_VALIDATION"},
+			Name:    "vela-disable-webhook-validation",
+			Usage:   "determines whether or not webhook validation is disabled.  useful for local development.",
+			Value:   false,
+		},
 
 		// Compiler Flags
 

--- a/cmd/vela-server/server.go
+++ b/cmd/vela-server/server.go
@@ -92,6 +92,7 @@ func server(c *cli.Context) error {
 		middleware.Secrets(secrets),
 		middleware.Source(source),
 		middleware.Allowlist(c.StringSlice("vela-repo-allowlist")),
+		middleware.WebhookValidation(!c.Bool("vela-disable-webhook-validation")),
 	)
 
 	var tomb tomb.Tomb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,16 @@ version: '3'
 
 services:
 
-  vela:
-    container_name: vela
+  server:
+    container_name: server
     build:
       context: .
       dockerfile: Dockerfile
-    image: vela:local
     networks:
       - vela
     environment:
-      VELA_ADDR: "http://localhost:8080"
+      VELA_ADDR: 'http://localhost:8080'
+      VELA_WEBUI_ADDR: 'http://ui:80'
       VELA_DATABASE_DRIVER: postgres
       VELA_DATABASE_CONFIG: postgres://vela:zB7mrKDTZqNeNTD8z47yG4DHywspAh@postgres:5432/vela?sslmode=disable
       VELA_LOG_LEVEL: trace
@@ -39,6 +39,41 @@ services:
       - postgres
       - redis
       - vault
+
+  worker:
+    container_name: worker
+    image: target/vela-worker:v0.6.0
+    networks:
+      - vela
+    environment:
+      VELA_BUILD_LIMIT: 1
+      VELA_BUILD_TIMEOUT: 30m
+      VELA_LOG_LEVEL: trace
+      VELA_QUEUE_DRIVER: redis
+      VELA_QUEUE_CONFIG: redis://redis:6379
+      VELA_QUEUE_WORKER_ROUTES: large,docker,large:docker
+      VELA_RUNTIME_DRIVER: docker
+      VELA_SERVER_ADDR: http://server:8080
+      VELA_SERVER_SECRET: zB7mrKDTZqNeNTD8z47yG4DHywspAh
+    restart: always
+    ports:
+      - "8081:8080"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    depends_on:
+      - server
+
+  ui:
+    container_name: ui
+    image: target/vela-ui
+    networks:
+      - vela
+    ports:
+      - "8888:80"
+    environment:
+      VELA_API: "http://localhost:8080"
+    depends_on:
+      - server
 
   redis:
     container_name: redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       VELA_SECRET_VAULT: "true"
       VELA_SECRET_VAULT_ADDR: http://vault:8200
       VELA_SECRET_VAULT_TOKEN: vela
+      VELA_DISABLE_WEBHOOK_VALIDATION: "true"
     env_file:
       - secrets.env
     restart: always

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/frankban/quicktest v1.7.2 // indirect
 	github.com/gin-gonic/gin v1.6.3
+	github.com/go-playground/assert/v2 v2.0.1
 	github.com/go-redis/redis v6.15.8+incompatible
 	github.com/go-vela/compiler v0.6.0
 	github.com/go-vela/types v0.6.1-0.20201019123446-226d0cc72538

--- a/router/middleware/webhook_validation.go
+++ b/router/middleware/webhook_validation.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// WebhookValidation determines whether or not incoming webhooks are validated coming from Github
+// This is primarily intended for local development.
+func WebhookValidation(validate bool) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set("webhookvalidation", validate)
+		c.Next()
+	}
+}

--- a/router/middleware/webhook_validation_test.go
+++ b/router/middleware/webhook_validation_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package middleware
+
+import (
+	"github.com/go-playground/assert/v2"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestWebhook_WebhookValidation(t *testing.T) {
+	type args struct {
+		validate bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "validation disabled",
+			args: args{
+				validate: false,
+			},
+			want: false,
+		},
+		{
+			name: "validation enabled",
+			args: args{
+				validate: true,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// setup context
+			gin.SetMode(gin.TestMode)
+
+			var got bool
+
+			resp := httptest.NewRecorder()
+			context, engine := gin.CreateTestContext(resp)
+			context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+
+			engine.Use(WebhookValidation(tt.args.validate))
+			engine.GET("/health", func(c *gin.Context) {
+				got = c.Value("webhookvalidation").(bool)
+
+				c.Status(http.StatusOK)
+			})
+
+			// run test
+			engine.ServeHTTP(context.Writer, context.Request)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
# Overview
When developing locally you currently have to comment out code in order to get the server to allow you to enable/disable repos.  This pr adds a new flag for disabling webhook validation.

`VELA_DISABLE_WEBHOOK_VALIDATION` - default: false

Changes were tested locally for both cases (with and without validation enabled)