### PR TITLE
feat(database): compress logs to reduce storage

### DIFF
--- a/database/log.go
+++ b/database/log.go
@@ -14,9 +14,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// set the compression level for the data stored in the logs.
-const logCompressionLevel = 3
-
 // GetBuildLogs gets a collection of logs for a build by unique ID from the database.
 func (c *client) GetBuildLogs(id int64) ([]*library.Log, error) {
 	logrus.Tracef("Listing logs for build %d from the database", id)
@@ -78,7 +75,7 @@ func (c *client) GetStepLog(id int64) (*library.Log, error) {
 		return l.ToLibrary(), fmt.Errorf("unable to decompress logs for step %d: %v", id, err)
 	}
 
-	return l.ToLibrary(), err
+	return l.ToLibrary(), nil
 }
 
 // GetServiceLog gets a log by unique ID from the database.
@@ -107,7 +104,7 @@ func (c *client) GetServiceLog(id int64) (*library.Log, error) {
 		return l.ToLibrary(), fmt.Errorf("unable to decompress logs for service %d: %v", id, err)
 	}
 
-	return l.ToLibrary(), err
+	return l.ToLibrary(), nil
 }
 
 // CreateLog creates a new log in the database.

--- a/database/log.go
+++ b/database/log.go
@@ -39,7 +39,10 @@ func (c *client) GetBuildLogs(id int64) ([]*library.Log, error) {
 		// https://pkg.go.dev/github.com/go-vela/types/database#Log.Decompress
 		err = tmp.Decompress()
 		if err != nil {
-			return logs, fmt.Errorf("unable to decompress logs for build %d: %v", id, err)
+			// ensures that the change is backwards compatible
+			// by logging the error instead of returning it
+			// which allows us to fetch uncompressed logs
+			logrus.Errorf("unable to decompress logs for build %d: %v", id, err)
 		}
 
 		// convert query result to library type
@@ -72,9 +75,16 @@ func (c *client) GetStepLog(id int64) (*library.Log, error) {
 	// https://pkg.go.dev/github.com/go-vela/types/database#Log.Decompress
 	err = l.Decompress()
 	if err != nil {
-		return l.ToLibrary(), fmt.Errorf("unable to decompress logs for step %d: %v", id, err)
+		// ensures that the change is backwards compatible
+		// by logging the error instead of returning it
+		// which allows us to fetch uncompressed logs
+		logrus.Errorf("unable to decompress logs for step %d: %v", id, err)
+
+		// return the uncompressed log
+		return l.ToLibrary(), nil
 	}
 
+	// return the decompressed log
 	return l.ToLibrary(), nil
 }
 
@@ -101,9 +111,16 @@ func (c *client) GetServiceLog(id int64) (*library.Log, error) {
 	// https://pkg.go.dev/github.com/go-vela/types/database#Log.Decompress
 	err = l.Decompress()
 	if err != nil {
-		return l.ToLibrary(), fmt.Errorf("unable to decompress logs for service %d: %v", id, err)
+		// ensures that the change is backwards compatible
+		// by logging the error instead of returning it
+		// which allowing us to fetch uncompressed logs
+		logrus.Errorf("unable to decompress logs for service %d: %v", id, err)
+
+		// return the uncompressed log
+		return l.ToLibrary(), nil
 	}
 
+	// return the decompressed log
 	return l.ToLibrary(), nil
 }
 

--- a/database/log_test.go
+++ b/database/log_test.go
@@ -68,63 +68,145 @@ func TestDatabase_Client_GetBuildLogs(t *testing.T) {
 
 func TestDatabase_Client_GetStepLog(t *testing.T) {
 	// setup types
-	want := testLog()
-	want.SetID(1)
-	want.SetBuildID(1)
-	want.SetRepoID(1)
-	want.SetStepID(1)
-	want.SetData([]byte{})
+	l := testLog()
+	l.SetID(1)
+	l.SetBuildID(1)
+	l.SetRepoID(1)
+	l.SetStepID(1)
+	l.SetData([]byte{})
 
-	// setup database
-	database, _ := NewTest()
+	l1 := testLog()
+	l1.SetID(1)
+	l1.SetBuildID(1)
+	l1.SetRepoID(1)
+	l1.SetStepID(1)
+	l1.SetData([]byte("foo"))
 
-	defer func() {
-		database.Database.Exec("delete from logs;")
-		database.Database.Close()
-	}()
-
-	_ = database.CreateLog(want)
-
-	// run test
-	got, err := database.GetStepLog(want.GetStepID())
-
-	if err != nil {
-		t.Errorf("GetLog returned err: %v", err)
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Log
+	}{
+		{
+			failure: false,
+			want:    l,
+		},
+		{
+			failure: false,
+			want:    l1,
+		},
+		{
+			failure: true,
+			want:    testLog(),
+		},
 	}
 
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("GetLog is %v, want %v", got, want)
+	// run tests
+	for _, test := range tests {
+		// setup database
+		database, _ := NewTest()
+
+		defer func() {
+			database.Database.Exec("delete from logs;")
+			database.Database.Close()
+		}()
+
+		if test.want.GetID() > 0 {
+			err := database.Database.Table(constants.TableLog).Create(test.want).Error
+			if err != nil {
+				t.Errorf("unable to create log: %v", err)
+			}
+		}
+
+		got, err := database.GetStepLog(test.want.GetStepID())
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetStepLog should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetStepLog returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetStepLog is %v, want %v", got, test.want)
+		}
 	}
 }
 
 func TestDatabase_Client_GetServiceLog(t *testing.T) {
 	// setup types
-	want := testLog()
-	want.SetID(1)
-	want.SetBuildID(1)
-	want.SetRepoID(1)
-	want.SetServiceID(1)
-	want.SetData([]byte{})
+	l := testLog()
+	l.SetID(1)
+	l.SetBuildID(1)
+	l.SetRepoID(1)
+	l.SetServiceID(1)
+	l.SetData([]byte{})
 
-	// setup database
-	database, _ := NewTest()
+	l1 := testLog()
+	l1.SetID(1)
+	l1.SetBuildID(1)
+	l1.SetRepoID(1)
+	l1.SetServiceID(1)
+	l1.SetData([]byte("foo"))
 
-	defer func() {
-		database.Database.Exec("delete from logs;")
-		database.Database.Close()
-	}()
-
-	_ = database.CreateLog(want)
-
-	// run test
-	got, err := database.GetServiceLog(want.GetServiceID())
-
-	if err != nil {
-		t.Errorf("GetLog returned err: %v", err)
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Log
+	}{
+		{
+			failure: false,
+			want:    l,
+		},
+		{
+			failure: false,
+			want:    l1,
+		},
+		{
+			failure: true,
+			want:    testLog(),
+		},
 	}
 
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("GetLog is %v, want %v", got, want)
+	// run tests
+	for _, test := range tests {
+		// setup database
+		database, _ := NewTest()
+
+		defer func() {
+			database.Database.Exec("delete from logs;")
+			database.Database.Close()
+		}()
+
+		if test.want.GetID() > 0 {
+			err := database.Database.Table(constants.TableLog).Create(test.want).Error
+			if err != nil {
+				t.Errorf("unable to create log: %v", err)
+			}
+		}
+
+		got, err := database.GetServiceLog(test.want.GetServiceID())
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetServiceLog should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetServiceLog returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetServiceLog is %v, want %v", got, test.want)
+		}
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/go-vela/server
 
 go 1.15
 
+replace github.com/go-vela/types => ../types
+
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/aws/aws-sdk-go v1.36.32

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/go-vela/server
 
 go 1.15
 
-replace github.com/go-vela/types => ../types
-
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/aws/aws-sdk-go v1.36.32
@@ -15,7 +13,7 @@ require (
 	github.com/go-playground/assert/v2 v2.0.1
 	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/go-vela/compiler v0.7.2
-	github.com/go-vela/types v0.7.3-0.20210215154746-b723e084889b
+	github.com/go-vela/types v0.7.3-0.20210219160032-9ca61f000f7a
 	github.com/google/go-cmp v0.5.4
 	github.com/google/go-github/v29 v29.0.3
 	github.com/google/gofuzz v1.2.0 // indirect
@@ -33,7 +31,7 @@ require (
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.9.0
-	github.com/sirupsen/logrus v1.7.0
+	github.com/sirupsen/logrus v1.8.0
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/oauth2 v0.0.0-20210126194326-f9ce19ea3013
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect

--- a/go.sum
+++ b/go.sum
@@ -177,10 +177,6 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-vela/compiler v0.7.2 h1:cvuCxJgxg+gxPBSrs2x0T5+VFSkKeyVKt20n6hk8AXs=
 github.com/go-vela/compiler v0.7.2/go.mod h1:cHDJdAps5eln5eAqU0xh8nEQtIUtiSSXot+6g3yBJKc=
-github.com/go-vela/types v0.7.2 h1:ERsqcAb2sXNqEPOBtRBnZ3IRp4xEIVEIZ9TqqgypKGo=
-github.com/go-vela/types v0.7.2/go.mod h1:VWpaynT/gWAMsqh6/FQygCzL8LSy289cqV36UIhubD8=
-github.com/go-vela/types v0.7.3-0.20210215154746-b723e084889b h1:YEdc5oVVM9UZOwaQDadlDSCB1DXcx8D7p81Dxkxq+Rw=
-github.com/go-vela/types v0.7.3-0.20210215154746-b723e084889b/go.mod h1:VWpaynT/gWAMsqh6/FQygCzL8LSy289cqV36UIhubD8=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,9 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-vela/compiler v0.7.2 h1:cvuCxJgxg+gxPBSrs2x0T5+VFSkKeyVKt20n6hk8AXs=
 github.com/go-vela/compiler v0.7.2/go.mod h1:cHDJdAps5eln5eAqU0xh8nEQtIUtiSSXot+6g3yBJKc=
+github.com/go-vela/types v0.7.2/go.mod h1:VWpaynT/gWAMsqh6/FQygCzL8LSy289cqV36UIhubD8=
+github.com/go-vela/types v0.7.3-0.20210219160032-9ca61f000f7a h1:xDCd6fT3CoMK4mPfxxBp88ows+VpG+HyPHghcFs2/w4=
+github.com/go-vela/types v0.7.3-0.20210219160032-9ca61f000f7a/go.mod h1:/IsyxCijlz8BArRxBfrfRv7BBe/hmJGtVWegkS3ooJU=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -382,6 +385,8 @@ github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
+github.com/magefile/mage v1.10.0 h1:3HiXzCUY12kh9bIuyXShaVe529fJfyqoVM42o/uom2g=
+github.com/magefile/mage v1.10.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
@@ -537,6 +542,8 @@ github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.8.0 h1:nfhvjKcUMhBMVqbKHJlk5RPrrfYr/NMo3692g0dwfWU=
+github.com/sirupsen/logrus v1.8.0/go.mod h1:4GuYW9TZmE769R5STWrRakJc4UqQ3+QQ95fyz7ENv1A=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=


### PR DESCRIPTION
Dependent on https://github.com/go-vela/types/pull/154

Before this change, we ran some builds locally and checked the size of the `logs` table in the database:

```
vela=# SELECT pg_size_pretty (pg_relation_size('logs'));
 pg_size_pretty
----------------
 24 kB
(1 row)
```

After this change, when we run those same builds and check the size of the `logs` table in the database:

```
vela=# SELECT pg_size_pretty (pg_relation_size('logs'));
 pg_size_pretty
----------------
 8192 bytes
(1 row)
```

Doing a rough calculation from the above data, we were able to shrink the size of the `logs` table to `1/3` it's original size.

i.e. `8` kB  /  `24` kB = `1/3`

> NOTE: This change **is backward compatible**. If you try fetching an uncompressed log, everything will work as expected.
>
> We'll plan to offer some sort of utility that will assist in compressing all existing logs in the database.