### PR TITLE
chore(database): remove unused indexes

### DIFF
--- a/database/ddl/ddl_test.go
+++ b/database/ddl/ddl_test.go
@@ -21,14 +21,12 @@ func TestDDL_NewMap_Postgres(t *testing.T) {
 			Create: postgres.CreateBuildTable,
 			Indexes: []string{
 				postgres.CreateBuildRepoIDIndex,
-				postgres.CreateBuildRepoIDNumberIndex,
 				postgres.CreateBuildStatusIndex,
 			},
 		},
 		HookService: &Service{
 			Create: postgres.CreateHookTable,
 			Indexes: []string{
-				postgres.CreateHookRepoIDNumberIndex,
 				postgres.CreateHookRepoIDIndex,
 			},
 		},
@@ -36,15 +34,12 @@ func TestDDL_NewMap_Postgres(t *testing.T) {
 			Create: postgres.CreateLogTable,
 			Indexes: []string{
 				postgres.CreateLogBuildIDIndex,
-				postgres.CreateLogStepIDIndex,
-				postgres.CreateLogServiceIDIndex,
 			},
 		},
 		RepoService: &Service{
 			Create: postgres.CreateRepoTable,
 			Indexes: []string{
 				postgres.CreateRepoOrgNameIndex,
-				postgres.CreateRepoFullNameIndex,
 			},
 		},
 		SecretService: &Service{
@@ -53,25 +48,19 @@ func TestDDL_NewMap_Postgres(t *testing.T) {
 				postgres.CreateSecretTypeOrgRepo,
 				postgres.CreateSecretTypeOrgTeam,
 				postgres.CreateSecretTypeOrg,
-				postgres.CreateSecretType,
 			},
 		},
 		ServiceService: &Service{
-			Create: postgres.CreateServiceTable,
-			Indexes: []string{
-				postgres.CreateServiceBuildIDNumberIndex,
-			},
+			Create:  postgres.CreateServiceTable,
+			Indexes: []string{},
 		},
 		StepService: &Service{
-			Create: postgres.CreateStepTable,
-			Indexes: []string{
-				postgres.CreateStepBuildIDNumberIndex,
-			},
+			Create:  postgres.CreateStepTable,
+			Indexes: []string{},
 		},
 		UserService: &Service{
 			Create: postgres.CreateUserTable,
 			Indexes: []string{
-				postgres.CreateUserNameIndex,
 				postgres.CreateRefreshIndex,
 			},
 		},
@@ -102,14 +91,12 @@ func TestDDL_NewMap_Sqlite(t *testing.T) {
 			Create: sqlite.CreateBuildTable,
 			Indexes: []string{
 				sqlite.CreateBuildRepoIDIndex,
-				sqlite.CreateBuildRepoIDNumberIndex,
 				sqlite.CreateBuildStatusIndex,
 			},
 		},
 		HookService: &Service{
 			Create: sqlite.CreateHookTable,
 			Indexes: []string{
-				sqlite.CreateHookRepoIDNumberIndex,
 				sqlite.CreateHookRepoIDIndex,
 			},
 		},
@@ -117,15 +104,12 @@ func TestDDL_NewMap_Sqlite(t *testing.T) {
 			Create: sqlite.CreateLogTable,
 			Indexes: []string{
 				sqlite.CreateLogBuildIDIndex,
-				sqlite.CreateLogStepIDIndex,
-				sqlite.CreateLogServiceIDIndex,
 			},
 		},
 		RepoService: &Service{
 			Create: sqlite.CreateRepoTable,
 			Indexes: []string{
 				sqlite.CreateRepoOrgNameIndex,
-				sqlite.CreateRepoFullNameIndex,
 			},
 		},
 		SecretService: &Service{
@@ -134,25 +118,19 @@ func TestDDL_NewMap_Sqlite(t *testing.T) {
 				sqlite.CreateSecretTypeOrgRepo,
 				sqlite.CreateSecretTypeOrgTeam,
 				sqlite.CreateSecretTypeOrg,
-				sqlite.CreateSecretType,
 			},
 		},
 		ServiceService: &Service{
-			Create: sqlite.CreateServiceTable,
-			Indexes: []string{
-				sqlite.CreateServiceBuildIDNumberIndex,
-			},
+			Create:  sqlite.CreateServiceTable,
+			Indexes: []string{},
 		},
 		StepService: &Service{
-			Create: sqlite.CreateStepTable,
-			Indexes: []string{
-				sqlite.CreateStepBuildIDNumberIndex,
-			},
+			Create:  sqlite.CreateStepTable,
+			Indexes: []string{},
 		},
 		UserService: &Service{
 			Create: sqlite.CreateUserTable,
 			Indexes: []string{
-				sqlite.CreateUserNameIndex,
 				sqlite.CreateRefreshIndex,
 			},
 		},

