### PR TITLE
feat(database): encrypt secret values for enhanced security

### DIFF
--- a/cmd/vela-server/main.go
+++ b/cmd/vela-server/main.go
@@ -151,6 +151,17 @@ func main() {
 			Usage:   "sets the level of compression for logs stored in the database",
 			Value:   constants.CompressionThree,
 		},
+		&cli.IntFlag{
+			EnvVars: []string{"VELA_DATABASE_COMPRESSION_LEVEL", "DATABASE_COMPRESSION_LEVEL"},
+			Name:    "database.compression.level",
+			Usage:   "sets the level of compression for logs stored in the database",
+			Value:   constants.CompressionThree,
+		},
+		&cli.StringFlag{
+			EnvVars: []string{"VELA_DATABASE_ENCRYPTION_KEY", "DATABASE_ENCRYPTION_KEY"},
+			Name:    "database.encryption.key",
+			Usage:   "32 char string for encrypting and decrypting values",
+		},
 
 		// Queue Flags
 

--- a/cmd/vela-server/main.go
+++ b/cmd/vela-server/main.go
@@ -154,7 +154,7 @@ func main() {
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_DATABASE_ENCRYPTION_KEY", "DATABASE_ENCRYPTION_KEY"},
 			Name:    "database.encryption.key",
-			Usage:   "32 char string for encrypting and decrypting values",
+			Usage:   "AES-256 key for encrypting and decrypting values",
 		},
 
 		// Queue Flags

--- a/cmd/vela-server/main.go
+++ b/cmd/vela-server/main.go
@@ -151,12 +151,6 @@ func main() {
 			Usage:   "sets the level of compression for logs stored in the database",
 			Value:   constants.CompressionThree,
 		},
-		&cli.IntFlag{
-			EnvVars: []string{"VELA_DATABASE_COMPRESSION_LEVEL", "DATABASE_COMPRESSION_LEVEL"},
-			Name:    "database.compression.level",
-			Usage:   "sets the level of compression for logs stored in the database",
-			Value:   constants.CompressionThree,
-		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_DATABASE_ENCRYPTION_KEY", "DATABASE_ENCRYPTION_KEY"},
 			Name:    "database.encryption.key",

--- a/cmd/vela-server/validate.go
+++ b/cmd/vela-server/validate.go
@@ -159,6 +159,13 @@ func validateDatabase(c *cli.Context) error {
 		return fmt.Errorf("database compression level of '%d' is unsupported", c.Int("database.compression.level"))
 	}
 
+	// enforce AES-256, so check explicitly for 32 bytes on the key
+	//
+	// nolint: gomnd // ignore magic number
+	if len(c.String("database.encryption.key")) != 32 {
+		return fmt.Errorf("database.encryption.key (VELA_DATABASE_ENCRYPTION_KEY or DATABASE_ENCRYPTION_KEY) invalid length specified: %d", len(c.String("database.encryption.key")))
+	}
+
 	return nil
 }
 

