### PR TITLE
fix(webhook): duplicate compiler before processing

### DIFF
--- a/api/webhook.go
+++ b/api/webhook.go
@@ -390,6 +390,7 @@ func PostWebhook(c *gin.Context) {
 
 		// parse and compile the pipeline configuration file
 		p, err = compiler.FromContext(c).
+			Duplicate().
 			WithBuild(b).
 			WithComment(webhook.Comment).
 			WithFiles(files).
@@ -421,6 +422,11 @@ func PostWebhook(c *gin.Context) {
 
 			// check if the retry limit has been exceeded
 			if i < retryLimit {
+				// reset fields set by cleanBuild for retry
+				b.SetError("")
+				b.SetStatus(constants.StatusPending)
+				b.SetFinished(0)
+
 				// continue to the next iteration of the loop
 				continue
 			}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-playground/assert/v2 v2.0.1
 	github.com/go-redis/redis v6.15.9+incompatible
-	github.com/go-vela/compiler v0.7.0-rc2
+	github.com/go-vela/compiler v0.7.0-rc2.0.20210121205127-ae60fe509522
 	github.com/go-vela/types v0.7.0-rc2
 	github.com/google/go-cmp v0.5.4
 	github.com/google/go-github/v29 v29.0.3

--- a/go.sum
+++ b/go.sum
@@ -175,12 +175,14 @@ github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/go-vela/compiler v0.7.0-rc2 h1:oqEzF1rbQYTDepgWX5YWVmoPMHwYCPZFByb4WEm4LUg=
-github.com/go-vela/compiler v0.7.0-rc2/go.mod h1:yDLkztd1U/29EPleiBbkNzPWnxxUwvKNGYMTX3pYPQ8=
+github.com/go-vela/compiler v0.7.0-rc2.0.20210121205127-ae60fe509522 h1:YhQJzc2SiuzatjbJuxn/1/TAtMmJNrqc1lBIZGwuz/0=
+github.com/go-vela/compiler v0.7.0-rc2.0.20210121205127-ae60fe509522/go.mod h1:OMys0YNrCX3B54BYxwU59U91hnqH+hs6/KLrHlZvVOk=
 github.com/go-vela/types v0.7.0-rc2 h1:snUSTjd1BW3Kkn9RxfLeufSxbmlomFicmoPBeNNl+ik=
 github.com/go-vela/types v0.7.0-rc2/go.mod h1:ATtwTwp2l4jI4GUmw840xHZgHmg8FbZPo4g0azImggA=
 github.com/goccy/go-yaml v1.8.4 h1:AOEdR7aQgbgwHznGe3BLkDQVujxCPUpHOZZcQcp8Y3M=
 github.com/goccy/go-yaml v1.8.4/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
+github.com/goccy/go-yaml v1.8.5 h1:f1UH5GVhLZE6ElNBAgCtF3ZUOuJ62dNOo3Y5dOJqTV4=
+github.com/goccy/go-yaml v1.8.5/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=


### PR DESCRIPTION
should fix https://github.com/go-vela/community/issues/181

This fix will create a clone of the `Engine` with basic settings before compiling the incoming request. This is to avoid situation where the shared compiler attached at application start up is "corrupted" with other build data.

Tested by emitting multiple concurrent requests and logging on the worker where the situation was observed prior to the fix and not after.

Testing surfaced another issue where we attach an error if the first attempt to create a build fails. When the subsequent attempt succeeds the error is not cleared.

Note: an arguably nicer solution would be to handle this via mutex. i did spend some time on that, but i think it might require some additional changes.