### PR TITLE
fix: set user ID when repairing a repo

### DIFF
--- a/api/repo.go
+++ b/api/repo.go
@@ -706,16 +706,19 @@ func RepairRepo(c *gin.Context) {
 	// if the repo was previously inactive, mark it as active
 	if !r.GetActive() {
 		r.SetActive(true)
+	}
 
-		// send API call to update the repo
-		err = database.FromContext(c).UpdateRepo(r)
-		if err != nil {
-			retErr := fmt.Errorf("unable to set repo %s to active: %w", r.GetFullName(), err)
+	// update repo owner user id
+	r.SetUserID(u.GetID())
 
-			util.HandleError(c, http.StatusInternalServerError, retErr)
+	// send API call to update the repo
+	err = database.FromContext(c).UpdateRepo(r)
+	if err != nil {
+		retErr := fmt.Errorf("unable to set repo %s to active: %w", r.GetFullName(), err)
 
-			return
-		}
+		util.HandleError(c, http.StatusInternalServerError, retErr)
+
+		return
 	}
 
 	c.JSON(http.StatusOK, fmt.Sprintf("Repo %s repaired", r.GetFullName()))


### PR DESCRIPTION
### description
set userid when repairing a repo, keep git webhook owner and vela repo owner in sync

(discussion) is there a scenario where we would want this to stay out of sync?


### problem
fixes 403 permissions errors that are hard to track down because webhook owner and repo owner can become out of sync.

### scenario
USER_A is the owner of a Vela webhook, USER_A leaves the git organization. Then, USER_B receives `403 account was suspended` runs Repair Repo, owner of the webhook in git is now USER_B but the owner in Vela is still USER_A, where they continue to receive 403 errors.
