### PR TITLE
ci(Makefile): remove pull target from up target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ restart: down up
 #
 # Usage: `make up`
 .PHONY: up
-up: build pull compose-up
+up: build compose-up
 
 # The `down` target is intended to destroy
 # the local Docker compose stack.


### PR DESCRIPTION
This modifies the `make up` target to no longer run the `make pull` target.

> NOTE: The `make pull` target still exists, but it will no longer be executed when invoking `make up`.

Last year, Docker introduced rate limiting when pulling images as an unauthenticated user:

https://www.docker.com/increase-rate-limits

The impact is that you can actually hit the rate limit from Docker if you are doing a fair amount of local development where you are running `make restart` and/or `make up`, which starts the Vela stack via `docker-compose`, in those efforts.

I personally, have only experienced this a handful of times, but I still feel it warrants reducing the potential to run into this.

The end idea being that the user who is running the Vela stack locally will be responsible for pulling the images themselves.

It's worth mentioning that compose will already pull the Docker images on your behalf if they aren't cached locally.