### PR TITLE
fix(database): capturing list of logs for a build

### DIFF
--- a/database/log.go
+++ b/database/log.go
@@ -26,6 +26,9 @@ func (c *client) GetBuildLogs(id int64) ([]*library.Log, error) {
 		Table(constants.TableLog).
 		Raw(c.DML.LogService.List["build"], id).
 		Scan(l).Error
+	if err != nil {
+		return nil, err
+	}
 
 	// variable we want to return
 	logs := []*library.Log{}
@@ -49,7 +52,7 @@ func (c *client) GetBuildLogs(id int64) ([]*library.Log, error) {
 		logs = append(logs, tmp.ToLibrary())
 	}
 
-	return logs, err
+	return logs, nil
 }
 
 // GetStepLog gets a log by unique ID from the database.


### PR DESCRIPTION
Carry over from https://github.com/go-vela/server/pull/291

After submitting the above PR, we noticed we're unable to capture logs for the entire build via API or CLI.

This change fixes that by properly handling the errors returned throughout the function.