### PR TITLE
fix: set repo fields off input provided

### DIFF
--- a/api/repo.go
+++ b/api/repo.go
@@ -104,15 +104,25 @@ func CreateRepo(c *gin.Context) {
 	// update fields in repo object
 	r.SetUserID(u.GetID())
 
+	// set the active field based off the input provided
 	if input.Active == nil {
+		// default active field to true
 		r.SetActive(true)
+	} else {
+		r.SetActive(input.GetActive())
 	}
 
+	// set the timeout field based off the input provided
 	if input.GetTimeout() == 0 {
+		// default build timeout to 30m
 		r.SetTimeout(constants.BuildTimeoutMin)
+	} else {
+		r.SetTimeout(input.GetTimeout())
 	}
 
+	// set the visibility field based off the input provided
 	if len(input.GetVisibility()) == 0 {
+		// default visibility field to public
 		r.SetVisibility(constants.VisibilityPublic)
 	} else {
 		r.SetVisibility(input.GetVisibility())
@@ -122,8 +132,15 @@ func CreateRepo(c *gin.Context) {
 	if !input.GetAllowPull() && !input.GetAllowPush() &&
 		!input.GetAllowDeploy() && !input.GetAllowTag() &&
 		!input.GetAllowComment() {
+		// default events to push and pull_request
 		r.SetAllowPull(true)
 		r.SetAllowPush(true)
+	} else {
+		r.SetAllowComment(input.GetAllowComment())
+		r.SetAllowDeploy(input.GetAllowDeploy())
+		r.SetAllowPull(input.GetAllowPull())
+		r.SetAllowPush(input.GetAllowPush())
+		r.SetAllowTag(input.GetAllowTag())
 	}
 
 	// create unique id for the repo


### PR DESCRIPTION
Related to https://github.com/go-vela/server/pull/200 and https://github.com/go-vela/server/pull/207

Currently, there is a bug where not all the fields provided in the JSON payload when creating a repo are respected.

This PR intends to resolve this issue by ensuring we set fields based off the input provided.