--- a/database/ddl/postgres/build.go
+++ b/database/ddl/postgres/build.go
@@ -45,15 +45,6 @@ builds (
 );
 `
 
-	// CreateBuildRepoIDNumberIndex represents a query to create an
-	// index on the builds table for the repo_id and number columns.
-	CreateBuildRepoIDNumberIndex = `
-CREATE INDEX
-IF NOT EXISTS
-builds_repo_id_number
-ON builds (repo_id, number);
-`
-
 	// CreateBuildRepoIDIndex represents a query to create an
 	// index on the builds table for the repo_id column.
 	CreateBuildRepoIDIndex = `
@@ -78,6 +69,6 @@ ON builds (status);
 func createBuildService() *Service {
 	return &Service{
 		Create:  CreateBuildTable,
-		Indexes: []string{CreateBuildRepoIDIndex, CreateBuildRepoIDNumberIndex, CreateBuildStatusIndex},
+		Indexes: []string{CreateBuildRepoIDIndex, CreateBuildStatusIndex},
 	}
 }

--- a/database/ddl/postgres/build_test.go
+++ b/database/ddl/postgres/build_test.go
@@ -13,7 +13,7 @@ func TestPostgres_createBuildService(t *testing.T) {
 	// setup types
 	want := &Service{
 		Create:  CreateBuildTable,
-		Indexes: []string{CreateBuildRepoIDIndex, CreateBuildRepoIDNumberIndex, CreateBuildStatusIndex},
+		Indexes: []string{CreateBuildRepoIDIndex, CreateBuildStatusIndex},
 	}
 
 	// run test

--- a/database/ddl/postgres/hook.go
+++ b/database/ddl/postgres/hook.go
@@ -27,15 +27,6 @@ hooks (
 );
 `
 
-	// CreateHookRepoIDNumberIndex represents a query to create an
-	// index on the hooks table for the repo_id and number columns.
-	CreateHookRepoIDNumberIndex = `
-CREATE INDEX
-IF NOT EXISTS
-hooks_repo_id_number
-ON hooks (repo_id, number);
-`
-
 	// CreateHookRepoIDIndex represents a query to create an
 	// index on the hooks table for the repo_id column.
 	CreateHookRepoIDIndex = `
@@ -51,6 +42,6 @@ ON hooks (repo_id);
 func createHookService() *Service {
 	return &Service{
 		Create:  CreateHookTable,
-		Indexes: []string{CreateHookRepoIDNumberIndex, CreateHookRepoIDIndex},
+		Indexes: []string{CreateHookRepoIDIndex},
 	}
 }

--- a/database/ddl/postgres/hook_test.go
+++ b/database/ddl/postgres/hook_test.go
@@ -13,7 +13,7 @@ func TestPostgres_createHookService(t *testing.T) {
 	// setup types
 	want := &Service{
 		Create:  CreateHookTable,
-		Indexes: []string{CreateHookRepoIDNumberIndex, CreateHookRepoIDIndex},
+		Indexes: []string{CreateHookRepoIDIndex},
 	}
 
 	// run test

--- a/database/ddl/postgres/log.go
+++ b/database/ddl/postgres/log.go
@@ -30,24 +30,6 @@ IF NOT EXISTS
 logs_build_id
 ON logs (build_id);
 `
-
-	// CreateLogStepIDIndex represents a query to create an
-	// index on the logs table for the step_id column.
-	CreateLogStepIDIndex = `
-CREATE INDEX
-IF NOT EXISTS
-logs_step_id
-ON logs (step_id);
-`
-
-	// CreateLogServiceIDIndex represents a query to create an
-	// index on the logs table for the service_id column.
-	CreateLogServiceIDIndex = `
-CREATE INDEX
-IF NOT EXISTS
-logs_service_id
-ON logs (service_id);
-`
 )
 
 // createLogService is a helper function to return
@@ -55,6 +37,6 @@ ON logs (service_id);
 func createLogService() *Service {
 	return &Service{
 		Create:  CreateLogTable,
-		Indexes: []string{CreateLogBuildIDIndex, CreateLogStepIDIndex, CreateLogServiceIDIndex},
+		Indexes: []string{CreateLogBuildIDIndex},
 	}
 }

--- a/database/ddl/postgres/log_test.go
+++ b/database/ddl/postgres/log_test.go
@@ -13,7 +13,7 @@ func TestPostgres_createLogService(t *testing.T) {
 	// setup types
 	want := &Service{
 		Create:  CreateLogTable,
-		Indexes: []string{CreateLogBuildIDIndex, CreateLogStepIDIndex, CreateLogServiceIDIndex},
+		Indexes: []string{CreateLogBuildIDIndex},
 	}
 
 	// run test

--- a/database/ddl/postgres/postgres_test.go
+++ b/database/ddl/postgres/postgres_test.go
@@ -14,19 +14,19 @@ func TestPostgres_NewMap(t *testing.T) {
 	want := &Map{
 		BuildService: &Service{
 			Create:  CreateBuildTable,
-			Indexes: []string{CreateBuildRepoIDIndex, CreateBuildRepoIDNumberIndex, CreateBuildStatusIndex},
+			Indexes: []string{CreateBuildRepoIDIndex, CreateBuildStatusIndex},
 		},
 		HookService: &Service{
 			Create:  CreateHookTable,
-			Indexes: []string{CreateHookRepoIDNumberIndex, CreateHookRepoIDIndex},
+			Indexes: []string{CreateHookRepoIDIndex},
 		},
 		LogService: &Service{
 			Create:  CreateLogTable,
-			Indexes: []string{CreateLogBuildIDIndex, CreateLogStepIDIndex, CreateLogServiceIDIndex},
+			Indexes: []string{CreateLogBuildIDIndex},
 		},
 		RepoService: &Service{
 			Create:  CreateRepoTable,
-			Indexes: []string{CreateRepoOrgNameIndex, CreateRepoFullNameIndex},
+			Indexes: []string{CreateRepoOrgNameIndex},
 		},
 		SecretService: &Service{
 			Create: CreateSecretTable,
@@ -34,20 +34,19 @@ func TestPostgres_NewMap(t *testing.T) {
 				CreateSecretTypeOrgRepo,
 				CreateSecretTypeOrgTeam,
 				CreateSecretTypeOrg,
-				CreateSecretType,
 			},
 		},
 		ServiceService: &Service{
 			Create:  CreateServiceTable,
-			Indexes: []string{CreateServiceBuildIDNumberIndex},
+			Indexes: []string{},
 		},
 		StepService: &Service{
 			Create:  CreateStepTable,
-			Indexes: []string{CreateStepBuildIDNumberIndex},
+			Indexes: []string{},
 		},
 		UserService: &Service{
 			Create:  CreateUserTable,
-			Indexes: []string{CreateUserNameIndex, CreateRefreshIndex},
+			Indexes: []string{CreateRefreshIndex},
 		},
 		WorkerService: &Service{
 			Create:  CreateWorkerTable,

--- a/database/ddl/postgres/repo.go
+++ b/database/ddl/postgres/repo.go
@@ -42,15 +42,6 @@ IF NOT EXISTS
 repos_org_name
 ON repos (org, name);
 `
-
-	// CreateRepoFullNameIndex represents a query to create an
-	// index on the repos table for the full_name column.
-	CreateRepoFullNameIndex = `
-CREATE INDEX
-IF NOT EXISTS
-repos_full_name
-ON repos (full_name);
-`
 )
 
 // createRepoService is a helper function to return
@@ -58,6 +49,6 @@ ON repos (full_name);
 func createRepoService() *Service {
 	return &Service{
 		Create:  CreateRepoTable,
-		Indexes: []string{CreateRepoOrgNameIndex, CreateRepoFullNameIndex},
+		Indexes: []string{CreateRepoOrgNameIndex},
 	}
 }

--- a/database/ddl/postgres/repo_test.go
+++ b/database/ddl/postgres/repo_test.go
@@ -13,7 +13,7 @@ func TestPostgres_createRepoService(t *testing.T) {
 	// setup types
 	want := &Service{
 		Create:  CreateRepoTable,
-		Indexes: []string{CreateRepoOrgNameIndex, CreateRepoFullNameIndex},
+		Indexes: []string{CreateRepoOrgNameIndex},
 	}
 
 	// run test

--- a/database/ddl/postgres/secret.go
+++ b/database/ddl/postgres/secret.go
@@ -58,17 +58,6 @@ IF NOT EXISTS
 secrets_type_org
 ON secrets (type, org);
 `
-
-	// CreateSecretType represents a query to create an
-	// index on the secrets table for the type column.
-	//
-	// nolint: gosec // ignore false positive
-	CreateSecretType = `
-CREATE INDEX
-IF NOT EXISTS
-secrets_type
-ON secrets (type);
-`
 )
 
 // createSecretService is a helper function to return
@@ -80,7 +69,6 @@ func createSecretService() *Service {
 			CreateSecretTypeOrgRepo,
 			CreateSecretTypeOrgTeam,
 			CreateSecretTypeOrg,
-			CreateSecretType,
 		},
 	}
 }

--- a/database/ddl/postgres/secret_test.go
+++ b/database/ddl/postgres/secret_test.go
@@ -17,7 +17,6 @@ func TestPostgres_createSecretService(t *testing.T) {
 			CreateSecretTypeOrgRepo,
 			CreateSecretTypeOrgTeam,
 			CreateSecretTypeOrg,
-			CreateSecretType,
 		},
 	}
 

--- a/database/ddl/postgres/service.go
+++ b/database/ddl/postgres/service.go
@@ -29,15 +29,6 @@ services (
 	UNIQUE(build_id, number)
 );
 `
-
-	// CreateServiceBuildIDNumberIndex represents a query to create an
-	// index on the services table for the build_id and number columns.
-	CreateServiceBuildIDNumberIndex = `
-CREATE INDEX
-IF NOT EXISTS
-services_build_id_number
-ON services (build_id, number);
-`
 )
 
 // createServiceService is a helper function to return
@@ -45,6 +36,6 @@ ON services (build_id, number);
 func createServiceService() *Service {
 	return &Service{
 		Create:  CreateServiceTable,
-		Indexes: []string{CreateServiceBuildIDNumberIndex},
+		Indexes: []string{},
 	}
 }

--- a/database/ddl/postgres/service_test.go
+++ b/database/ddl/postgres/service_test.go
@@ -13,7 +13,7 @@ func TestPostgres_createServiceService(t *testing.T) {
 	// setup types
 	want := &Service{
 		Create:  CreateServiceTable,
-		Indexes: []string{CreateServiceBuildIDNumberIndex},
+		Indexes: []string{},
 	}
 
 	// run test

--- a/database/ddl/postgres/step.go
+++ b/database/ddl/postgres/step.go
@@ -30,15 +30,6 @@ steps (
 	UNIQUE(build_id, number)
 );
 `
-
-	// CreateStepBuildIDNumberIndex represents a query to create an
-	// index on the steps table for the build_id and number columns.
-	CreateStepBuildIDNumberIndex = `
-CREATE INDEX
-IF NOT EXISTS
-steps_build_id_number
-ON steps (build_id, number);
-`
 )
 
 // createStepService is a helper function to return
@@ -46,6 +37,6 @@ ON steps (build_id, number);
 func createStepService() *Service {
 	return &Service{
 		Create:  CreateStepTable,
-		Indexes: []string{CreateStepBuildIDNumberIndex},
+		Indexes: []string{},
 	}
 }

--- a/database/ddl/postgres/step_test.go
+++ b/database/ddl/postgres/step_test.go
@@ -13,7 +13,7 @@ func TestPostgres_createStepService(t *testing.T) {
 	// setup types
 	want := &Service{
 		Create:  CreateStepTable,
-		Indexes: []string{CreateStepBuildIDNumberIndex},
+		Indexes: []string{},
 	}
 
 	// run test

--- a/database/ddl/postgres/user.go
+++ b/database/ddl/postgres/user.go
@@ -23,15 +23,6 @@ users (
 );
 `
 
-	// CreateUserNameIndex represents a query to create an
-	// index on the users table for the name column.
-	CreateUserNameIndex = `
-CREATE INDEX
-IF NOT EXISTS
-users_name
-ON users (name);
-`
-
 	// CreateRefreshIndex represents a query to create an
 	// index on the users table for the refresh_token column.
 	CreateRefreshIndex = `
@@ -47,6 +38,6 @@ ON users (refresh_token);
 func createUserService() *Service {
 	return &Service{
 		Create:  CreateUserTable,
-		Indexes: []string{CreateUserNameIndex, CreateRefreshIndex},
+		Indexes: []string{CreateRefreshIndex},
 	}
 }

--- a/database/ddl/postgres/user_test.go
+++ b/database/ddl/postgres/user_test.go
@@ -13,7 +13,7 @@ func TestPostgres_createUserService(t *testing.T) {
 	// setup types
 	want := &Service{
 		Create:  CreateUserTable,
-		Indexes: []string{CreateUserNameIndex, CreateRefreshIndex},
+		Indexes: []string{CreateRefreshIndex},
 	}
 
 	// run test

--- a/database/ddl/postgres_test.go
+++ b/database/ddl/postgres_test.go
@@ -18,14 +18,12 @@ func TestDDL_mapFromPostgres(t *testing.T) {
 			Create: postgres.CreateBuildTable,
 			Indexes: []string{
 				postgres.CreateBuildRepoIDIndex,
-				postgres.CreateBuildRepoIDNumberIndex,
 				postgres.CreateBuildStatusIndex,
 			},
 		},
 		HookService: &Service{
 			Create: postgres.CreateHookTable,
 			Indexes: []string{
-				postgres.CreateHookRepoIDNumberIndex,
 				postgres.CreateHookRepoIDIndex,
 			},
 		},
@@ -33,15 +31,12 @@ func TestDDL_mapFromPostgres(t *testing.T) {
 			Create: postgres.CreateLogTable,
 			Indexes: []string{
 				postgres.CreateLogBuildIDIndex,
-				postgres.CreateLogStepIDIndex,
-				postgres.CreateLogServiceIDIndex,
 			},
 		},
 		RepoService: &Service{
 			Create: postgres.CreateRepoTable,
 			Indexes: []string{
 				postgres.CreateRepoOrgNameIndex,
-				postgres.CreateRepoFullNameIndex,
 			},
 		},
 		SecretService: &Service{
@@ -50,25 +45,19 @@ func TestDDL_mapFromPostgres(t *testing.T) {
 				postgres.CreateSecretTypeOrgRepo,
 				postgres.CreateSecretTypeOrgTeam,
 				postgres.CreateSecretTypeOrg,
-				postgres.CreateSecretType,
 			},
 		},
 		ServiceService: &Service{
-			Create: postgres.CreateServiceTable,
-			Indexes: []string{
-				postgres.CreateServiceBuildIDNumberIndex,
-			},
+			Create:  postgres.CreateServiceTable,
+			Indexes: []string{},
 		},
 		StepService: &Service{
-			Create: postgres.CreateStepTable,
-			Indexes: []string{
-				postgres.CreateStepBuildIDNumberIndex,
-			},
+			Create:  postgres.CreateStepTable,
+			Indexes: []string{},
 		},
 		UserService: &Service{
 			Create: postgres.CreateUserTable,
 			Indexes: []string{
-				postgres.CreateUserNameIndex,
 				postgres.CreateRefreshIndex,
 			},
 		},
@@ -94,7 +83,6 @@ func TestDDL_serviceFromPostgres(t *testing.T) {
 		Create: postgres.CreateBuildTable,
 		Indexes: []string{
 			postgres.CreateBuildRepoIDIndex,
-			postgres.CreateBuildRepoIDNumberIndex,
 			postgres.CreateBuildStatusIndex,
 		},
 	}

--- a/database/ddl/sqlite/build.go
+++ b/database/ddl/sqlite/build.go
@@ -45,15 +45,6 @@ builds (
 );
 `
 
-	// CreateBuildRepoIDNumberIndex represents a query to create an
-	// index on the builds table for the repo_id and number columns.
-	CreateBuildRepoIDNumberIndex = `
-CREATE INDEX
-IF NOT EXISTS
-builds_repo_id_number
-ON builds (repo_id, number);
-`
-
 	// CreateBuildRepoIDIndex represents a query to create an
 	// index on the builds table for the repo_id column.
 	CreateBuildRepoIDIndex = `
@@ -78,6 +69,6 @@ ON builds (status);
 func createBuildService() *Service {
 	return &Service{
 		Create:  CreateBuildTable,
-		Indexes: []string{CreateBuildRepoIDIndex, CreateBuildRepoIDNumberIndex, CreateBuildStatusIndex},
+		Indexes: []string{CreateBuildRepoIDIndex, CreateBuildStatusIndex},
 	}
 }

--- a/database/ddl/sqlite/build_test.go
+++ b/database/ddl/sqlite/build_test.go
@@ -13,7 +13,7 @@ func TestSqlite_createBuildService(t *testing.T) {
 	// setup types
 	want := &Service{
 		Create:  CreateBuildTable,
-		Indexes: []string{CreateBuildRepoIDIndex, CreateBuildRepoIDNumberIndex, CreateBuildStatusIndex},
+		Indexes: []string{CreateBuildRepoIDIndex, CreateBuildStatusIndex},
 	}
 
 	// run test

--- a/database/ddl/sqlite/hook.go
+++ b/database/ddl/sqlite/hook.go
@@ -27,15 +27,6 @@ hooks (
 );
 `
 
-	// CreateHookRepoIDNumberIndex represents a query to create an
-	// index on the hooks table for the repo_id and number columns.
-	CreateHookRepoIDNumberIndex = `
-CREATE INDEX
-IF NOT EXISTS
-hooks_repo_id_number
-ON hooks (repo_id, number);
-`
-
 	// CreateHookRepoIDIndex represents a query to create an
 	// index on the hooks table for the repo_id column.
 	CreateHookRepoIDIndex = `
@@ -51,6 +42,6 @@ ON hooks (repo_id);
 func createHookService() *Service {
 	return &Service{
 		Create:  CreateHookTable,
-		Indexes: []string{CreateHookRepoIDNumberIndex, CreateHookRepoIDIndex},
+		Indexes: []string{CreateHookRepoIDIndex},
 	}
 }

--- a/database/ddl/sqlite/hook_test.go
+++ b/database/ddl/sqlite/hook_test.go
@@ -13,7 +13,7 @@ func TestSqlite_createHookService(t *testing.T) {
 	// setup types
 	want := &Service{
 		Create:  CreateHookTable,
-		Indexes: []string{CreateHookRepoIDNumberIndex, CreateHookRepoIDIndex},
+		Indexes: []string{CreateHookRepoIDIndex},
 	}
 
 	// run test

--- a/database/ddl/sqlite/log.go
+++ b/database/ddl/sqlite/log.go
@@ -30,24 +30,6 @@ IF NOT EXISTS
 logs_build_id
 ON logs (build_id);
 `
-
-	// CreateLogStepIDIndex represents a query to create an
-	// index on the logs table for the step_id column.
-	CreateLogStepIDIndex = `
-CREATE INDEX
-IF NOT EXISTS
-logs_step_id
-ON logs (step_id);
-`
-
-	// CreateLogServiceIDIndex represents a query to create an
-	// index on the logs table for the service_id column.
-	CreateLogServiceIDIndex = `
-CREATE INDEX
-IF NOT EXISTS
-logs_service_id
-ON logs (service_id);
-`
 )
 
 // createLogService is a helper function to return
@@ -55,6 +37,6 @@ ON logs (service_id);
 func createLogService() *Service {
 	return &Service{
 		Create:  CreateLogTable,
-		Indexes: []string{CreateLogBuildIDIndex, CreateLogStepIDIndex, CreateLogServiceIDIndex},
+		Indexes: []string{CreateLogBuildIDIndex},
 	}
 }

--- a/database/ddl/sqlite/log_test.go
+++ b/database/ddl/sqlite/log_test.go
@@ -13,7 +13,7 @@ func TestSqlite_createLogService(t *testing.T) {
 	// setup types
 	want := &Service{
 		Create:  CreateLogTable,
-		Indexes: []string{CreateLogBuildIDIndex, CreateLogStepIDIndex, CreateLogServiceIDIndex},
+		Indexes: []string{CreateLogBuildIDIndex},
 	}
 
 	// run test

--- a/database/ddl/sqlite/repo.go
+++ b/database/ddl/sqlite/repo.go
@@ -42,15 +42,6 @@ IF NOT EXISTS
 repos_org_name
 ON repos (org, name);
 `
-
-	// CreateRepoFullNameIndex represents a query to create an
-	// index on the repos table for the full_name column.
-	CreateRepoFullNameIndex = `
-CREATE INDEX
-IF NOT EXISTS
-repos_full_name
-ON repos (full_name);
-`
 )
 
 // createRepoService is a helper function to return
@@ -58,6 +49,6 @@ ON repos (full_name);
 func createRepoService() *Service {
 	return &Service{
 		Create:  CreateRepoTable,
-		Indexes: []string{CreateRepoOrgNameIndex, CreateRepoFullNameIndex},
+		Indexes: []string{CreateRepoOrgNameIndex},
 	}
 }

--- a/database/ddl/sqlite/repo_test.go
+++ b/database/ddl/sqlite/repo_test.go
@@ -13,7 +13,7 @@ func TestSqlite_createRepoService(t *testing.T) {
 	// setup types
 	want := &Service{
 		Create:  CreateRepoTable,
-		Indexes: []string{CreateRepoOrgNameIndex, CreateRepoFullNameIndex},
+		Indexes: []string{CreateRepoOrgNameIndex},
 	}
 
 	// run test

--- a/database/ddl/sqlite/secret.go
+++ b/database/ddl/sqlite/secret.go
@@ -58,17 +58,6 @@ IF NOT EXISTS
 secrets_type_org
 ON secrets (type, org);
 `
-
-	// CreateSecretType represents a query to create an
-	// index on the secrets table for the type column.
-	//
-	// nolint: gosec // ignore false positive
-	CreateSecretType = `
-CREATE INDEX
-IF NOT EXISTS
-secrets_type
-ON secrets (type);
-`
 )
 
 // createSecretService is a helper function to return
@@ -80,7 +69,6 @@ func createSecretService() *Service {
 			CreateSecretTypeOrgRepo,
 			CreateSecretTypeOrgTeam,
 			CreateSecretTypeOrg,
-			CreateSecretType,
 		},
 	}
 }

