### PR TITLE
fix(open-api): spec parameter order correction

### DIFF
--- a/api-spec/vela-server.json
+++ b/api-spec/vela-server.json
@@ -666,15 +666,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           }
@@ -721,15 +721,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           }
@@ -775,15 +775,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -824,15 +824,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           }
@@ -888,15 +888,15 @@
           },
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           }
@@ -942,15 +942,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -1000,13 +1000,11 @@
         "operationId": "UpdateHook",
         "parameters": [
           {
-            "description": "Webhook payload that we expect from the user or VCS",
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Webhook"
-            }
+            "type": "string",
+            "description": "Name of the org",
+            "name": "org",
+            "in": "path",
+            "required": true
           },
           {
             "type": "string",
@@ -1018,16 +1016,18 @@
           {
             "type": "string",
             "description": "Name of the org",
-            "name": "org",
+            "name": "hook",
             "in": "path",
             "required": true
           },
           {
-            "type": "string",
-            "description": "Name of the org",
-            "name": "hook",
-            "in": "path",
-            "required": true
+            "description": "Webhook payload that we expect from the user or VCS",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Webhook"
+            }
           }
         ],
         "responses": {
@@ -1075,15 +1075,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -1300,15 +1300,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           }
@@ -1339,13 +1339,11 @@
         "operationId": "UpdateRepo",
         "parameters": [
           {
-            "description": "Payload containing the repo to update",
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Repo"
-            }
+            "type": "string",
+            "description": "Name of the org",
+            "name": "org",
+            "in": "path",
+            "required": true
           },
           {
             "type": "string",
@@ -1355,11 +1353,13 @@
             "required": true
           },
           {
-            "type": "string",
-            "description": "Name of the org",
-            "name": "org",
-            "in": "path",
-            "required": true
+            "description": "Payload containing the repo to update",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Repo"
+            }
           }
         ],
         "responses": {
@@ -1413,15 +1413,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           }
@@ -1467,15 +1467,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           }
@@ -1521,13 +1521,11 @@
         "operationId": "CreateBuild",
         "parameters": [
           {
-            "description": "Payload containing the build to update",
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Build"
-            }
+            "type": "string",
+            "description": "Name of the org",
+            "name": "org",
+            "in": "path",
+            "required": true
           },
           {
             "type": "string",
@@ -1537,11 +1535,13 @@
             "required": true
           },
           {
-            "type": "string",
-            "description": "Name of the org",
-            "name": "org",
-            "in": "path",
-            "required": true
+            "description": "Payload containing the build to update",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Build"
+            }
           }
         ],
         "responses": {
@@ -1591,15 +1591,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -1637,13 +1637,11 @@
         "operationId": "UpdateBuild",
         "parameters": [
           {
-            "description": "Payload containing the build to update",
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Build"
-            }
+            "type": "string",
+            "description": "Name of the org",
+            "name": "org",
+            "in": "path",
+            "required": true
           },
           {
             "type": "string",
@@ -1653,18 +1651,20 @@
             "required": true
           },
           {
-            "type": "string",
-            "description": "Name of the org",
-            "name": "org",
-            "in": "path",
-            "required": true
-          },
-          {
             "type": "integer",
             "description": "Build number to restart",
             "name": "build",
             "in": "path",
             "required": true
+          },
+          {
+            "description": "Payload containing the build to update",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Build"
+            }
           }
         ],
         "responses": {
@@ -1706,15 +1706,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -1771,15 +1771,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -1826,15 +1826,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -1884,15 +1884,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -1945,13 +1945,11 @@
         "operationId": "CreateService",
         "parameters": [
           {
-            "description": "Payload containing the service to create",
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Service"
-            }
+            "type": "string",
+            "description": "Name of the org",
+            "name": "org",
+            "in": "path",
+            "required": true
           },
           {
             "type": "string",
@@ -1961,18 +1959,20 @@
             "required": true
           },
           {
-            "type": "string",
-            "description": "Name of the org",
-            "name": "org",
-            "in": "path",
-            "required": true
-          },
-          {
             "type": "integer",
             "description": "Build number",
             "name": "build",
             "in": "path",
             "required": true
+          },
+          {
+            "description": "Payload containing the service to create",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Service"
+            }
           }
         ],
         "responses": {
@@ -2016,15 +2016,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -2081,25 +2081,16 @@
         "operationId": "UpdateService",
         "parameters": [
           {
-            "description": "Payload containing the service to update",
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Service"
-            }
-          },
-          {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -2116,6 +2107,15 @@
             "name": "service",
             "in": "path",
             "required": true
+          },
+          {
+            "description": "Payload containing the service to update",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Service"
+            }
           }
         ],
         "responses": {
@@ -2157,15 +2157,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -2219,15 +2219,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -2240,7 +2240,7 @@
           },
           {
             "type": "integer",
-            "description": "Name of the service",
+            "description": "ID of the service",
             "name": "service",
             "in": "path",
             "required": true
@@ -2278,25 +2278,16 @@
         "operationId": "UpdateServiceLog",
         "parameters": [
           {
-            "description": "Payload containing the log to update",
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Log"
-            }
-          },
-          {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -2313,6 +2304,15 @@
             "name": "service",
             "in": "path",
             "required": true
+          },
+          {
+            "description": "Payload containing the log to update",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Log"
+            }
           }
         ],
         "responses": {
@@ -2353,25 +2353,16 @@
         "operationId": "CreateServiceLogs",
         "parameters": [
           {
-            "description": "Payload containing the log to create",
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Log"
-            }
-          },
-          {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -2384,10 +2375,19 @@
           },
           {
             "type": "integer",
-            "description": "Name of the service",
+            "description": "ID of the service",
             "name": "service",
             "in": "path",
             "required": true
+          },
+          {
+            "description": "Payload containing the log to create",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Log"
+            }
           }
         ],
         "responses": {
@@ -2429,15 +2429,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -2450,7 +2450,7 @@
           },
           {
             "type": "integer",
-            "description": "Name of the service",
+            "description": "ID of the service",
             "name": "service",
             "in": "path",
             "required": true
@@ -2491,15 +2491,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -2552,13 +2552,11 @@
         "operationId": "CreateStep",
         "parameters": [
           {
-            "description": "Payload containing the step to create",
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Step"
-            }
+            "type": "string",
+            "description": "Name of the org",
+            "name": "org",
+            "in": "path",
+            "required": true
           },
           {
             "type": "string",
@@ -2568,18 +2566,20 @@
             "required": true
           },
           {
-            "type": "string",
-            "description": "Name of the org",
-            "name": "org",
-            "in": "path",
-            "required": true
-          },
-          {
             "type": "integer",
             "description": "Build number",
             "name": "build",
             "in": "path",
             "required": true
+          },
+          {
+            "description": "Payload containing the step to create",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Step"
+            }
           }
         ],
         "responses": {
@@ -2623,15 +2623,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -2676,25 +2676,16 @@
         "operationId": "UpdateStep",
         "parameters": [
           {
-            "description": "Payload containing the step to update",
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Step"
-            }
-          },
-          {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -2711,6 +2702,15 @@
             "name": "step",
             "in": "path",
             "required": true
+          },
+          {
+            "description": "Payload containing the step to update",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Step"
+            }
           }
         ],
         "responses": {
@@ -2752,15 +2752,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -2814,15 +2814,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -2867,25 +2867,16 @@
         "operationId": "UpdateStepLog",
         "parameters": [
           {
-            "description": "Payload containing the log to update",
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Log"
-            }
-          },
-          {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -2902,6 +2893,15 @@
             "name": "step",
             "in": "path",
             "required": true
+          },
+          {
+            "description": "Payload containing the log to update",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Log"
+            }
           }
         ],
         "responses": {
@@ -2942,25 +2942,16 @@
         "operationId": "CreateStepLog",
         "parameters": [
           {
-            "description": "Payload containing the log to create",
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Log"
-            }
-          },
-          {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -2977,6 +2968,15 @@
             "name": "step",
             "in": "path",
             "required": true
+          },
+          {
+            "description": "Payload containing the log to create",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Log"
+            }
           }
         ],
         "responses": {
@@ -3018,15 +3018,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           },
@@ -3080,15 +3080,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           }
@@ -3128,15 +3128,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo",
-            "name": "repo",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Name of the repo",
+            "name": "repo",
             "in": "path",
             "required": true
           }
