### PR TITLE
chore: update go-vela/compiler on v0.7.0-rc4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-playground/assert/v2 v2.0.1
 	github.com/go-redis/redis v6.15.9+incompatible
-	github.com/go-vela/compiler v0.7.0-rc3
+	github.com/go-vela/compiler v0.7.0-rc4
 	github.com/go-vela/types v0.7.0-rc3
 	github.com/google/go-cmp v0.5.4
 	github.com/google/go-github/v29 v29.0.3

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/go-vela/compiler v0.7.0-rc3 h1:mCw6uUGqpGuPHIQfBYswMEcCSU9R/ZK2t+GLQagHJ+M=
-github.com/go-vela/compiler v0.7.0-rc3/go.mod h1:XbNRK9QmVlYh+iVeRmwLAxRe3mCQ/xxJcR4vruSqs/U=
+github.com/go-vela/compiler v0.7.0-rc4 h1:S6lJMvJo4yaZHXYS3NbqRdTmq5EeZSyVfE+bLYi6WuQ=
+github.com/go-vela/compiler v0.7.0-rc4/go.mod h1:XbNRK9QmVlYh+iVeRmwLAxRe3mCQ/xxJcR4vruSqs/U=
 github.com/go-vela/types v0.7.0-rc3 h1:47vQFWitVF7DcHKH7/bI1eFaTdLfOrWqhoTogIiZhR4=
 github.com/go-vela/types v0.7.0-rc3/go.mod h1:N6YU6eSm/hxAgIdaZtHyKSquNZm2nqK0fFwwPdDWDS0=
 github.com/goccy/go-yaml v1.8.5 h1:f1UH5GVhLZE6ElNBAgCtF3ZUOuJ62dNOo3Y5dOJqTV4=


### PR DESCRIPTION
Upgrading [go-vela/compiler](https://github.com/go-vela/compiler) on `v0.7.0-rc4`

https://github.com/go-vela/compiler/releases/tag/v0.7.0-rc4