--- a/cmd/vela-server/validate.go
+++ b/cmd/vela-server/validate.go
@@ -163,6 +163,7 @@ func validateDatabase(c *cli.Context) error {
 	//
 	// nolint: gomnd // ignore magic number
 	if len(c.String("database.encryption.key")) != 32 {
+		// nolint: lll // ignore long line length due to long error message
 		return fmt.Errorf("database.encryption.key (VELA_DATABASE_ENCRYPTION_KEY or DATABASE_ENCRYPTION_KEY) invalid length specified: %d", len(c.String("database.encryption.key")))
 	}
 

--- a/database/client.go
+++ b/database/client.go
@@ -134,6 +134,7 @@ func NewTest() (*client, error) {
 		DDL:              ddlMap,
 		DML:              dmlMap,
 		CompressionLevel: constants.CompressionZero,
+		EncryptionKey:    "C639A572E14D5075C526FDDD43E4ECF6",
 	}
 
 	return client, nil

--- a/database/client.go
+++ b/database/client.go
@@ -27,6 +27,7 @@ type client struct {
 	DML *dml.Map
 
 	CompressionLevel int
+	EncryptionKey    string
 }
 
 // New returns a Database implementation that
@@ -72,6 +73,7 @@ func New(c *cli.Context) (*client, error) {
 		DDL:              ddlMap,
 		DML:              dmlMap,
 		CompressionLevel: c.Int("database.compression.level"),
+		EncryptionKey:    c.String("database.encryption.key"),
 	}
 
 	return client, nil

--- a/database/secret.go
+++ b/database/secret.go
@@ -5,6 +5,8 @@
 package database
 
 import (
+	"fmt"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -48,7 +50,7 @@ func (c *client) GetSecret(t, o, n, secretName string) (*library.Secret, error) 
 		// ensures that the change is backwards compatible
 		// by logging the error instead of returning it
 		// which allows us to fetch unencrypted secrets
-		logrus.Errorf("unable to decrypt %s secret %s for %s/%s: %v", t, secretName, o, n err)
+		logrus.Errorf("unable to decrypt %s secret %s for %s/%s: %v", t, secretName, o, n, err)
 
 		// return the unencrypted secret
 		return s.ToLibrary(), nil
@@ -86,7 +88,7 @@ func (c *client) GetSecretList() ([]*library.Secret, error) {
 			// ensures that the change is backwards compatible
 			// by logging the error instead of returning it
 			// which allows us to fetch unencrypted secrets
-			logrus.Errorf("unable to decrypt secret %d: %v", tmp.ID err)
+			logrus.Errorf("unable to decrypt secret %d: %v", tmp.ID.Int64, err)
 		}
 
 		// convert query result to library type
@@ -142,7 +144,7 @@ func (c *client) GetTypeSecretList(t, o, n string, page, perPage int) ([]*librar
 			// ensures that the change is backwards compatible
 			// by logging the error instead of returning it
 			// which allows us to fetch unencrypted secrets
-			logrus.Errorf("unable to decrypt secret %d: %v", tmp.ID err)
+			logrus.Errorf("unable to decrypt secret %d: %v", tmp.ID.Int64, err)
 		}
 
 		// convert query result to library type

--- a/database/secret.go
+++ b/database/secret.go
@@ -41,6 +41,9 @@ func (c *client) GetSecret(t, o, n, secretName string) (*library.Secret, error) 
 			Raw(c.DML.SecretService.Select["shared"], o, n, secretName).
 			Scan(s).Error
 	}
+	if err != nil {
+		return nil, err
+	}
 
 	// decrypt the value for the secret
 	//
@@ -57,7 +60,7 @@ func (c *client) GetSecret(t, o, n, secretName string) (*library.Secret, error) 
 	}
 
 	// return the decrypted log
-	return s.ToLibrary(), err
+	return s.ToLibrary(), nil
 }
 
 // GetSecretList gets a list of all secrets from the database.
@@ -72,6 +75,9 @@ func (c *client) GetSecretList() ([]*library.Secret, error) {
 		Table(constants.TableSecret).
 		Raw(c.DML.SecretService.List["all"]).
 		Scan(s).Error
+	if err != nil {
+		return nil, err
+	}
 
 	// variable we want to return
 	secrets := []*library.Secret{}
@@ -95,7 +101,7 @@ func (c *client) GetSecretList() ([]*library.Secret, error) {
 		secrets = append(secrets, tmp.ToLibrary())
 	}
 
-	return secrets, err
+	return secrets, nil
 }
 
 // GetTypeSecretList gets a list of secrets by type,
@@ -128,6 +134,9 @@ func (c *client) GetTypeSecretList(t, o, n string, page, perPage int) ([]*librar
 			Raw(c.DML.SecretService.List["shared"], o, n, perPage, offset).
 			Scan(s).Error
 	}
+	if err != nil {
+		return nil, err
+	}
 
 	// variable we want to return
 	secrets := []*library.Secret{}
@@ -151,7 +160,7 @@ func (c *client) GetTypeSecretList(t, o, n string, page, perPage int) ([]*librar
 		secrets = append(secrets, tmp.ToLibrary())
 	}
 