--- a/database/ddl/sqlite/secret_test.go
+++ b/database/ddl/sqlite/secret_test.go
@@ -17,7 +17,6 @@ func TestSqlite_createSecretService(t *testing.T) {
 			CreateSecretTypeOrgRepo,
 			CreateSecretTypeOrgTeam,
 			CreateSecretTypeOrg,
-			CreateSecretType,
 		},
 	}
 

--- a/database/ddl/sqlite/service.go
+++ b/database/ddl/sqlite/service.go
@@ -29,15 +29,6 @@ services (
 	UNIQUE(build_id, number)
 );
 `
-
-	// CreateServiceBuildIDNumberIndex represents a query to create an
-	// index on the services table for the build_id and number columns.
-	CreateServiceBuildIDNumberIndex = `
-CREATE INDEX
-IF NOT EXISTS
-services_build_id_number
-ON services (build_id, number);
-`
 )
 
 // createServiceService is a helper function to return
@@ -45,6 +36,6 @@ ON services (build_id, number);
 func createServiceService() *Service {
 	return &Service{
 		Create:  CreateServiceTable,
-		Indexes: []string{CreateServiceBuildIDNumberIndex},
+		Indexes: []string{},
 	}
 }

--- a/database/ddl/sqlite/service_test.go
+++ b/database/ddl/sqlite/service_test.go
@@ -13,7 +13,7 @@ func TestSqlite_createServiceService(t *testing.T) {
 	// setup types
 	want := &Service{
 		Create:  CreateServiceTable,
-		Indexes: []string{CreateServiceBuildIDNumberIndex},
+		Indexes: []string{},
 	}
 
 	// run test

--- a/database/ddl/sqlite/sqlite_test.go
+++ b/database/ddl/sqlite/sqlite_test.go
@@ -14,19 +14,19 @@ func TestSqlite_NewMap(t *testing.T) {
 	want := &Map{
 		BuildService: &Service{
 			Create:  CreateBuildTable,
-			Indexes: []string{CreateBuildRepoIDIndex, CreateBuildRepoIDNumberIndex, CreateBuildStatusIndex},
+			Indexes: []string{CreateBuildRepoIDIndex, CreateBuildStatusIndex},
 		},
 		HookService: &Service{
 			Create:  CreateHookTable,
-			Indexes: []string{CreateHookRepoIDNumberIndex, CreateHookRepoIDIndex},
+			Indexes: []string{CreateHookRepoIDIndex},
 		},
 		LogService: &Service{
 			Create:  CreateLogTable,
-			Indexes: []string{CreateLogBuildIDIndex, CreateLogStepIDIndex, CreateLogServiceIDIndex},
+			Indexes: []string{CreateLogBuildIDIndex},
 		},
 		RepoService: &Service{
 			Create:  CreateRepoTable,
-			Indexes: []string{CreateRepoOrgNameIndex, CreateRepoFullNameIndex},
+			Indexes: []string{CreateRepoOrgNameIndex},
 		},
 		SecretService: &Service{
 			Create: CreateSecretTable,
@@ -34,20 +34,19 @@ func TestSqlite_NewMap(t *testing.T) {
 				CreateSecretTypeOrgRepo,
 				CreateSecretTypeOrgTeam,
 				CreateSecretTypeOrg,
-				CreateSecretType,
 			},
 		},
 		ServiceService: &Service{
 			Create:  CreateServiceTable,
-			Indexes: []string{CreateServiceBuildIDNumberIndex},
+			Indexes: []string{},
 		},
 		StepService: &Service{
 			Create:  CreateStepTable,
-			Indexes: []string{CreateStepBuildIDNumberIndex},
+			Indexes: []string{},
 		},
 		UserService: &Service{
 			Create:  CreateUserTable,
-			Indexes: []string{CreateUserNameIndex, CreateRefreshIndex},
+			Indexes: []string{CreateRefreshIndex},
 		},
 		WorkerService: &Service{
 			Create:  CreateWorkerTable,

--- a/database/ddl/sqlite/step.go
+++ b/database/ddl/sqlite/step.go
@@ -30,15 +30,6 @@ steps (
 	UNIQUE(build_id, number)
 );
 `
