### PR TITLE
fix(api-spec): Log spec return type

### DIFF
--- a/api-spec/vela-server.json
+++ b/api-spec/vela-server.json
@@ -1850,7 +1850,10 @@
           "200": {
             "description": "Successfully retrieved logs for the build",
             "schema": {
-              "$ref": "#/definitions/Log"
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Log"
+              }
             }
           },
           "500": {

--- a/api/log.go
+++ b/api/log.go
@@ -52,7 +52,9 @@ import (
 //     description: Successfully retrieved logs for the build
 //     type: json
 //     schema:
-//       "$ref": "#/definitions/Log"
+//       type: array
+//       items:
+//         "$ref": "#/definitions/Log"
 //   '500':
 //     description: Unable to retrieve logs for the build
 //     schema:


### PR DESCRIPTION
Fix the swagger spec to return the correct type for the get build logs endpoint.

Fixes https://github.com/go-vela/community/issues/147