### PR TITLE
fix(metrics): set default values to 0

### DIFF
--- a/database/service.go
+++ b/database/service.go
@@ -141,7 +141,13 @@ func (c *client) GetServiceStatusCount() (map[string]float64, error) {
 
 	// variable to store query results
 	s := new([]statusCount)
-	counts := make(map[string]float64)
+	counts := map[string]float64{
+		"pending": 0,
+		"failure": 0,
+		"killed":  0,
+		"running": 0,
+		"success": 0,
+	}
 
 	// send query to the database and store result in variable
 	err := c.Database.

--- a/database/service_test.go
+++ b/database/service_test.go
@@ -306,6 +306,9 @@ func TestDatabase_Client_GetServiceStatusCount(t *testing.T) {
 	want := make(map[string]float64)
 	want["success"] = 2
 	want["failure"] = 1
+	want["pending"] = 0
+	want["killed"] = 0
+	want["running"] = 0
 
 	// setup database
 	db, _ := NewTest()

--- a/database/step.go
+++ b/database/step.go
@@ -141,7 +141,13 @@ func (c *client) GetStepStatusCount() (map[string]float64, error) {
 
 	// variable to store query results
 	s := new([]statusCount)
-	counts := make(map[string]float64)
+	counts := map[string]float64{
+		"pending": 0,
+		"failure": 0,
+		"killed":  0,
+		"running": 0,
+		"success": 0,
+	}
 
 	// send query to the database and store result in variable
 	err := c.Database.

--- a/database/step_test.go
+++ b/database/step_test.go
@@ -306,6 +306,9 @@ func TestDatabase_Client_GetStepStatusCount(t *testing.T) {
 	want := make(map[string]float64)
 	want["success"] = 2
 	want["failure"] = 1
+	want["killed"] = 0
+	want["pending"] = 0
+	want["running"] = 0
 
 	// setup database
 	db, _ := NewTest()


### PR DESCRIPTION
Sets the default value of the following metrics to 0:

```
vela_totals{field="status",resource="services",value="failure"} 0
vela_totals{field="status",resource="services",value="killed"} 0
vela_totals{field="status",resource="services",value="pending"} 0
vela_totals{field="status",resource="services",value="running"} 0
vela_totals{field="status",resource="services",value="success"} 0
vela_totals{field="status",resource="steps",value="failure"} 0
vela_totals{field="status",resource="steps",value="killed"} 0
vela_totals{field="status",resource="steps",value="pending"} 0
vela_totals{field="status",resource="steps",value="running"} 0
vela_totals{field="status",resource="steps",value="success"} 0
```

This resolves the scenario where metrics are outdated/not present throughout the lifecycle of the server.