### PR TITLE
fix(ingress): revert #236

### DIFF
--- a/cmd/vela-server/main.go
+++ b/cmd/vela-server/main.go
@@ -21,6 +21,12 @@ func main() {
 
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
+			EnvVars: []string{"VELA_PORT"},
+			Name:    "server-port",
+			Usage:   "API port to listen on",
+			Value:   ":8080",
+		},
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_LOG_LEVEL", "LOG_LEVEL"},
 			Name:    "log-level",
 			Usage:   "set log level - options: (trace|debug|info|warn|error|fatal|panic)",

--- a/cmd/vela-server/server.go
+++ b/cmd/vela-server/server.go
@@ -6,9 +6,7 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/go-vela/server/router"
@@ -99,25 +97,11 @@ func server(c *cli.Context) error {
 		middleware.Worker(c.Duration("worker-active-interval")),
 	)
 
-	addr, err := url.Parse(c.String("server-addr"))
-	if err != nil {
-		return err
-	}
-
 	var tomb tomb.Tomb
 	// start http server
 	tomb.Go(func() error {
-		port := addr.Port()
+		srv := &http.Server{Addr: c.String("server-port"), Handler: router}
 
-		// check if a port is part of the address
-		if len(port) == 0 {
-			port = "8080"
-		}
-
-		// gin expects the address to be ":<port>" ie ":8080"
-		srv := &http.Server{Addr: fmt.Sprintf(":%s", port), Handler: router}
-
-		logrus.Infof("running server on %s", addr.Host)
 		go func() {
 			logrus.Info("Starting HTTP server...")
 			err := srv.ListenAndServe()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       VELA_QUEUE_DRIVER: redis
       VELA_QUEUE_CONFIG: 'redis://redis:6379'
       VELA_QUEUE_WORKER_ROUTES: 'docker,local,docker:local'
+      VELA_PORT: ':8080'
       VELA_SECRET: 'zB7mrKDTZqNeNTD8z47yG4DHywspAh'
       VELA_SOURCE_DRIVER: github
       VELA_SECRET_NATIVE_KEY: 'C639A572E14D5075C526FDDD43E4ECF6'


### PR DESCRIPTION
Reverting the changes within #236 since the changes cause invalid redirects if the server is setup with a load balancer handling TLS termination.  More context:

Purpose the Vela Administrator would like the server to listen on port 8080 (HTTP) but redirect clients to port 443 (HTTPS) to be served by the load balancer. Utilizing the `VELA_ADDR` value of `https://vela.company.com:8080` will cause the server to listen on 8080 but redirect clients to `https://vela.company.com:8080` instead of `https://vela.company.com`. 

I don't see any simple code changes to accomplish this behavior besides reverting the change altogether. 