-
-	// CreateStepBuildIDNumberIndex represents a query to create an
-	// index on the steps table for the build_id and number columns.
-	CreateStepBuildIDNumberIndex = `
-CREATE INDEX
-IF NOT EXISTS
-steps_build_id_number
-ON steps (build_id, number);
-`
 )
 
 // createStepService is a helper function to return
@@ -46,6 +37,6 @@ ON steps (build_id, number);
 func createStepService() *Service {
 	return &Service{
 		Create:  CreateStepTable,
-		Indexes: []string{CreateStepBuildIDNumberIndex},
+		Indexes: []string{},
 	}
 }

--- a/database/ddl/sqlite/step_test.go
+++ b/database/ddl/sqlite/step_test.go
@@ -13,7 +13,7 @@ func TestSqlite_createStepService(t *testing.T) {
 	// setup types
 	want := &Service{
 		Create:  CreateStepTable,
-		Indexes: []string{CreateStepBuildIDNumberIndex},
+		Indexes: []string{},
 	}
 
 	// run test

--- a/database/ddl/sqlite/user.go
+++ b/database/ddl/sqlite/user.go
@@ -23,15 +23,6 @@ users (
 );
 `
 
-	// CreateUserNameIndex represents a query to create an
-	// index on the users table for the name column.
-	CreateUserNameIndex = `
-CREATE INDEX
-IF NOT EXISTS
-users_name
-ON users (name);
-`
-
 	// CreateRefreshIndex represents a query to create an
 	// index on the users table for the refresh_token column.
 	CreateRefreshIndex = `
@@ -47,6 +38,6 @@ ON users (refresh_token);
 func createUserService() *Service {
 	return &Service{
 		Create:  CreateUserTable,
-		Indexes: []string{CreateUserNameIndex, CreateRefreshIndex},
+		Indexes: []string{CreateRefreshIndex},
 	}
 }

--- a/database/ddl/sqlite/user_test.go
+++ b/database/ddl/sqlite/user_test.go
@@ -13,7 +13,7 @@ func TestSqlite_createUserService(t *testing.T) {
 	// setup types
 	want := &Service{
 		Create:  CreateUserTable,
-		Indexes: []string{CreateUserNameIndex, CreateRefreshIndex},
+		Indexes: []string{CreateRefreshIndex},
 	}
 
 	// run test

--- a/database/ddl/sqlite_test.go
+++ b/database/ddl/sqlite_test.go
@@ -18,14 +18,12 @@ func TestDDL_mapFromSqlite(t *testing.T) {
 			Create: sqlite.CreateBuildTable,
 			Indexes: []string{
 				sqlite.CreateBuildRepoIDIndex,
-				sqlite.CreateBuildRepoIDNumberIndex,
 				sqlite.CreateBuildStatusIndex,
 			},
 		},
 		HookService: &Service{
 			Create: sqlite.CreateHookTable,
 			Indexes: []string{
-				sqlite.CreateHookRepoIDNumberIndex,
 				sqlite.CreateHookRepoIDIndex,
 			},
 		},
@@ -33,15 +31,12 @@ func TestDDL_mapFromSqlite(t *testing.T) {
 			Create: sqlite.CreateLogTable,
 			Indexes: []string{
 				sqlite.CreateLogBuildIDIndex,
-				sqlite.CreateLogStepIDIndex,
-				sqlite.CreateLogServiceIDIndex,
 			},
 		},
 		RepoService: &Service{
 			Create: sqlite.CreateRepoTable,
 			Indexes: []string{
 				sqlite.CreateRepoOrgNameIndex,
-				sqlite.CreateRepoFullNameIndex,
 			},
 		},
 		SecretService: &Service{
@@ -50,25 +45,19 @@ func TestDDL_mapFromSqlite(t *testing.T) {
 				sqlite.CreateSecretTypeOrgRepo,
 				sqlite.CreateSecretTypeOrgTeam,
 				sqlite.CreateSecretTypeOrg,
-				sqlite.CreateSecretType,
 			},
 		},
 		ServiceService: &Service{
-			Create: sqlite.CreateServiceTable,
-			Indexes: []string{
-				sqlite.CreateServiceBuildIDNumberIndex,
-			},
+			Create:  sqlite.CreateServiceTable,
+			Indexes: []string{},
 		},
 		StepService: &Service{
-			Create: sqlite.CreateStepTable,
-			Indexes: []string{
-				sqlite.CreateStepBuildIDNumberIndex,
-			},
+			Create:  sqlite.CreateStepTable,
+			Indexes: []string{},
 		},
 		UserService: &Service{
 			Create: sqlite.CreateUserTable,
 			Indexes: []string{
-				sqlite.CreateUserNameIndex,
 				sqlite.CreateRefreshIndex,
 			},
 		},
@@ -94,7 +83,6 @@ func TestDDL_serviceFromSqlite(t *testing.T) {
 		Create: sqlite.CreateBuildTable,
 		Indexes: []string{
 			sqlite.CreateBuildRepoIDIndex,
-			sqlite.CreateBuildRepoIDNumberIndex,
 			sqlite.CreateBuildStatusIndex,
 		},
 	}


### PR DESCRIPTION
This removes all unused or unneeded indexes from the database setup.

Currently, we have unused indexes because we created them for fields that already have a `UNIQUE` constraint.

The examples below will specifically refer to the `logs` table but I've applied these changes across all tables:

https://github.com/go-vela/server/blob/1a3af5e908d2410c33ce25d51014c36223aa9e9b/database/ddl/postgres/log.go#L11-L22

Note how we apply a `UNIQUE` constraint for the fields `service_id` and `step_id`.

But then we also have logic to create indexes for those fields too:

https://github.com/go-vela/server/blob/1a3af5e908d2410c33ce25d51014c36223aa9e9b/database/ddl/postgres/log.go#L37-L40

https://github.com/go-vela/server/blob/1a3af5e908d2410c33ce25d51014c36223aa9e9b/database/ddl/postgres/log.go#L46-L49

These indexes aren't needed because when we apply the `UNIQUE` constraint to those fields an index is already created.

Here is a list of all indexes that have been removed:

* `builds_repo_id_number`
* `hooks_repo_id_number`
* `logs_step_id`
* `logs_service_id`
* `repos_full_name`
* `secrets_type`
* `services_build_id_number`
* `steps_build_id_number`
* `users_name`