### PR TITLE
fix: update branch on re-enable

### DIFF
--- a/api/repo.go
+++ b/api/repo.go
@@ -210,6 +210,8 @@ func CreateRepo(c *gin.Context) {
 	if len(dbRepo.GetOrg()) > 0 && !dbRepo.GetActive() {
 		// update the repo owner
 		dbRepo.SetUserID(u.GetID())
+		// update the default branch
+		dbRepo.SetBranch(r.GetBranch())
 		// activate the repo
 		dbRepo.SetActive(true)
 


### PR DESCRIPTION
between disabling and re-enabling a repo, the default branch might be changed at the source provider. currently this does not get updated if that's the case. this change will account for that.