@@ -3183,15 +3183,15 @@
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Secret type to create. Options 'org', 'repo', or 'shared'",
+            "name": "type",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Secret type to create. Options 'org', 'repo', or 'shared'",
-            "name": "type",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
@@ -3244,25 +3244,9 @@
         "operationId": "CreateSecret",
         "parameters": [
           {
-            "description": "Payload containing the secret to create",
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Secret"
-            }
-          },
-          {
             "type": "string",
             "description": "Secret engine to create a secret in",
             "name": "engine",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Name of the org",
-            "name": "org",
             "in": "path",
             "required": true
           },
@@ -3275,10 +3259,26 @@
           },
           {
             "type": "string",
+            "description": "Name of the org",
+            "name": "org",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
             "description": "Name of the repo if a repo secret, team name if a shared secret, or '*' if an org secret",
             "name": "name",
             "in": "path",
             "required": true
+          },
+          {
+            "description": "Payload containing the secret to create",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Secret"
+            }
           }
         ],
         "responses": {
@@ -3329,15 +3329,15 @@
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Secret type to create. Options 'org', 'repo', or 'shared'",
+            "name": "type",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Secret type to create. Options 'org', 'repo', or 'shared'",
-            "name": "type",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
@@ -3388,15 +3388,6 @@
         "operationId": "UpdateSecrets",
         "parameters": [
           {
-            "description": "Payload containing the secret to create",
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Secret"
-            }
-          },
-          {
             "type": "string",
             "description": "Secret engine to create a secret in",
             "name": "engine",
@@ -3405,15 +3396,15 @@
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Secret type to create. Options 'org', 'repo', or 'shared'",
+            "name": "type",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Secret type to create. Options 'org', 'repo', or 'shared'",
-            "name": "type",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
@@ -3430,6 +3421,15 @@
             "name": "secret",
             "in": "path",
             "required": true
+          },
+          {
+            "description": "Payload containing the secret to create",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Secret"
+            }
           }
         ],
         "responses": {
@@ -3478,15 +3478,15 @@
           },
           {
             "type": "string",
-            "description": "Name of the org",
-            "name": "org",
+            "description": "Secret type to create. Options 'org', 'repo', or 'shared'",
+            "name": "type",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Secret type to create. Options 'org', 'repo', or 'shared'",
-            "name": "type",
+            "description": "Name of the org",
+            "name": "org",
             "in": "path",
             "required": true
           },
