### PR TITLE
chore: linter fixes v2

### DIFF
--- a/database/service.go
+++ b/database/service.go
@@ -131,6 +131,8 @@ func (c *client) GetServiceImageCount() (map[string]float64, error) {
 
 // GetServiceStatusCount gets a list of all service statuses
 // and the count of their occurrence in the database.
+//
+// nolint: dupl // ignore similar code with steps
 func (c *client) GetServiceStatusCount() (map[string]float64, error) {
 	logrus.Trace("Counting the total of each status for services in the database")
 

--- a/database/step.go
+++ b/database/step.go
@@ -131,6 +131,8 @@ func (c *client) GetStepImageCount() (map[string]float64, error) {
 
 // GetStepStatusCount gets a list of all step statuses
 // and the count of their occurrence in the database.
+//
+// nolint: dupl // ignore similar code with services
 func (c *client) GetStepStatusCount() (map[string]float64, error) {
 	logrus.Trace("Counting the total of each status for steps in the database")
 

--- a/router/middleware/payload.go
+++ b/router/middleware/payload.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Payload is a middleware function that captures the user provided json body
-// and attaches it to the context of every http.Request to be logged
+// and attaches it to the context of every http.Request to be logged.
 func Payload() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// bind JSON payload from request to be added to context

--- a/router/middleware/worker.go
+++ b/router/middleware/worker.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Worker is a middleware function that attaches the worker interval
-// to determine which workers are active
+// to determine which workers are active.
 func Worker(duration time.Duration) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Set("worker_active_interval", duration)

--- a/router/middleware/worker/worker.go
+++ b/router/middleware/worker/worker.go
@@ -17,12 +17,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Retrieve gets the worker in the given context
+// Retrieve gets the worker in the given context.
 func Retrieve(c *gin.Context) *library.Worker {
 	return FromContext(c)
 }
 
-// Establish sets the worker in the given context
+// Establish sets the worker in the given context.
 func Establish() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		wParam := c.Param("worker")


### PR DESCRIPTION
A continuation of https://github.com/go-vela/server/pull/270

The above change was intended to address **ALL** reported linter issues in the codebase.

At the time that change was submitted, the `golangci` report was showing no issues:

https://github.com/go-vela/server/runs/1816270741

Unsure if that old report was inaccurate or if these new linter issues were added after the fact.

At any rate, this adds a few `nolint` comments and some `.` at the end of comments to address these.