### PR TITLE
feat: set service/step environment after database creation

### DIFF
--- a/api/service.go
+++ b/api/service.go
@@ -523,6 +523,14 @@ func planServices(database database.Service, p *pipeline.Build, b *library.Build
 			return services, fmt.Errorf("unable to get service %s: %w", s.GetName(), err)
 		}
 
+		// populate environment variables from service library
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/library#Service.Environment
+		err = service.MergeEnv(s.Environment())
+		if err != nil {
+			return services, err
+		}
+
 		// create the log object
 		l := new(library.Log)
 		l.SetServiceID(s.GetID())

--- a/api/step.go
+++ b/api/step.go
@@ -527,6 +527,14 @@ func planSteps(database database.Service, p *pipeline.Build, b *library.Build) (
 				return steps, fmt.Errorf("unable to get step %s: %w", s.GetName(), err)
 			}
 
+			// populate environment variables from step library
+			//
+			// https://pkg.go.dev/github.com/go-vela/types/library#step.Environment
+			err = step.MergeEnv(s.Environment())
+			if err != nil {
+				return steps, err
+			}
+
 			// create the log object
 			l := new(library.Log)
 			l.SetStepID(s.GetID())
@@ -566,6 +574,14 @@ func planSteps(database database.Service, p *pipeline.Build, b *library.Build) (
 		s, err = database.GetStep(s.GetNumber(), b)
 		if err != nil {
 			return steps, fmt.Errorf("unable to get step %s: %w", s.GetName(), err)
+		}
+
+		// populate environment variables from step library
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/library#step.Environment
+		err = step.MergeEnv(s.Environment())
+		if err != nil {
+			return steps, err
 		}
 
 		// create the log object

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/go-vela/server
 
 go 1.13
 
-replace github.com/go-vela/types => ../types
-
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/aws/aws-sdk-go v1.36.32
@@ -15,7 +13,7 @@ require (
 	github.com/go-playground/assert/v2 v2.0.1
 	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/go-vela/compiler v0.7.2
-	github.com/go-vela/types v0.7.2
+	github.com/go-vela/types v0.7.3-0.20210215154746-b723e084889b
 	github.com/google/go-cmp v0.5.4
 	github.com/google/go-github/v29 v29.0.3
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/go-vela/server
 
 go 1.13
 
+replace github.com/go-vela/types => ../types
+
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/aws/aws-sdk-go v1.36.32

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,10 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-vela/compiler v0.7.2 h1:cvuCxJgxg+gxPBSrs2x0T5+VFSkKeyVKt20n6hk8AXs=
 github.com/go-vela/compiler v0.7.2/go.mod h1:cHDJdAps5eln5eAqU0xh8nEQtIUtiSSXot+6g3yBJKc=
+github.com/go-vela/types v0.7.2 h1:ERsqcAb2sXNqEPOBtRBnZ3IRp4xEIVEIZ9TqqgypKGo=
+github.com/go-vela/types v0.7.2/go.mod h1:VWpaynT/gWAMsqh6/FQygCzL8LSy289cqV36UIhubD8=
+github.com/go-vela/types v0.7.3-0.20210215154746-b723e084889b h1:YEdc5oVVM9UZOwaQDadlDSCB1DXcx8D7p81Dxkxq+Rw=
+github.com/go-vela/types v0.7.3-0.20210215154746-b723e084889b/go.mod h1:VWpaynT/gWAMsqh6/FQygCzL8LSy289cqV36UIhubD8=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,6 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-vela/compiler v0.7.2 h1:cvuCxJgxg+gxPBSrs2x0T5+VFSkKeyVKt20n6hk8AXs=
 github.com/go-vela/compiler v0.7.2/go.mod h1:cHDJdAps5eln5eAqU0xh8nEQtIUtiSSXot+6g3yBJKc=
-github.com/go-vela/types v0.7.2 h1:ERsqcAb2sXNqEPOBtRBnZ3IRp4xEIVEIZ9TqqgypKGo=
-github.com/go-vela/types v0.7.2/go.mod h1:VWpaynT/gWAMsqh6/FQygCzL8LSy289cqV36UIhubD8=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=


### PR DESCRIPTION
Dependent on https://github.com/go-vela/types/pull/151

This will update the server to apply pipeline resource environment variables after they are created in the database.

Currently, in a typical webhook workflow, the server is responsible for:

* processing the webhook
* compiling the pipeline
* creating all pipeline resources (`services` and `steps`) in the database
* publishing the build to the queue

However, after the resources are created in the database, we don't update the environment variables for that resource.

This leads to the containers for those resources having incomplete data i.e.

```
# for step containers
VELA_STEP_NAME=
VELA_STEP_IMAGE=

# for service containers
VELA_SERVICE_NAME=
VELA_SERVICE_IMAGE=
```

This will call the intended `Environment()` function for the resource and inject into the environment after they are created in the database:

* [Service Environment](https://pkg.go.dev/github.com/go-vela/types/library#Service.Environment)
* [Step Environment](https://pkg.go.dev/github.com/go-vela/types/library#Step.Environment)