@@ -3848,6 +3848,13 @@
         "operationId": "UpdateUser",
         "parameters": [
           {
+            "type": "string",
+            "description": "Name of the user",
+            "name": "user",
+            "in": "path",
+            "required": true
+          },
+          {
             "description": "Payload containing the user to update",
             "name": "body",
             "in": "body",
@@ -3855,13 +3862,6 @@
             "schema": {
               "$ref": "#/definitions/User"
             }
-          },
-          {
-            "type": "string",
-            "description": "Name of the user",
-            "name": "user",
-            "in": "path",
-            "required": true
           }
         ],
         "responses": {
@@ -3977,6 +3977,11 @@
         "x-success_http_code": "200"
       },
       "post": {
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "description": "Create a worker for the configured backend",
         "produces": [
           "application/json"
@@ -3994,13 +3999,6 @@
             "schema": {
               "$ref": "#/definitions/Worker"
             }
-          },
-          {
-            "type": "string",
-            "description": "Vela bearer token",
-            "name": "Authorization",
-            "in": "header",
-            "required": true
           }
         ],
         "responses": {
@@ -4028,6 +4026,11 @@
     },
     "/api/v1/workers/{worker}": {
       "get": {
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "description": "Retrieve a worker for the configured backend",
         "produces": [
           "application/json"
@@ -4042,13 +4045,6 @@
             "description": "Hostname of the worker",
             "name": "worker",
             "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Vela bearer token",
-            "name": "Authorization",
-            "in": "header",
             "required": true
           }
         ],
@@ -4069,6 +4065,11 @@
         "x-success_http_code": "200"
       },
       "put": {
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "description": "Update a worker for the configured backend",
         "produces": [
           "application/json"
@@ -4092,13 +4093,6 @@
             "description": "Name of the worker",
             "name": "worker",
             "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Vela bearer token",
-            "name": "Authorization",
-            "in": "header",
             "required": true
           }
         ],
