### PR TITLE
refactor: add API port back to server

### DIFF
--- a/cmd/vela-server/main.go
+++ b/cmd/vela-server/main.go
@@ -32,6 +32,12 @@ func main() {
 			Usage:   "server address as a fully qualified url (<scheme>://<host>)",
 		},
 		&cli.StringFlag{
+			EnvVars: []string{"VELA_PORT"},
+			Name:    "server-port",
+			Usage:   "server port for the API to listen on",
+			Value:   "8080",
+		},
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_WEBUI_ADDR", "VELA_WEBUI_HOST"},
 			Name:    "webui-addr",
 			Usage:   "web ui address as a fully qualified url (<scheme>://<host>)",

--- a/cmd/vela-server/server.go
+++ b/cmd/vela-server/server.go
@@ -112,7 +112,7 @@ func server(c *cli.Context) error {
 
 		// check if a port is part of the address
 		if len(port) == 0 {
-			port = "8080"
+			port = c.String("server-port")
 		}
 
 		// gin expects the address to be ":<port>" ie ":8080"


### PR DESCRIPTION
Based off of https://github.com/go-vela/server/pull/247

This is a partial revert of https://github.com/go-vela/server/pull/236

We will still continue to use `url.Parse()` in the codebase but will allow customizing the port the API listens on.