### PR TITLE
chore: linter setup and fixes, doc changes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -63,6 +63,22 @@ cd $HOME/go-vela/server
 
 * Write your code and tests to implement the changes you desire.
   * Please be sure to [follow our commit rules](https://chris.beams.io/posts/git-commit/#seven-rules)
+  * Please address linter warnings appropriately. If you are intentionally violating a rule that triggers a linter, please annotate the respective code with `nolint` declarations [[docs](https://golangci-lint.run/usage/false-positives/)]. we are using the following format for `nolint` declarations:
+
+    ```go
+    // nolint:<linter(s)> // <short reason>
+    ```
+  
+    Example:
+
+    ```go
+    // nolint:gocyclo // legacy function is complex, needs simplification
+    func superComplexFunction() error {
+      // ..
+    }
+    ```
+
+    Check the [documentation for more examples](https://golangci-lint.run/usage/false-positives/).
 
 * Run the repository code (ensures your changes perform as you desire):
 
@@ -92,4 +108,25 @@ make clean
 git push fork master
 ```
 
-* Open a pull request. Thank you for your contribution!
+* Open a pull request!
+  * For the title of the pull request, please use the following format for the title:
+
+    ```text
+    feat(wobble): add hat wobble
+    ^--^^------^  ^------------^
+    |   |         |
+    |   |         +---> Summary in present tense.
+    |   +---> Scope: a noun describing a section of the codebase (optional)
+    +---> Type: chore, docs, feat, fix, refactor, or test.
+    ```
+
+    * feat: adds a new feature (equivalent to a MINOR in Semantic Versioning)
+    * fix: fixes a bug (equivalent to a PATCH in Semantic Versioning)
+    * docs: changes to the documentation
+    * refactor: refactors production code, eg. renaming a variable; doesn't change public API
+    * test: adds missing tests, refactors tests; no production code change
+    * chore: updates something without impacting the user (ex: bump a dependency in package.json or go.mod); no production code change
+
+    If a code change introduces a breaking change, place ! suffix after type, ie. feat(change)!: adds breaking change. correlates with MAJOR in semantic versioning.
+
+Thank you for your contribution!

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,10 +56,10 @@ linters-settings:
 
   # https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+    allow-leading-space: true # allow non-"machine-readable" format (ie. with leading space) 
+    allow-unused: false # allow nolint directives that don't address a linting issue
+    require-explanation: true # require an explanation for nolint directives
+    require-specific: true # require nolint directives to be specific about which linter is being skipped
 
 # This section provides the configuration for which linters
 # golangci will execute. Several of them were disabled by
@@ -131,7 +131,9 @@ issues:
     # prevent linters from running on *_test.go files
     - path: _test\.go
       linters:
+        - dupl
         - funlen
         - goconst
         - gocyclo
         - gomnd
+        - lll

--- a/api/authenticate.go
+++ b/api/authenticate.go
@@ -52,6 +52,8 @@ import (
 // Authenticate represents the API handler to
 // process a user logging in to Vela from
 // the API or UI.
+//
+// nolint: funlen // ignore function length due to comments
 func Authenticate(c *gin.Context) {
 	var err error
 

--- a/api/badge.go
+++ b/api/badge.go
@@ -66,7 +66,7 @@ func GetBadge(c *gin.Context) {
 	c.String(http.StatusOK, badge)
 }
 
-// badgeForStatus is a helper to match the build status with a badge
+// badgeForStatus is a helper to match the build status with a badge.
 func badgeForStatus(s string) string {
 	switch s {
 	case constants.StatusRunning, constants.StatusPending:

--- a/api/build.go
+++ b/api/build.go
@@ -79,6 +79,8 @@ import (
 
 // CreateBuild represents the API handler to
 // create a build in the configured backend.
+//
+// nolint: funlen // ignore function length due to comments
 func CreateBuild(c *gin.Context) {
 	// capture middleware values
 	m := c.MustGet("metadata").(*types.Metadata)
@@ -103,6 +105,7 @@ func CreateBuild(c *gin.Context) {
 		(input.GetEvent() == constants.EventPull && !r.GetAllowPull()) ||
 		(input.GetEvent() == constants.EventTag && !r.GetAllowTag()) ||
 		(input.GetEvent() == constants.EventDeploy && !r.GetAllowDeploy()) {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to create new build: %s does not have %s events enabled", r.GetFullName(), input.GetEvent())
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -158,6 +161,7 @@ func CreateBuild(c *gin.Context) {
 		// send API call to capture list of files changed for the commit
 		files, err = source.FromContext(c).Changeset(u, r, input.GetCommit())
 		if err != nil {
+			// nolint: lll // ignore long line length due to error message
 			retErr := fmt.Errorf("unable to process webhook: failed to get changeset for %s: %w", r.GetFullName(), err)
 
 			util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -171,7 +175,7 @@ func CreateBuild(c *gin.Context) {
 		// capture number from build
 		number, err := getPRNumberFromBuild(input)
 		if err != nil {
-			// nolint:lll // long log message
+			// nolint: lll // ignore long line length due to error message
 			retErr := fmt.Errorf("unable to create build: failed to get pull_request number for %s: %w", r.GetFullName(), err)
 
 			util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -182,6 +186,7 @@ func CreateBuild(c *gin.Context) {
 		// send API call to capture list of files changed for the pull request
 		files, err = source.FromContext(c).ChangesetPR(u, r, number)
 		if err != nil {
+			// nolint: lll // ignore long line length due to error message
 			retErr := fmt.Errorf("unable to process webhook: failed to get changeset for %s: %w", r.GetFullName(), err)
 
 			util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -193,6 +198,7 @@ func CreateBuild(c *gin.Context) {
 	// send API call to capture the pipeline configuration file
 	config, err := source.FromContext(c).ConfigBackoff(u, r.GetOrg(), r.GetName(), input.GetCommit())
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get pipeline configuration for %s/%d: %w", r.GetFullName(), input.GetNumber(), err)
 
 		util.HandleError(c, http.StatusNotFound, retErr)
@@ -209,6 +215,7 @@ func CreateBuild(c *gin.Context) {
 		WithUser(u).
 		Compile(config)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to compile pipeline configuration for %s/%d: %w", r.GetFullName(), input.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -232,6 +239,7 @@ func CreateBuild(c *gin.Context) {
 	// send API call to set the status on the commit
 	err = source.FromContext(c).Status(u, input, r.GetOrg(), r.GetName())
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		logrus.Errorf("unable to set commit status for build %s/%d: %v", r.GetFullName(), input.GetNumber(), err)
 	}
 
@@ -302,6 +310,7 @@ func GetBuilds(c *gin.Context) {
 	// capture page query parameter if present
 	page, err := strconv.Atoi(c.DefaultQuery("page", "1"))
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to convert page query parameter for repo %s: %w", r.GetFullName(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -312,6 +321,7 @@ func GetBuilds(c *gin.Context) {
 	// capture per_page query parameter if present
 	perPage, err := strconv.Atoi(c.DefaultQuery("per_page", "10"))
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to convert per_page query parameter for repo %s: %w", r.GetFullName(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -320,6 +330,8 @@ func GetBuilds(c *gin.Context) {
 	}
 
 	// ensure per_page isn't above or below allowed values
+	//
+	// nolint: gomnd // ignore magic number
 	perPage = util.MaxInt(1, util.MinInt(100, perPage))
 
 	// send API call to capture the list of builds for the repo (and event type if passed in)
@@ -386,7 +398,7 @@ func GetBuilds(c *gin.Context) {
 //       type: string
 
 // GetOrgBuilds represents the API handler to capture a
-// list of builds associated with an org from the configured backend
+// list of builds associated with an org from the configured backend.
 func GetOrgBuilds(c *gin.Context) {
 	// variables that will hold the build list and total count
 	var (
@@ -422,7 +434,9 @@ func GetOrgBuilds(c *gin.Context) {
 	}
 
 	// ensure per_page isn't above or below allowed values
-	perPage = util.MaxInt(1, util.MinInt(100, perPage)) //nolint:gomnd
+	//
+	// nolint: gomnd // ignore magic number
+	perPage = util.MaxInt(1, util.MinInt(100, perPage))
 
 	// send API call to capture the list of builds for the org (and event type if passed in)
 	if len(event) > 0 {
@@ -545,6 +559,8 @@ func GetBuild(c *gin.Context) {
 
 // RestartBuild represents the API handler to
 // restart an existing build in the configured backend.
+//
+// nolint: funlen // ignore function length due to comments
 func RestartBuild(c *gin.Context) {
 	// capture middleware values
 	m := c.MustGet("metadata").(*types.Metadata)
@@ -566,6 +582,7 @@ func RestartBuild(c *gin.Context) {
 	// send API call to capture the last build for the repo
 	lastBuild, err := database.FromContext(c).GetLastBuild(r)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get last build for %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -600,6 +617,7 @@ func RestartBuild(c *gin.Context) {
 		// send API call to capture list of files changed for the commit
 		files, err = source.FromContext(c).Changeset(u, r, b.GetCommit())
 		if err != nil {
+			// nolint: lll // ignore long line length due to error message
 			retErr := fmt.Errorf("unable to process webhook: failed to get changeset for %s: %w", r.GetFullName(), err)
 
 			util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -613,7 +631,7 @@ func RestartBuild(c *gin.Context) {
 		// capture number from build
 		number, err := getPRNumberFromBuild(b)
 		if err != nil {
-			// nolint:lll // long log message
+			// nolint: lll // ignore long line length due to error message
 			retErr := fmt.Errorf("unable to restart build: failed to get pull_request number for %s: %w", r.GetFullName(), err)
 
 			util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -624,6 +642,7 @@ func RestartBuild(c *gin.Context) {
 		// send API call to capture list of files changed for the pull request
 		files, err = source.FromContext(c).ChangesetPR(u, r, number)
 		if err != nil {
+			// nolint: lll // ignore long line length due to error message
 			retErr := fmt.Errorf("unable to process webhook: failed to get changeset for %s: %w", r.GetFullName(), err)
 
 			util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -635,6 +654,7 @@ func RestartBuild(c *gin.Context) {
 	// send API call to capture the pipeline configuration file
 	config, err := source.FromContext(c).ConfigBackoff(u, r.GetOrg(), r.GetName(), b.GetCommit())
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get pipeline configuration for %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 
 		util.HandleError(c, http.StatusNotFound, retErr)
@@ -651,6 +671,7 @@ func RestartBuild(c *gin.Context) {
 		WithUser(u).
 		Compile(config)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to compile pipeline configuration for %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -674,6 +695,7 @@ func RestartBuild(c *gin.Context) {
 	// send API call to set the status on the commit
 	err = source.FromContext(c).Status(u, b, r.GetOrg(), r.GetName())
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		logrus.Errorf("unable to set commit status for build %s/%d: %v", r.GetFullName(), b.GetNumber(), err)
 	}
 
@@ -748,6 +770,7 @@ func UpdateBuild(c *gin.Context) {
 
 	err := c.Bind(input)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to decode JSON for build %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 
 		util.HandleError(c, http.StatusNotFound, retErr)
@@ -830,6 +853,7 @@ func UpdateBuild(c *gin.Context) {
 		// send API call to set the status on the commit
 		err = source.FromContext(c).Status(u, b, r.GetOrg(), r.GetName())
 		if err != nil {
+			// nolint: lll // ignore long line length due to error message
 			logrus.Errorf("unable to set commit status for build %s/%d: %v", r.GetFullName(), b.GetNumber(), err)
 		}
 	}
@@ -905,6 +929,7 @@ func getPRNumberFromBuild(b *library.Build) (int, error) {
 	}
 
 	// just being safe to avoid out of range index errors
+	//
 	// nolint:gomnd // magic number of 3 used once
 	if len(parts) < 3 {
 		return 0, fmt.Errorf("invalid ref: %s", b.GetRef())
@@ -917,6 +942,8 @@ func getPRNumberFromBuild(b *library.Build) (int, error) {
 // planBuild is a helper function to plan the build for
 // execution. This creates all resources, like steps
 // and services, for the build in the configured backend.
+//
+// nolint: lll // ignore long line length due to variable names
 func planBuild(database database.Service, p *pipeline.Build, b *library.Build, r *library.Repo) error {
 	// update fields in build object
 	b.SetCreated(time.Now().UTC().Unix())
@@ -931,7 +958,7 @@ func planBuild(database database.Service, p *pipeline.Build, b *library.Build, r
 	}
 
 	// send API call to capture the created build
-	b, _ = database.GetBuild(int(b.GetNumber()), r)
+	b, _ = database.GetBuild(b.GetNumber(), r)
 
 	// plan all services for the build
 	services, err := planServices(database, p, b)
@@ -958,6 +985,8 @@ func planBuild(database database.Service, p *pipeline.Build, b *library.Build, r
 // without execution. This will kill all resources,
 // like steps and services, for the build in the
 // configured backend.
+//
+// nolint: lll // ignore long line length due to variable names
 func cleanBuild(database database.Service, b *library.Build, services []*library.Service, steps []*library.Step) {
 	// update fields in build object
 	b.SetError("unable to publish build to queue")

--- a/api/deployment.go
+++ b/api/deployment.go
@@ -163,6 +163,7 @@ func GetDeployments(c *gin.Context) {
 	// capture per_page query parameter if present
 	perPage, err := strconv.Atoi(c.DefaultQuery("per_page", "10"))
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to convert per_page query parameter for %s: %w", r.GetFullName(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -171,6 +172,8 @@ func GetDeployments(c *gin.Context) {
 	}
 
 	// ensure per_page isn't above or below allowed values
+	//
+	// nolint: gomnd // ignore magic number
 	perPage = util.MaxInt(1, util.MinInt(100, perPage))
 
 	// send API call to capture the total number of deployments for the repo

--- a/api/hook.go
+++ b/api/hook.go
@@ -75,6 +75,7 @@ func CreateHook(c *gin.Context) {
 
 	err := c.Bind(input)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to decode JSON for new webhook for repo %s: %w", r.GetFullName(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -162,6 +163,8 @@ func CreateHook(c *gin.Context) {
 
 // GetHooks represents the API handler to capture a list
 // of webhooks from the configured backend.
+//
+// nolint: dupl // ignore false positive
 func GetHooks(c *gin.Context) {
 	// capture middleware values
 	r := repo.Retrieve(c)
@@ -171,6 +174,7 @@ func GetHooks(c *gin.Context) {
 	// capture page query parameter if present
 	page, err := strconv.Atoi(c.DefaultQuery("page", "1"))
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to convert page query parameter for repo %s: %w", r.GetFullName(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -181,6 +185,7 @@ func GetHooks(c *gin.Context) {
 	// capture per_page query parameter if present
 	perPage, err := strconv.Atoi(c.DefaultQuery("per_page", "10"))
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to convert per_page query parameter for repo %s: %w", r.GetFullName(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -189,6 +194,8 @@ func GetHooks(c *gin.Context) {
 	}
 
 	// ensure per_page isn't above or below allowed values
+	//
+	// nolint: gomnd // ignore magic number
 	perPage = util.MaxInt(1, util.MinInt(100, perPage))
 
 	// send API call to capture the total number of webhooks for the repo

--- a/api/log.go
+++ b/api/log.go
@@ -72,6 +72,7 @@ func GetBuildLogs(c *gin.Context) {
 	// send API call to capture the list of logs for the build
 	l, err := database.FromContext(c).GetBuildLogs(b.GetID())
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get logs for build %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -82,6 +83,8 @@ func GetBuildLogs(c *gin.Context) {
 	c.JSON(http.StatusOK, l)
 }
 
+// nolint: lll // ignore long line length due to API path
+//
 // swagger:operation POST /api/v1/repos/{org}/{repo}/builds/{build}/services/{service}/logs services CreateServiceLogs
 //
 // Create the logs for a service
@@ -136,6 +139,8 @@ func GetBuildLogs(c *gin.Context) {
 
 // CreateServiceLog represents the API handler to create
 // the logs for a service in the configured backend.
+//
+// nolint: dupl // ignore similar code with step
 func CreateServiceLog(c *gin.Context) {
 	// capture middleware values
 	b := build.Retrieve(c)
@@ -149,6 +154,7 @@ func CreateServiceLog(c *gin.Context) {
 
 	err := c.Bind(input)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to decode JSON for service %s/%d/%d: %w", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -164,6 +170,7 @@ func CreateServiceLog(c *gin.Context) {
 	// send API call to create the logs
 	err = database.FromContext(c).CreateLog(input)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to create logs for service %s/%d/%d: %w", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -177,6 +184,8 @@ func CreateServiceLog(c *gin.Context) {
 	c.JSON(http.StatusCreated, l)
 }
 
+// nolint: lll // ignore long line length due to API path
+//
 // swagger:operation GET /api/v1/repos/{org}/{repo}/builds/{build}/services/{service}/logs services GetServiceLogs
 //
 // Retrieve the logs for a service
@@ -232,6 +241,7 @@ func GetServiceLog(c *gin.Context) {
 	// send API call to capture the service logs
 	l, err := database.FromContext(c).GetServiceLog(s.GetID())
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get logs for service %s/%d/%d: %w", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -242,6 +252,8 @@ func GetServiceLog(c *gin.Context) {
 	c.JSON(http.StatusOK, l)
 }
 
+// nolint: lll // ignore long line length due to API path
+//
 // swagger:operation PUT /api/v1/repos/{org}/{repo}/builds/{build}/services/{service}/logs services UpdateServiceLog
 //
 // Update the logs for a service
@@ -307,6 +319,7 @@ func UpdateServiceLog(c *gin.Context) {
 	// send API call to capture the service logs
 	l, err := database.FromContext(c).GetServiceLog(s.GetID())
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get logs for service %s/%d/%d: %w", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -319,6 +332,7 @@ func UpdateServiceLog(c *gin.Context) {
 
 	err = c.Bind(input)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to decode JSON for service %s/%d/%d: %w", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -335,6 +349,7 @@ func UpdateServiceLog(c *gin.Context) {
 	// send API call to update the log
 	err = database.FromContext(c).UpdateLog(l)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to update logs for service %s/%d/%d: %w", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -348,6 +363,8 @@ func UpdateServiceLog(c *gin.Context) {
 	c.JSON(http.StatusOK, l)
 }
 
+// nolint: lll // ignore long line length due to API path
+//
 // swagger:operation DELETE /api/v1/repos/{org}/{repo}/builds/{build}/services/{service}/logs services DeleteServiceLogs
 //
 // Delete the logs for a service
@@ -391,6 +408,8 @@ func UpdateServiceLog(c *gin.Context) {
 
 // DeleteServiceLog represents the API handler to remove
 // the logs for a service from the configured backend.
+//
+// nolint: dupl // ignore similar code with step
 func DeleteServiceLog(c *gin.Context) {
 	// capture middleware values
 	b := build.Retrieve(c)
@@ -402,6 +421,7 @@ func DeleteServiceLog(c *gin.Context) {
 	// send API call to remove the log
 	err := database.FromContext(c).DeleteLog(s.GetID())
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to delete logs for service %s/%d/%d: %w", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -409,9 +429,12 @@ func DeleteServiceLog(c *gin.Context) {
 		return
 	}
 
+	// nolint: lll // ignore long line length due to return message
 	c.JSON(http.StatusOK, fmt.Sprintf("Logs deleted for service %s/%d/%d", r.GetFullName(), b.GetNumber(), s.GetNumber()))
 }
 
+// nolint: lll // ignore long line length due to API path
+//
 // swagger:operation POST /api/v1/repos/{org}/{repo}/builds/{build}/steps/{step}/logs steps CreateStepLog
 //
 // Create the logs for a step
@@ -466,6 +489,8 @@ func DeleteServiceLog(c *gin.Context) {
 
 // CreateStepLog represents the API handler to create
 // the logs for a step in the configured backend.
+//
+// nolint: dupl // ignore similar code with service
 func CreateStepLog(c *gin.Context) {
 	// capture middleware values
 	b := build.Retrieve(c)
@@ -479,6 +504,7 @@ func CreateStepLog(c *gin.Context) {
 
 	err := c.Bind(input)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to decode JSON for step %s/%d/%d: %w", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -494,6 +520,7 @@ func CreateStepLog(c *gin.Context) {
 	// send API call to create the logs
 	err = database.FromContext(c).CreateLog(input)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to create logs for step %s/%d/%d: %w", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -507,6 +534,8 @@ func CreateStepLog(c *gin.Context) {
 	c.JSON(http.StatusCreated, l)
 }
 
+// nolint: lll // ignore long line length due to API path
+//
 // swagger:operation GET /api/v1/repos/{org}/{repo}/builds/{build}/steps/{step}/logs steps GetStepLog
 //
 // Retrieve the logs for a step
@@ -558,6 +587,7 @@ func GetStepLog(c *gin.Context) {
 	// send API call to capture the step logs
 	l, err := database.FromContext(c).GetStepLog(s.GetID())
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get logs for step %s/%d/%d: %w", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -568,6 +598,8 @@ func GetStepLog(c *gin.Context) {
 	c.JSON(http.StatusOK, l)
 }
 
+// nolint: lll // ignore long line length due to API path
+//
 // swagger:operation PUT /api/v1/repos/{org}/{repo}/builds/{build}/steps/{step}/logs steps UpdateStepLog
 //
 // Update the logs for a step
@@ -633,6 +665,7 @@ func UpdateStepLog(c *gin.Context) {
 	// send API call to capture the step logs
 	l, err := database.FromContext(c).GetStepLog(s.GetID())
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get logs for step %s/%d/%d: %w", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -645,6 +678,7 @@ func UpdateStepLog(c *gin.Context) {
 
 	err = c.Bind(input)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to decode JSON for step %s/%d/%d: %v", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -661,6 +695,7 @@ func UpdateStepLog(c *gin.Context) {
 	// send API call to update the log
 	err = database.FromContext(c).UpdateLog(l)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to update logs for step %s/%d/%d: %v", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -674,6 +709,8 @@ func UpdateStepLog(c *gin.Context) {
 	c.JSON(http.StatusOK, l)
 }
 
+// nolint: lll // ignore long line length due to API path
+//
 // swagger:operation DELETE /api/v1/repos/{org}/{repo}/builds/{build}/steps/{step}/logs steps DeleteStepLog
 //
 // Delete the logs for a step
@@ -717,6 +754,8 @@ func UpdateStepLog(c *gin.Context) {
 
 // DeleteStepLog represents the API handler to remove
 // the logs for a step from the configured backend.
+//
+// nolint: dupl // ignore similar code with service
 func DeleteStepLog(c *gin.Context) {
 	// capture middleware values
 	b := build.Retrieve(c)
@@ -728,6 +767,7 @@ func DeleteStepLog(c *gin.Context) {
 	// send API call to remove the log
 	err := database.FromContext(c).DeleteLog(s.GetID())
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to delete logs for step %s/%d/%d: %w", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -735,5 +775,6 @@ func DeleteStepLog(c *gin.Context) {
 		return
 	}
 
+	// nolint: lll // ignore long line length due to return message
 	c.JSON(http.StatusOK, fmt.Sprintf("Logs deleted for step %s/%d/%d", r.GetFullName(), b.GetNumber(), s.GetNumber()))
 }

--- a/api/logout.go
+++ b/api/logout.go
@@ -57,7 +57,9 @@ func Logout(c *gin.Context) {
 	}
 
 	// remove the refresh token from the cookies, Max-Age value -1 will do it
-	c.SetCookie(constants.RefreshTokenName, "", -1, "/", addr.Hostname(), c.Value("securecookie").(bool), true)
+	c.SetCookie(
+		constants.RefreshTokenName, "", -1, "/", addr.Hostname(), c.Value("securecookie").(bool), true,
+	)
 
 	// unset the refresh token for the user
 	u.SetRefreshToken("")

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -18,7 +18,7 @@ import (
 
 // predefine Prometheus metrics else they will be regenerated
 // each function call which will throw error:
-// "duplicate metrics collector registration attempted"
+// "duplicate metrics collector registration attempted".
 var (
 	totals = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -60,18 +60,20 @@ var (
 //     schema:
 //       type: string
 
-// BaseMetrics returns a Prometheus handler for serving go metrics
+// BaseMetrics returns a Prometheus handler for serving go metrics.
 func BaseMetrics() http.Handler {
 	return promhttp.Handler()
 }
 
-// CustomMetrics returns custom Prometheus metrics from private functions
+// CustomMetrics returns custom Prometheus metrics from private functions.
 func CustomMetrics(c *gin.Context) {
 	// call helper function to return total users
 	recordGauges(c)
 }
 
-// helper function to get the totals of resource types
+// helper function to get the totals of resource types.
+//
+// nolint: funlen // ignore function length due to comments
 func recordGauges(c *gin.Context) {
 	// send API call to capture the total number of users
 	u, err := database.FromContext(c).GetUserCount()

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -14,14 +14,14 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// Pagination holds basic information pertaining to paginating results
+// Pagination holds basic information pertaining to paginating results.
 type Pagination struct {
 	PerPage int
 	Page    int
 	Total   int64
 }
 
-// HeaderLink will hold the information needed to form a link element in the header
+// HeaderLink will hold the information needed to form a link element in the header.
 type HeaderLink map[string]int
 
 // SetHeaderLink sets the Link HTTP header element to provide clients with paging information
@@ -57,7 +57,16 @@ func (p *Pagination) SetHeaderLink(c *gin.Context) {
 	}
 
 	for rel, page := range hl {
-		ls := fmt.Sprintf(`<%s://%s%s?per_page=%d&page=%d>; rel="%s"`, resolveScheme(r), r.Host, r.URL.Path, p.PerPage, page, rel)
+		ls := fmt.Sprintf(
+			`<%s://%s%s?per_page=%d&page=%d>; rel="%s"`,
+			resolveScheme(r),
+			r.Host,
+			r.URL.Path,
+			p.PerPage,
+			page,
+			rel,
+		)
+
 		l = append(l, ls)
 	}
 
@@ -65,7 +74,7 @@ func (p *Pagination) SetHeaderLink(c *gin.Context) {
 	c.Header("Link", strings.Join(l, ", "))
 }
 
-// NextPage returns the next page number
+// NextPage returns the next page number.
 func (p *Pagination) NextPage() int {
 	if !p.HasNext() {
 		return p.Page
@@ -74,7 +83,7 @@ func (p *Pagination) NextPage() int {
 	return p.Page + 1
 }
 
-// PrevPage returns the previous page number
+// PrevPage returns the previous page number.
 func (p *Pagination) PrevPage() int {
 	if !p.HasPrev() {
 		return 1
@@ -83,22 +92,22 @@ func (p *Pagination) PrevPage() int {
 	return p.Page - 1
 }
 
-// HasPrev will return true if there is a previous page
+// HasPrev will return true if there is a previous page.
 func (p *Pagination) HasPrev() bool {
 	return p.Page > 1
 }
 
-// HasNext will return true if there is a next page
+// HasNext will return true if there is a next page.
 func (p *Pagination) HasNext() bool {
 	return p.Page < p.TotalPages()
 }
 
-// HasPages returns true if there is need to deal with pagination
+// HasPages returns true if there is need to deal with pagination.
 func (p *Pagination) HasPages() bool {
 	return p.Total > int64(p.PerPage)
 }
 
-// TotalPages will return the total number of pages
+// TotalPages will return the total number of pages.
 func (p *Pagination) TotalPages() int {
 	n := int(math.Ceil(float64(p.Total) / float64(p.PerPage)))
 	if n == 0 {
@@ -109,7 +118,9 @@ func (p *Pagination) TotalPages() int {
 }
 
 // resolveScheme is a helper to determine the protocol scheme
-// c.Request.URL.Scheme does not seem to reliably provide this
+// c.Request.URL.Scheme does not seem to reliably provide this.
+//
+// nolint: goconst // ignore making constant for https
 func resolveScheme(r *http.Request) string {
 	switch {
 	case r.Header.Get("X-Forwarded-Proto") == "https":

--- a/api/pipeline.go
+++ b/api/pipeline.go
@@ -102,6 +102,7 @@ func GetPipeline(c *gin.Context) {
 	// send API call to capture the pipeline configuration file
 	config, err := source.FromContext(c).ConfigBackoff(u, r.GetOrg(), r.GetName(), ref)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 		util.HandleError(c, http.StatusNotFound, retErr)
@@ -118,6 +119,7 @@ func GetPipeline(c *gin.Context) {
 	// parse the pipeline configuration file
 	p, _, err := comp.Parse(config)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to parse pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -209,6 +211,7 @@ func GetTemplates(c *gin.Context) {
 	// send API call to capture the pipeline configuration file
 	config, err := source.FromContext(c).ConfigBackoff(u, r.GetOrg(), r.GetName(), ref)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 		util.HandleError(c, http.StatusNotFound, retErr)
@@ -225,6 +228,7 @@ func GetTemplates(c *gin.Context) {
 	// parse the pipeline configuration file
 	p, _, err := comp.Parse(config)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to parse pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -326,6 +330,7 @@ func ExpandPipeline(c *gin.Context) {
 	// send API call to capture the pipeline configuration file
 	config, err := source.FromContext(c).ConfigBackoff(u, r.GetOrg(), r.GetName(), ref)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 		util.HandleError(c, http.StatusNotFound, retErr)
@@ -342,6 +347,7 @@ func ExpandPipeline(c *gin.Context) {
 	// parse the pipeline configuration file
 	p, _, err := comp.Parse(config)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to parse pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -357,6 +363,7 @@ func ExpandPipeline(c *gin.Context) {
 		// inject the templates into the stages
 		p.Stages, err = comp.ExpandStages(p.Stages, t)
 		if err != nil {
+			// nolint: lll // ignore long line length due to error message
 			retErr := fmt.Errorf("unable to expand stages in pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 			util.HandleError(c, http.StatusBadRequest, retErr)
@@ -367,6 +374,7 @@ func ExpandPipeline(c *gin.Context) {
 		// inject the templates into the steps
 		p.Steps, err = comp.ExpandSteps(p.Steps, t)
 		if err != nil {
+			// nolint: lll // ignore long line length due to error message
 			retErr := fmt.Errorf("unable to expand steps in pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 			util.HandleError(c, http.StatusBadRequest, retErr)
@@ -458,6 +466,7 @@ func ValidatePipeline(c *gin.Context) {
 	// send API call to capture the pipeline configuration file
 	config, err := source.FromContext(c).ConfigBackoff(u, r.GetOrg(), r.GetName(), ref)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 		util.HandleError(c, http.StatusNotFound, retErr)
@@ -474,6 +483,7 @@ func ValidatePipeline(c *gin.Context) {
 	// parse the pipeline configuration file
 	p, raw, err := comp.Parse(config)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to parse pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -491,6 +501,7 @@ func ValidatePipeline(c *gin.Context) {
 			// inject the templates into the stages
 			p.Stages, err = comp.ExpandStages(p.Stages, t)
 			if err != nil {
+				// nolint: lll // ignore long line length due to error message
 				retErr := fmt.Errorf("unable to expand stages in pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 				util.HandleError(c, http.StatusBadRequest, retErr)
@@ -500,6 +511,7 @@ func ValidatePipeline(c *gin.Context) {
 		} else { // inject the templates into the stages
 			p.Steps, err = comp.ExpandSteps(p.Steps, t)
 			if err != nil {
+				// nolint: lll // ignore long line length due to error message
 				retErr := fmt.Errorf("unable to expand steps in pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 				util.HandleError(c, http.StatusBadRequest, retErr)
@@ -512,6 +524,7 @@ func ValidatePipeline(c *gin.Context) {
 	// validate the yaml configuration
 	err = p.Validate(raw)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to validate pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -574,6 +587,8 @@ func ValidatePipeline(c *gin.Context) {
 
 // CompilePipeline represents the API handler to capture,
 // expand and compile a pipeline configuration.
+//
+// nolint: funlen // ignore function length due to comments
 func CompilePipeline(c *gin.Context) {
 	// capture middleware values
 	m := c.MustGet("metadata").(*types.Metadata)
@@ -596,6 +611,7 @@ func CompilePipeline(c *gin.Context) {
 	// send API call to capture the pipeline configuration file
 	config, err := source.FromContext(c).ConfigBackoff(u, r.GetOrg(), r.GetName(), ref)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 		util.HandleError(c, http.StatusNotFound, retErr)
@@ -612,6 +628,7 @@ func CompilePipeline(c *gin.Context) {
 	// parse the pipeline configuration file
 	p, raw, err := comp.Parse(config)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to parse pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -627,6 +644,7 @@ func CompilePipeline(c *gin.Context) {
 		// inject the templates into the stages
 		p.Stages, err = comp.ExpandStages(p.Stages, t)
 		if err != nil {
+			// nolint: lll // ignore long line length due to error message
 			retErr := fmt.Errorf("unable to expand stages in pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 			util.HandleError(c, http.StatusBadRequest, retErr)
@@ -637,6 +655,7 @@ func CompilePipeline(c *gin.Context) {
 		// inject the substituted environment variables into the stages
 		p.Stages, err = comp.SubstituteStages(p.Stages)
 		if err != nil {
+			// nolint: lll // ignore long line length due to error message
 			retErr := fmt.Errorf("unable to substitute stages in pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 			util.HandleError(c, http.StatusBadRequest, retErr)
@@ -647,6 +666,7 @@ func CompilePipeline(c *gin.Context) {
 		// inject the templates into the steps
 		p.Steps, err = comp.ExpandSteps(p.Steps, t)
 		if err != nil {
+			// nolint: lll // ignore long line length due to error message
 			retErr := fmt.Errorf("unable to expand steps in pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 			util.HandleError(c, http.StatusBadRequest, retErr)
@@ -657,6 +677,7 @@ func CompilePipeline(c *gin.Context) {
 		// inject the substituted environment variables into the steps
 		p.Steps, err = comp.SubstituteSteps(p.Steps)
 		if err != nil {
+			// nolint: lll // ignore long line length due to error message
 			retErr := fmt.Errorf("unable to substitute steps in pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 			util.HandleError(c, http.StatusBadRequest, retErr)
@@ -668,6 +689,7 @@ func CompilePipeline(c *gin.Context) {
 	// validate the yaml configuration
 	err = p.Validate(raw)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to validate pipeline configuration for %s@%s: %w", r.GetFullName(), ref, err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -686,11 +708,13 @@ func CompilePipeline(c *gin.Context) {
 	}
 }
 
-// setTemplateLinks helper function that retrieves source provider links for a list of templates and returns a map of library templates.
+// setTemplateLinks helper function that retrieves source provider links
+// for a list of templates and returns a map of library templates.
+//
+// nolint: lll // ignore long line length due to variable names
 func setTemplateLinks(c *gin.Context, u *library.User, r *library.Repo, templates yaml.TemplateSlice) (map[string]*library.Template, error) {
 	m := make(map[string]*library.Template)
 	for _, t := range templates {
-
 		// convert to library type
 		tmpl := t.ToLibrary()
 

--- a/api/repo.go
+++ b/api/repo.go
@@ -274,6 +274,8 @@ func CreateRepo(c *gin.Context) {
 
 // GetRepos represents the API handler to capture a list
 // of repos for a user from the configured backend.
+//
+// nolint: dupl // ignore false positive
 func GetRepos(c *gin.Context) {
 	// capture middleware values
 	u := user.Retrieve(c)
@@ -292,6 +294,7 @@ func GetRepos(c *gin.Context) {
 	// capture per_page query parameter if present
 	perPage, err := strconv.Atoi(c.DefaultQuery("per_page", "10"))
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to convert per_page query parameter for user %s: %w", u.GetName(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -300,6 +303,8 @@ func GetRepos(c *gin.Context) {
 	}
 
 	// ensure per_page isn't above or below allowed values
+	//
+	// nolint: gomnd // ignore magic number
 	perPage = util.MaxInt(1, util.MinInt(100, perPage))
 
 	// send API call to capture the total number of repos for the user
@@ -425,6 +430,8 @@ func GetRepo(c *gin.Context) {
 
 // UpdateRepo represents the API handler to update
 // a repo in the configured backend.
+//
+// nolint: funlen // ignore function length due to comments and conditionals
 func UpdateRepo(c *gin.Context) {
 	// capture middleware values
 	r := repo.Retrieve(c)

--- a/api/secret.go
+++ b/api/secret.go
@@ -21,6 +21,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// nolint: lll // ignore long line length due to description
+//
 // swagger:operation POST /api/v1/secrets/{engine}/{type}/{org}/{name} secrets CreateSecret
 //
 // Create a secret
@@ -92,6 +94,7 @@ func CreateSecret(c *gin.Context) {
 
 	err := c.Bind(input)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to decode JSON for secret %s/%s/%s for %s service: %w", t, o, n, e, err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -142,6 +145,8 @@ func CreateSecret(c *gin.Context) {
 	c.JSON(http.StatusOK, s.Sanitize())
 }
 
+// nolint: lll // ignore long line length due to description
+//
 // swagger:operation GET /api/v1/secrets/{engine}/{type}/{org}/{name} secrets GetSecrets
 //
 // Retrieve a list of secrets from the configured backend.
@@ -204,6 +209,7 @@ func GetSecrets(c *gin.Context) {
 	// capture page query parameter if present
 	page, err := strconv.Atoi(c.DefaultQuery("page", "1"))
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to convert page query parameter for %s/%s/%s from %s service: %w", t, o, n, e, err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -214,6 +220,7 @@ func GetSecrets(c *gin.Context) {
 	// capture per_page query parameter if present
 	perPage, err := strconv.Atoi(c.DefaultQuery("per_page", "10"))
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to convert per_page query parameter for %s/%s/%s from %s service: %w", t, o, n, e, err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -224,6 +231,7 @@ func GetSecrets(c *gin.Context) {
 	// send API call to capture the total number of secrets
 	total, err := secret.FromContext(c, e).Count(t, o, n)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get secret count for %s/%s/%s from %s service: %w", t, o, n, e, err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -232,6 +240,8 @@ func GetSecrets(c *gin.Context) {
 	}
 
 	// ensure per_page isn't above or below allowed values
+	//
+	// nolint: gomnd // ignore magic number
 	perPage = util.MaxInt(1, util.MinInt(100, perPage))
 
 	// send API call to capture the list of secrets
@@ -267,6 +277,8 @@ func GetSecrets(c *gin.Context) {
 	c.JSON(http.StatusOK, secrets)
 }
 
+// nolint: lll // ignore long line length due to description
+//
 // swagger:operation GET /api/v1/secrets/{engine}/{type}/{org}/{name}/{secret} secrets GetSecret
 //
 // Retrieve a secret from the configured backend.
@@ -346,6 +358,8 @@ func GetSecret(c *gin.Context) {
 	c.JSON(http.StatusOK, secret.Sanitize())
 }
 
+// nolint: lll // ignore long line length due to description
+//
 // swagger:operation PUT /api/v1/secrets/{engine}/{type}/{org}/{name}/{secret} secrets UpdateSecrets
 //
 // Update a secret from the configured backend.
@@ -419,6 +433,7 @@ func UpdateSecret(c *gin.Context) {
 
 	err := c.Bind(input)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to decode JSON for secret %s/%s/%s/%s for %s service: %v", t, o, n, s, e, err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -469,6 +484,8 @@ func UpdateSecret(c *gin.Context) {
 	c.JSON(http.StatusOK, secret.Sanitize())
 }
 
+// nolint: lll // ignore long line length due to description
+//
 // swagger:operation DELETE /api/v1/secrets/{engine}/{type}/{org}/{name}/{secret} secrets DeleteSecret
 //
 // Delete a secret from the configured backend.
@@ -535,6 +552,7 @@ func DeleteSecret(c *gin.Context) {
 	// send API call to remove the secret
 	err := secret.FromContext(c, e).Delete(t, o, n, s)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to delete secret %s/%s/%s/%s from %s service: %w", t, o, n, s, e, err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)

--- a/api/service.go
+++ b/api/service.go
@@ -73,6 +73,8 @@ import (
 
 // CreateService represents the API handler to create
 // a service for a build in the configured backend.
+//
+// nolint: dupl // ignore similar code with step
 func CreateService(c *gin.Context) {
 	// capture middleware values
 	b := build.Retrieve(c)
@@ -85,6 +87,7 @@ func CreateService(c *gin.Context) {
 
 	err := c.Bind(input)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to decode JSON for new service for build %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -107,6 +110,7 @@ func CreateService(c *gin.Context) {
 	// send API call to create the service
 	err = database.FromContext(c).CreateService(input)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to create service for build %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -175,6 +179,7 @@ func GetServices(c *gin.Context) {
 	// capture page query parameter if present
 	page, err := strconv.Atoi(c.DefaultQuery("page", "1"))
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to convert page query parameter for build %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -185,6 +190,7 @@ func GetServices(c *gin.Context) {
 	// capture per_page query parameter if present
 	perPage, err := strconv.Atoi(c.DefaultQuery("per_page", "10"))
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to convert per_page query parameter for build %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -193,11 +199,14 @@ func GetServices(c *gin.Context) {
 	}
 
 	// ensure per_page isn't above or below allowed values
+	//
+	// nolint: gomnd // ignore magic number
 	perPage = util.MaxInt(1, util.MinInt(100, perPage))
 
 	// send API call to capture the total number of services for the build
 	t, err := database.FromContext(c).GetBuildServiceCount(b)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get services count for build %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -208,6 +217,7 @@ func GetServices(c *gin.Context) {
 	// send API call to capture the list of services for the build
 	s, err := database.FromContext(c).GetBuildServiceList(b, page, perPage)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get services for build %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -227,6 +237,8 @@ func GetServices(c *gin.Context) {
 	c.JSON(http.StatusOK, s)
 }
 
+// nolint: lll // ignore long line length due to API path
+//
 // swagger:operation GET /api/v1/repos/{org}/{repo}/builds/{build}/services/{service} services GetService
 //
 // Get a service for a build in the configured backend
@@ -288,6 +300,8 @@ func GetService(c *gin.Context) {
 	c.JSON(http.StatusOK, s)
 }
 
+// nolint: lll // ignore long line length due to API path
+//
 // swagger:operation PUT /api/v1/repos/{org}/{repo}/builds/{build}/services/{service} services UpdateService
 //
 // Update a service for a build in the configured backend
@@ -355,6 +369,7 @@ func UpdateService(c *gin.Context) {
 
 	err := c.Bind(input)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to decode JSON for service %s/%d/%d: %w", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -391,6 +406,7 @@ func UpdateService(c *gin.Context) {
 	// send API call to update the service
 	err = database.FromContext(c).UpdateService(s)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to update service %s/%d/%d: %w", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -404,6 +420,8 @@ func UpdateService(c *gin.Context) {
 	c.JSON(http.StatusOK, s)
 }
 
+// nolint: lll // ignore long line length due to API path
+//
 // swagger:operation DELETE /api/v1/repos/{org}/{repo}/builds/{build}/services/{service} services DeleteService
 //
 // Delete a service for a build in the configured backend
@@ -447,6 +465,8 @@ func UpdateService(c *gin.Context) {
 
 // DeleteService represents the API handler to remove
 // a service for a build from the configured backend.
+//
+// nolint: dupl // ignore similar code with step
 func DeleteService(c *gin.Context) {
 	// capture middleware values
 	b := build.Retrieve(c)
@@ -458,6 +478,7 @@ func DeleteService(c *gin.Context) {
 	// send API call to remove the service
 	err := database.FromContext(c).DeleteService(s.GetID())
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to delete service %s/%d/%d: %w", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -465,12 +486,15 @@ func DeleteService(c *gin.Context) {
 		return
 	}
 
+	// nolint: lll // ignore long line length due to return message
 	c.JSON(http.StatusOK, fmt.Sprintf("Service %s/%d/%d deleted", r.GetFullName(), b.GetNumber(), s.GetNumber()))
 }
 
 // planServices is a helper function to plan all services
 // in the build for execution. This creates the services
 // for the build in the configured backend.
+//
+// nolint: lll // ignore long line length due to variable names
 func planServices(database database.Service, p *pipeline.Build, b *library.Build) ([]*library.Service, error) {
 	// variable to store planned services
 	services := []*library.Service{}

--- a/api/step.go
+++ b/api/step.go
@@ -73,6 +73,8 @@ import (
 
 // CreateStep represents the API handler to create
 // a step for a build in the configured backend.
+//
+// nolint: dupl // ignore similar code with service
 func CreateStep(c *gin.Context) {
 	// capture middleware values
 	b := build.Retrieve(c)
@@ -85,6 +87,7 @@ func CreateStep(c *gin.Context) {
 
 	err := c.Bind(input)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to decode JSON for new step for build %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -107,6 +110,7 @@ func CreateStep(c *gin.Context) {
 	// send API call to create the step
 	err = database.FromContext(c).CreateStep(input)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to create step for build %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -175,6 +179,7 @@ func GetSteps(c *gin.Context) {
 	// capture page query parameter if present
 	page, err := strconv.Atoi(c.DefaultQuery("page", "1"))
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to convert page query parameter for build %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -185,6 +190,7 @@ func GetSteps(c *gin.Context) {
 	// capture per_page query parameter if present
 	perPage, err := strconv.Atoi(c.DefaultQuery("per_page", "10"))
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to convert per_page query parameter for build %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -193,11 +199,14 @@ func GetSteps(c *gin.Context) {
 	}
 
 	// ensure per_page isn't above or below allowed values
+	//
+	// nolint: gomnd // ignore magic number
 	perPage = util.MaxInt(1, util.MinInt(100, perPage))
 
 	// send API call to capture the total number of steps for the build
 	t, err := database.FromContext(c).GetBuildStepCount(b)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get steps count for build %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -208,6 +217,7 @@ func GetSteps(c *gin.Context) {
 	// send API call to capture the list of steps for the build
 	s, err := database.FromContext(c).GetBuildStepList(b, page, perPage)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get steps for build %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -347,6 +357,7 @@ func UpdateStep(c *gin.Context) {
 
 	err := c.Bind(input)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to decode JSON for step %s/%d/%d: %v", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -398,6 +409,7 @@ func UpdateStep(c *gin.Context) {
 	// send API call to update the step
 	err = database.FromContext(c).UpdateStep(s)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to update step %s/%d/%d: %w", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -454,6 +466,8 @@ func UpdateStep(c *gin.Context) {
 
 // DeleteStep represents the API handler to remove
 // a step for a build from the configured backend.
+//
+// nolint: dupl // ignore similar code with service
 func DeleteStep(c *gin.Context) {
 	// capture middleware values
 	b := build.Retrieve(c)
@@ -465,6 +479,7 @@ func DeleteStep(c *gin.Context) {
 	// send API call to remove the step
 	err := database.FromContext(c).DeleteStep(s.GetID())
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to delete step %s/%d/%d: %w", r.GetFullName(), b.GetNumber(), s.GetNumber(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -472,12 +487,15 @@ func DeleteStep(c *gin.Context) {
 		return
 	}
 
+	// nolint: lll // ignore long line length due to return message
 	c.JSON(http.StatusOK, fmt.Sprintf("Step %s/%d/%d deleted", r.GetFullName(), b.GetNumber(), s.GetNumber()))
 }
 
 // planSteps is a helper function to plan all steps
 // in the build for execution. This creates the steps
 // for the build in the configured backend.
+//
+// nolint: funlen,lll // ignore function length and long line length
 func planSteps(database database.Service, p *pipeline.Build, b *library.Build) ([]*library.Step, error) {
 	// variable to store planned steps
 	steps := []*library.Step{}
@@ -504,7 +522,7 @@ func planSteps(database database.Service, p *pipeline.Build, b *library.Build) (
 			}
 
 			// send API call to capture the created step
-			s, err = database.GetStep(int(s.GetNumber()), b)
+			s, err = database.GetStep(s.GetNumber(), b)
 			if err != nil {
 				return steps, fmt.Errorf("unable to get step %s: %w", s.GetName(), err)
 			}
@@ -545,7 +563,7 @@ func planSteps(database database.Service, p *pipeline.Build, b *library.Build) (
 		}
 
 		// send API call to capture the created step
-		s, err = database.GetStep(int(s.GetNumber()), b)
+		s, err = database.GetStep(s.GetNumber(), b)
 		if err != nil {
 			return steps, fmt.Errorf("unable to get step %s: %w", s.GetName(), err)
 		}

--- a/api/user.go
+++ b/api/user.go
@@ -141,6 +141,8 @@ func GetUsers(c *gin.Context) {
 	}
 
 	// ensure per_page isn't above or below allowed values
+	//
+	// nolint: gomnd // ignore magic number
 	perPage = util.MaxInt(1, util.MinInt(100, perPage))
 
 	// send API call to capture the total number of users
@@ -366,7 +368,6 @@ func GetUserSourceRepos(c *gin.Context) {
 	logrus.Infof("Getting list of available repos for user %s", u.GetName())
 
 	// variables to capture requested data
-	srcRepos := []*library.Repo{}
 	dbRepos := []*library.Repo{}
 	output := make(map[string][]library.Repo)
 
@@ -416,6 +417,8 @@ func GetUserSourceRepos(c *gin.Context) {
 			dbRepos = append(dbRepos, dbReposPart...)
 
 			// making an assumption that 50 means there is another page
+			//
+			// nolint: gomnd // ignore magic number
 			if len(dbReposPart) == 50 {
 				page++
 			} else {

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -66,6 +66,8 @@ var baseErr = "unable to process webhook"
 // PostWebhook represents the API handler to capture
 // a webhook from a source control provider and
 // publish it to the configure queue.
+//
+// nolint: funlen,gocyclo // ignore function length and cyclomatic complexity
 func PostWebhook(c *gin.Context) {
 	logrus.Info("Webhook received")
 
@@ -233,6 +235,7 @@ func PostWebhook(c *gin.Context) {
 		(b.GetEvent() == constants.EventComment && !r.GetAllowComment()) ||
 		(b.GetEvent() == constants.EventTag && !r.GetAllowTag()) ||
 		(b.GetEvent() == constants.EventDeploy && !r.GetAllowDeploy()) {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("%s: %s does not have %s events enabled", baseErr, r.GetFullName(), b.GetEvent())
 		util.HandleError(c, http.StatusBadRequest, retErr)
 
@@ -272,8 +275,10 @@ func PostWebhook(c *gin.Context) {
 
 	// if this is a comment on a pull_request event
 	if strings.EqualFold(b.GetEvent(), constants.EventComment) && webhook.PRNumber > 0 {
+		// nolint: lll // ignore long line length due to variable names
 		commit, branch, baseref, headref, err := source.FromContext(c).GetPullRequest(u, r, webhook.PRNumber)
 		if err != nil {
+			// nolint: lll // ignore long line length due to error message
 			retErr := fmt.Errorf("%s: failed to get pull request info for %s: %v", baseErr, r.GetFullName(), err)
 			util.HandleError(c, http.StatusInternalServerError, retErr)
 
@@ -327,6 +332,7 @@ func PostWebhook(c *gin.Context) {
 	// send API call to capture the pipeline configuration file
 	config, err := source.FromContext(c).ConfigBackoff(u, r.GetOrg(), r.GetName(), b.GetCommit())
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("%s: failed to get pipeline configuration for %s: %v", baseErr, r.GetFullName(), err)
 		util.HandleError(c, http.StatusNotFound, retErr)
 
@@ -447,6 +453,7 @@ func PostWebhook(c *gin.Context) {
 	// send API call to capture the triggered build
 	b, err = database.FromContext(c).GetBuild(b.GetNumber(), r)
 	if err != nil {
+		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("%s: failed to get new build %s/%d: %v", baseErr, r.GetFullName(), b.GetNumber(), err)
 		util.HandleError(c, http.StatusInternalServerError, retErr)
 
@@ -477,6 +484,8 @@ func PostWebhook(c *gin.Context) {
 
 // publishToQueue is a helper function that creates
 // a build item and publishes it to the queue.
+//
+// nolint: lll // ignore long line length due to variables
 func publishToQueue(queue queue.Service, p *pipeline.Build, b *library.Build, r *library.Repo, u *library.User) {
 	// update fields in build object
 	b.SetEnqueued(time.Now().UTC().Unix())

--- a/api/worker.go
+++ b/api/worker.go
@@ -49,7 +49,7 @@ import (
 //       type: string
 
 // CreateWorker represents the API handler to
-// create a worker in the configured backend
+// create a worker in the configured backend.
 func CreateWorker(c *gin.Context) {
 	logrus.Info("Creating new worker")
 
@@ -204,7 +204,7 @@ func GetWorker(c *gin.Context) {
 //       type: string
 
 // UpdateWorker represents the API handler to
-// create a worker in the configured backend
+// create a worker in the configured backend.
 func UpdateWorker(c *gin.Context) {
 	// capture middleware values
 	worker := c.Param("worker")


### PR DESCRIPTION
Continuation of the efforts from https://github.com/go-vela/mock/pull/76 and https://github.com/go-vela/types/pull/122

* Updating the contributing guide to include fixing linter warnings if any are present
* Skipping the `dupl` and `lll` linters on `*_test.go` files
* Added `nolint` directives across the repo to address any current linter issues