@@ -4131,6 +4125,11 @@
         "x-success_http_code": "200"
       },
       "delete": {
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "description": "Delete a worker for the configured backend",
         "produces": [
           "application/json"
@@ -4145,13 +4144,6 @@
             "description": "Name of the worker",
             "name": "worker",
             "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Vela bearer token",
-            "name": "Authorization",
-            "in": "header",
             "required": true
           }
         ],
@@ -4272,15 +4264,15 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Name of the repo to get the badge for",
-            "name": "repo",
+            "description": "Name of the org the repo belongs to",
+            "name": "org",
             "in": "path",
             "required": true
           },
           {
             "type": "string",
-            "description": "Name of the org the repo belongs to",
-            "name": "org",
+            "description": "Name of the repo to get the badge for",
+            "name": "repo",
             "in": "path",
             "required": true
           }

--- a/api/badge.go
+++ b/api/badge.go
@@ -25,13 +25,13 @@ import (
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo to get the badge for
+//   name: org
+//   description: Name of the org the repo belongs to
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org the repo belongs to
+//   name: repo
+//   description: Name of the repo to get the badge for
 //   required: true
 //   type: string
 // responses:

--- a/api/build.go
+++ b/api/build.go
@@ -38,22 +38,22 @@ import (
 // produces:
 // - application/json
 // parameters:
+// - in: path
+//   name: org
+//   description: Name of the org
+//   required: true
+//   type: string
+// - in: path
+//   name: repo
+//   description: Name of the repo
+//   required: true
+//   type: string
 // - in: body
 //   name: body
 //   description: Payload containing the build to update
 //   required: true
 //   schema:
 //     "$ref": "#/definitions/Build"
-// - in: path
-//   name: repo
-//   description: Name of the repo
-//   required: true
-//   type: string
-// - in: path
-//   name: org
-//   description: Name of the org
-//   required: true
-//   type: string
 // security:
 //   - ApiKeyAuth: []
 // responses:
@@ -253,13 +253,13 @@ func CreateBuild(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // security:
@@ -459,13 +459,13 @@ func GetOrgBuilds(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -506,13 +506,13 @@ func GetBuild(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -694,20 +694,14 @@ func RestartBuild(c *gin.Context) {
 // produces:
 // - application/json
 // parameters:
-// - in: body
-//   name: body
-//   description: Payload containing the build to update
-//   required: true
-//   schema:
-//     "$ref": "#/definitions/Build"
-// - in: path
-//   name: repo
-//   description: Name of the repo
-//   required: true
-//   type: string
 // - in: path
 //   name: org
 //   description: Name of the org
+//   required: true
+//   type: string
+// - in: path
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -715,6 +709,12 @@ func RestartBuild(c *gin.Context) {
 //   description: Build number to restart
 //   required: true
 //   type: integer
+// - in: body
+//   name: body
+//   description: Payload containing the build to update
+//   required: true
+//   schema:
+//     "$ref": "#/definitions/Build"
 // security:
 //   - ApiKeyAuth: []
 // responses:
@@ -843,13 +843,13 @@ func UpdateBuild(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path

--- a/api/deployment.go
+++ b/api/deployment.go
@@ -30,13 +30,13 @@ import (
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // security:
@@ -113,13 +113,13 @@ func CreateDeployment(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // security:
@@ -215,13 +215,13 @@ func GetDeployments(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path

--- a/api/hook.go
+++ b/api/hook.go
@@ -36,13 +36,13 @@ import (
 //   schema:
 //     "$ref": "#/definitions/Webhook"
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // security:
@@ -132,13 +132,13 @@ func CreateHook(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // security:
@@ -233,13 +233,13 @@ func GetHooks(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -304,20 +304,14 @@ func GetHook(c *gin.Context) {
 // produces:
 // - application/json
 // parameters:
-// - in: body
-//   name: body
-//   description: Webhook payload that we expect from the user or VCS
-//   required: true
-//   schema:
-//     "$ref": "#/definitions/Webhook"
-// - in: path
-//   name: repo
-//   description: Name of the repo
-//   required: true
-//   type: string
 // - in: path
 //   name: org
 //   description: Name of the org
+//   required: true
+//   type: string
+// - in: path
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -325,6 +319,12 @@ func GetHook(c *gin.Context) {
 //   description: Name of the org
 //   required: true
 //   type: string
+// - in: body
+//   name: body
+//   description: Webhook payload that we expect from the user or VCS
+//   required: true
+//   schema:
+//     "$ref": "#/definitions/Webhook"
 // security:
 //   - ApiKeyAuth: []
 // responses:
@@ -448,13 +448,13 @@ func UpdateHook(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path

--- a/api/log.go
+++ b/api/log.go
@@ -31,13 +31,13 @@ import (
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -91,20 +91,14 @@ func GetBuildLogs(c *gin.Context) {
 // produces:
 // - application/json
 // parameters:
-// - in: body
-//   name: body
-//   description: Payload containing the log to create
-//   required: true
-//   schema:
-//     "$ref": "#/definitions/Log"
-// - in: path
-//   name: repo
-//   description: Name of the repo
-//   required: true
-//   type: string
 // - in: path
 //   name: org
 //   description: Name of the org
+//   required: true
+//   type: string
+// - in: path
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -114,9 +108,15 @@ func GetBuildLogs(c *gin.Context) {
 //   type: integer
 // - in: path
 //   name: service
-//   description: Name of the service
+//   description: ID of the service
 //   required: true
 //   type: integer
+// - in: body
+//   name: body
+//   description: Payload containing the log to create
+//   required: true
+//   schema:
+//     "$ref": "#/definitions/Log"
 // security:
 //   - ApiKeyAuth: []
 // responses:
@@ -187,13 +187,13 @@ func CreateServiceLog(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -203,7 +203,7 @@ func CreateServiceLog(c *gin.Context) {
 //   type: integer
 // - in: path
 //   name: service
-//   description: Name of the service
+//   description: ID of the service
 //   required: true
 //   type: integer
 // security:
@@ -251,20 +251,14 @@ func GetServiceLog(c *gin.Context) {
 // produces:
 // - application/json
 // parameters:
-// - in: body
-//   name: body
-//   description: Payload containing the log to update
-//   required: true
-//   schema:
-//     "$ref": "#/definitions/Log"
-// - in: path
-//   name: repo
-//   description: Name of the repo
-//   required: true
-//   type: string
 // - in: path
 //   name: org
 //   description: Name of the org
+//   required: true
+//   type: string
+// - in: path
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -277,6 +271,12 @@ func GetServiceLog(c *gin.Context) {
 //   description: Name of the service
 //   required: true
 //   type: integer
+// - in: body
+//   name: body
+//   description: Payload containing the log to update
+//   required: true
+//   schema:
+//     "$ref": "#/definitions/Log"
 // security:
 //   - ApiKeyAuth: []
 // responses:
@@ -358,13 +358,13 @@ func UpdateServiceLog(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -374,7 +374,7 @@ func UpdateServiceLog(c *gin.Context) {
 //   type: integer
 // - in: path
 //   name: service
-//   description: Name of the service
+//   description: ID of the service
 //   required: true
 //   type: integer
 // security:
@@ -421,20 +421,14 @@ func DeleteServiceLog(c *gin.Context) {
 // produces:
 // - application/json
 // parameters:
-// - in: body
-//   name: body
-//   description: Payload containing the log to create
-//   required: true
-//   schema:
-//     "$ref": "#/definitions/Log"
-// - in: path
-//   name: repo
-//   description: Name of the repo
-//   required: true
-//   type: string
 // - in: path
 //   name: org
 //   description: Name of the org
+//   required: true
+//   type: string
+// - in: path
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -447,6 +441,12 @@ func DeleteServiceLog(c *gin.Context) {
 //   description: Build number
 //   required: true
 //   type: string
+// - in: body
+//   name: body
+//   description: Payload containing the log to create
+//   required: true
+//   schema:
+//     "$ref": "#/definitions/Log"
 // security:
 //   - ApiKeyAuth: []
 // responses:
@@ -517,13 +517,13 @@ func CreateStepLog(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -577,20 +577,14 @@ func GetStepLog(c *gin.Context) {
 // produces:
 // - application/json
 // parameters:
-// - in: body
-//   name: body
-//   description: Payload containing the log to update
-//   required: true
-//   schema:
-//     "$ref": "#/definitions/Log"
-// - in: path
-//   name: repo
-//   description: Name of the repo
-//   required: true
-//   type: string
 // - in: path
 //   name: org
 //   description: Name of the org
+//   required: true
+//   type: string
+// - in: path
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -603,6 +597,12 @@ func GetStepLog(c *gin.Context) {
 //   description: Build number
 //   required: true
 //   type: string
+// - in: body
+//   name: body
+//   description: Payload containing the log to update
+//   required: true
+//   schema:
+//     "$ref": "#/definitions/Log"
 // security:
 //   - ApiKeyAuth: []
 // responses:
@@ -684,13 +684,13 @@ func UpdateStepLog(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path

--- a/api/repo.go
+++ b/api/repo.go
@@ -339,13 +339,13 @@ func GetRepos(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // security:
@@ -377,22 +377,22 @@ func GetRepo(c *gin.Context) {
 // produces:
 // - application/json
 // parameters:
+// - in: path
+//   name: org
+//   description: Name of the org
+//   required: true
+//   type: string
+// - in: path
+//   name: repo
+//   description: Name of the repo
+//   required: true
+//   type: string
 // - in: body
 //   name: body
 //   description: Payload containing the repo to update
 //   required: true
 //   schema:
 //     "$ref": "#/definitions/Repo"
-// - in: path
-//   name: repo
-//   description: Name of the repo
-//   required: true
-//   type: string
-// - in: path
-//   name: org
-//   description: Name of the org
-//   required: true
-//   type: string
 // security:
 //   - ApiKeyAuth: []
 // responses:
@@ -552,13 +552,13 @@ func UpdateRepo(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // security:
@@ -635,13 +635,13 @@ func DeleteRepo(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // security:
@@ -714,13 +714,13 @@ func RepairRepo(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // security:

--- a/api/secret.go
+++ b/api/secret.go
@@ -30,20 +30,9 @@ import (
 // produces:
 // - application/json
 // parameters:
-// - in: body
-//   name: body
-//   description: Payload containing the secret to create
-//   required: true
-//   schema:
-//     "$ref": "#/definitions/Secret"
 // - in: path
 //   name: engine
 //   description: Secret engine to create a secret in
-//   required: true
-//   type: string
-// - in: path
-//   name: org
-//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
@@ -52,10 +41,21 @@ import (
 //   required: true
 //   type: string
 // - in: path
+//   name: org
+//   description: Name of the org
+//   required: true
+//   type: string
+// - in: path
 //   name: name
 //   description: Name of the repo if a repo secret, team name if a shared secret, or '*' if an org secret
 //   required: true
 //   type: string
+// - in: body
+//   name: body
+//   description: Payload containing the secret to create
+//   required: true
+//   schema:
+//     "$ref": "#/definitions/Secret"
 // security:
 //   - ApiKeyAuth: []
 // responses:
@@ -157,13 +157,13 @@ func CreateSecret(c *gin.Context) {
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: type
+//   description: Secret type to create. Options 'org', 'repo', or 'shared'
 //   required: true
 //   type: string
 // - in: path
-//   name: type
-//   description: Secret type to create. Options 'org', 'repo', or 'shared'
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
@@ -282,13 +282,13 @@ func GetSecrets(c *gin.Context) {
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: type
+//   description: Secret type to create. Options 'org', 'repo', or 'shared'
 //   required: true
 //   type: string
 // - in: path
-//   name: type
-//   description: Secret type to create. Options 'org', 'repo', or 'shared'
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
@@ -355,25 +355,19 @@ func GetSecret(c *gin.Context) {
 // produces:
 // - application/json
 // parameters:
-// - in: body
-//   name: body
-//   description: Payload containing the secret to create
-//   required: true
-//   schema:
-//     "$ref": "#/definitions/Secret"
 // - in: path
 //   name: engine
 //   description: Secret engine to create a secret in
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: type
+//   description: Secret type to create. Options 'org', 'repo', or 'shared'
 //   required: true
 //   type: string
 // - in: path
-//   name: type
-//   description: Secret type to create. Options 'org', 'repo', or 'shared'
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
@@ -386,6 +380,12 @@ func GetSecret(c *gin.Context) {
 //   description: Name of the secret
 //   required: true
 //   type: string
+// - in: body
+//   name: body
+//   description: Payload containing the secret to create
+//   required: true
+//   schema:
+//     "$ref": "#/definitions/Secret"
 // security:
 //   - ApiKeyAuth: []
 // responses:
@@ -484,13 +484,13 @@ func UpdateSecret(c *gin.Context) {
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: type
+//   description: Secret type to create. Options 'org', 'repo', or 'shared'
 //   required: true
 //   type: string
 // - in: path
-//   name: type
-//   description: Secret type to create. Options 'org', 'repo', or 'shared'
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path

--- a/api/service.go
+++ b/api/service.go
@@ -33,20 +33,14 @@ import (
 // produces:
 // - application/json
 // parameters:
-// - in: body
-//   name: body
-//   description: Payload containing the service to create
-//   required: true
-//   schema:
-//     "$ref": "#/definitions/Service"
-// - in: path
-//   name: repo
-//   description: Name of the repo
-//   required: true
-//   type: string
 // - in: path
 //   name: org
 //   description: Name of the org
+//   required: true
+//   type: string
+// - in: path
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -54,6 +48,12 @@ import (
 //   description: Build number
 //   required: true
 //   type: integer
+// - in: body
+//   name: body
+//   description: Payload containing the service to create
+//   required: true
+//   schema:
+//     "$ref": "#/definitions/Service"
 // security:
 //   - ApiKeyAuth: []
 // responses:
@@ -130,13 +130,13 @@ func CreateService(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -237,13 +237,13 @@ func GetServices(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -297,20 +297,14 @@ func GetService(c *gin.Context) {
 // produces:
 // - application/json
 // parameters:
-// - in: body
-//   name: body
-//   description: Payload containing the service to update
-//   required: true
-//   schema:
-//     "$ref": "#/definitions/Service"
-// - in: path
-//   name: repo
-//   description: Name of the repo
-//   required: true
-//   type: string
 // - in: path
 //   name: org
 //   description: Name of the org
+//   required: true
+//   type: string
+// - in: path
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -323,6 +317,12 @@ func GetService(c *gin.Context) {
 //   description: Name of the service
 //   required: true
 //   type: integer
+// - in: body
+//   name: body
+//   description: Payload containing the service to update
+//   required: true
+//   schema:
+//     "$ref": "#/definitions/Service"
 // security:
 //   - ApiKeyAuth: []
 // responses:
@@ -414,13 +414,13 @@ func UpdateService(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path

--- a/api/step.go
+++ b/api/step.go
@@ -33,20 +33,14 @@ import (
 // produces:
 // - application/json
 // parameters:
-// - in: body
-//   name: body
-//   description: Payload containing the step to create
-//   required: true
-//   schema:
-//     "$ref": "#/definitions/Step"
-// - in: path
-//   name: repo
-//   description: Name of the repo
-//   required: true
-//   type: string
 // - in: path
 //   name: org
 //   description: Name of the org
+//   required: true
+//   type: string
+// - in: path
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -54,6 +48,12 @@ import (
 //   description: Build number
 //   required: true
 //   type: integer
+// - in: body
+//   name: body
+//   description: Payload containing the step to create
+//   required: true
+//   schema:
+//     "$ref": "#/definitions/Step"
 // security:
 //   - ApiKeyAuth: []
 // responses:
@@ -130,13 +130,13 @@ func CreateStep(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -237,13 +237,13 @@ func GetSteps(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -289,20 +289,14 @@ func GetStep(c *gin.Context) {
 // produces:
 // - application/json
 // parameters:
-// - in: body
-//   name: body
-//   description: Payload containing the step to update
-//   required: true
-//   schema:
-//     "$ref": "#/definitions/Step"
-// - in: path
-//   name: repo
-//   description: Name of the repo
-//   required: true
-//   type: string
 // - in: path
 //   name: org
 //   description: Name of the org
+//   required: true
+//   type: string
+// - in: path
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path
@@ -315,6 +309,12 @@ func GetStep(c *gin.Context) {
 //   description: Build number
 //   required: true
 //   type: string
+// - in: body
+//   name: body
+//   description: Payload containing the step to update
+//   required: true
+//   schema:
+//     "$ref": "#/definitions/Step"
 // security:
 //   - ApiKeyAuth: []
 // responses:
@@ -421,13 +421,13 @@ func UpdateStep(c *gin.Context) {
 // - application/json
 // parameters:
 // - in: path
-//   name: repo
-//   description: Name of the repo
+//   name: org
+//   description: Name of the org
 //   required: true
 //   type: string
 // - in: path
-//   name: org
-//   description: Name of the org
+//   name: repo
+//   description: Name of the repo
 //   required: true
 //   type: string
 // - in: path

--- a/api/user.go
+++ b/api/user.go
@@ -448,17 +448,17 @@ func GetUserSourceRepos(c *gin.Context) {
 // produces:
 // - application/json
 // parameters:
+// - in: path
+//   name: user
+//   description: Name of the user
+//   required: true
+//   type: string
 // - in: body
 //   name: body
 //   description: Payload containing the user to update
 //   required: true
 //   schema:
 //     "$ref": "#/definitions/User"
-// - in: path
-//   name: user
-//   description: Name of the user
-//   required: true
-//   type: string
 // security:
 //   - ApiKeyAuth: []
 // responses:

--- a/api/worker.go
+++ b/api/worker.go
@@ -31,11 +31,8 @@ import (
 //   required: true
 //   schema:
 //     "$ref": "#/definitions/Worker"
-// - in: header
-//   name: Authorization
-//   description: Vela bearer token
-//   required: true
-//   type: string
+// security:
+//   - ApiKeyAuth: []
 // responses:
 //   '201':
 //     description: Successfully created the worker
@@ -136,11 +133,8 @@ func GetWorkers(c *gin.Context) {
 //   description: Hostname of the worker
 //   required: true
 //   type: string
-// - in: header
-//   name: Authorization
-//   description: Vela bearer token
-//   required: true
-//   type: string
+// security:
+//   - ApiKeyAuth: []
 // responses:
 //   '200':
 //     description: Successfully retrieved the worker
@@ -188,11 +182,8 @@ func GetWorker(c *gin.Context) {
 //   description: Name of the worker
 //   required: true
 //   type: string
-// - in: header
-//   name: Authorization
-//   description: Vela bearer token
-//   required: true
-//   type: string
+// security:
+//   - ApiKeyAuth: []
 // responses:
 //   '200':
 //     description: Successfully updated the worker
@@ -292,11 +283,8 @@ func UpdateWorker(c *gin.Context) {
 //   description: Name of the worker
 //   required: true
 //   type: string
-// - in: header
-//   name: Authorization
-//   description: Vela bearer token
-//   required: true
-//   type: string
+// security:
+//   - ApiKeyAuth: []
 // responses:
 //   '200':
 //     description: Successfully deleted of worker


### PR DESCRIPTION
Fix swagger spec parameters
    
This fixes a few things with swagger spec parameters:
 * Consistently put the path arguments in the same order found in the path
 * Put body arguments after path arguments
 * Correct the description of the Service arguments to indicate its an ID, not a name
 * Fix the Workers API to use the "security" parameter, rather than header parameters
    
This is important to code-generation, as many of the created functions will have positional arguments, and we need them to match the API usage.
