### PR TITLE
fix(source): processing deployments with empty payloads

### DIFF
--- a/source/github/deployment.go
+++ b/source/github/deployment.go
@@ -132,7 +132,7 @@ func (c *client) CreateDeployment(u *library.User, r *library.Repo, d *library.D
 
 	var payload interface{}
 	if d.Payload == nil {
-		payload = github.String("")
+		payload = make(map[string]string)
 	} else {
 		payload = d.Payload
 	}

--- a/source/github/webhook.go
+++ b/source/github/webhook.go
@@ -263,7 +263,15 @@ func processDeploymentEvent(h *library.Hook, payload *github.DeploymentEvent) (*
 	b.SetRef(payload.GetDeployment().GetRef())
 
 	// check if payload is provided within request
-	if payload.GetDeployment().Payload != nil {
+	//
+	// use a length of 2 because the payload will
+	// never be nil even if no payload is provided.
+	//
+	// sending an API request to GitHub with no
+	// payload provided yields a default of `{}`.
+	//
+	// nolint: gomnd // ignore magic number
+	if len(payload.GetDeployment().Payload) > 2 {
 		deployPayload := make(map[string]string)
 		// unmarshal the payload into the expected map[string]string format
 		err := json.Unmarshal(payload.GetDeployment().Payload, &deployPayload)


### PR DESCRIPTION
Closes https://github.com/go-vela/community/issues/198

This enables Vela to properly handle a webhook for the `deployment` event with an "empty" `payload` field.

> NOTE:
>
> After discussions with Jordan Sussman, we learned that GitHub actually does support a string in the `payload` field:
>
> From GitHub Support:
> > If the payload is passed in the input when creating a deployment, this endpoint expects it to either be a JSON object or a string. Otherwise, a validation error will be thrown.
>
> However, we agreed that it is still better to adopt GitHub's default behavior of setting an empty map `{}`
>
> We believe this is a more transparent approach due to the default behavior of GitHub.

## Part 1

Previously, we were setting the `payload` field to an empty string (`""`) if one wasn't provided:

https://github.com/go-vela/server/blob/6391436389fed01c2a62a6fdfb2cd43808240bc7/source/github/deployment.go#L134-L138

This is inaccurate because GitHub sets a default value for that field to be an empty map (`{}`).

You can verify this by sending the following request to the [GitHub API](https://docs.github.com/en/rest/reference/repos#create-a-deployment):

```json
{
	"auto_merge": false,
	"description": "deployment via GitHub API",
	"ref": "master",
	"required_contexts": [],
	"environment": "production"
}
```

That request should create the deployment with the `payload` field as an empty map:

```
{
  ...
  "payload": {},
  ...
```

After this fix, we now ensure we adopt GitHub's behavior by setting the default for the `payload` field to an empty map:

https://github.com/go-vela/server/blob/d971dfa5c5e4d418bd9fecab229689da89efb851/source/github/deployment.go#L134-L138

## Part 2

Previously, we were checking if the `payload` field was `nil` when processing a `deployment` webhook:

https://github.com/go-vela/server/blob/6391436389fed01c2a62a6fdfb2cd43808240bc7/source/github/webhook.go#L265-L266

This isn't a great check because technically the `payload` field will never be `nil`.

The reason for this is GitHub sets a default value of `{}`, even if you provide no payload in the request.

After this fix, we now ensure we account for the default value of the `payload` field set by GitHub:

https://github.com/go-vela/server/blob/d971dfa5c5e4d418bd9fecab229689da89efb851/source/github/webhook.go#L265-L274