-	return secrets, err
+	return secrets, nil
 }
 
 // GetTypeSecretCount gets a count of secrets by type,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       VELA_WEBUI_ADDR: 'http://localhost:8888'
       VELA_DATABASE_DRIVER: postgres
       VELA_DATABASE_CONFIG: 'postgres://vela:zB7mrKDTZqNeNTD8z47yG4DHywspAh@postgres:5432/vela?sslmode=disable'
+      VELA_DATABASE_ENCRYPTION_KEY: 'C639A572E14D5075C526FDDD43E4ECF6'
       VELA_LOG_LEVEL: trace
       VELA_QUEUE_DRIVER: redis
       VELA_QUEUE_CONFIG: 'redis://redis:6379'

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/go-vela/server
 
 go 1.15
 
-replace github.com/go-vela/types => ../types
-
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/aws/aws-sdk-go v1.36.32
@@ -15,7 +13,7 @@ require (
 	github.com/go-playground/assert/v2 v2.0.1
 	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/go-vela/compiler v0.7.3
-	github.com/go-vela/types v0.7.4-0.20210225205732-6bf075d597f6
+	github.com/go-vela/types v0.7.4-0.20210304165129-580e7ea750df
 	github.com/google/go-cmp v0.5.4
 	github.com/google/go-github/v29 v29.0.3
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/go-vela/server
 
 go 1.15
 
+replace github.com/go-vela/types => ../types
+
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/aws/aws-sdk-go v1.36.32

--- a/go.sum
+++ b/go.sum
@@ -174,9 +174,6 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-vela/compiler v0.7.3 h1:/3AP1uYk+K0vZVJNttA0Dyp9lYsyLPTB/iAF/OfV/30=
 github.com/go-vela/compiler v0.7.3/go.mod h1:xMVdK2vQML4CyZP5pLXEGt8KuLVXSoT2+nz4laHE8EU=
-github.com/go-vela/types v0.7.3/go.mod h1:/IsyxCijlz8BArRxBfrfRv7BBe/hmJGtVWegkS3ooJU=
-github.com/go-vela/types v0.7.4-0.20210225205732-6bf075d597f6 h1:Goi9FZ2O6kv4uZiRAVGUEfTZEQGXmK0qXiBUnGoUP18=
-github.com/go-vela/types v0.7.4-0.20210225205732-6bf075d597f6/go.mod h1:/IsyxCijlz8BArRxBfrfRv7BBe/hmJGtVWegkS3ooJU=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,9 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-vela/compiler v0.7.3 h1:/3AP1uYk+K0vZVJNttA0Dyp9lYsyLPTB/iAF/OfV/30=
 github.com/go-vela/compiler v0.7.3/go.mod h1:xMVdK2vQML4CyZP5pLXEGt8KuLVXSoT2+nz4laHE8EU=
+github.com/go-vela/types v0.7.3/go.mod h1:/IsyxCijlz8BArRxBfrfRv7BBe/hmJGtVWegkS3ooJU=
+github.com/go-vela/types v0.7.4-0.20210304165129-580e7ea750df h1:7/PTAJmn1LPXrftKbxQPsIKKa6UgY7/cBmFcbr4q6Pw=
+github.com/go-vela/types v0.7.4-0.20210304165129-580e7ea750df/go.mod h1:/IsyxCijlz8BArRxBfrfRv7BBe/hmJGtVWegkS3ooJU=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=


### PR DESCRIPTION
Dependent on https://github.com/go-vela/types/pull/160

Related to:

* https://github.com/go-vela/server/pull/212
* https://github.com/go-vela/server/pull/216
* https://github.com/go-vela/server/pull/274

This change will re-introduce encryption for secret values that are stored in the Vela database.

We've decided to use the Advanced Encryption Standard (`AES`) with a `256` bit key (a.k.a. `AES-256`):

https://en.wikipedia.org/wiki/Advanced_Encryption_Standard

> NOTE: This change is backward compatible. If you try fetching an unencrypted secret, everything will work as expected.
>
> We'll plan to offer some sort of utility that will assist in encrypting all existing secrets in the database.