### PR TITLE
fix(api): setting repo owner for enabled repo

### DIFF
--- a/api/repo.go
+++ b/api/repo.go
@@ -207,6 +207,8 @@ func CreateRepo(c *gin.Context) {
 
 	// if the repo exists but is inactive
 	if len(dbRepo.GetOrg()) > 0 && !dbRepo.GetActive() {
+		// update the repo owner
+		dbRepo.SetUserID(u.GetID())
 		// activate the repo
 		dbRepo.SetActive(true)
 


### PR DESCRIPTION
Currently, if you disable and re-enable a repository, we don't properly update the "owner" of that repo in Vela.

This ensures that we set the proper repo owner if the event a user attempts to disable and re-enable a repository.