### PR TITLE
feat: add source.Driver() function

### DIFF
--- a/source/github/driver.go
+++ b/source/github/driver.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package github
+
+import "github.com/go-vela/types/constants"
+
+// Driver outputs the configured source driver.
+func (c *client) Driver() string {
+	return constants.DriverGithub
+}

--- a/source/github/driver_test.go
+++ b/source/github/driver_test.go
@@ -24,7 +24,7 @@ func TestGitHub_Driver(t *testing.T) {
 		WithWebUIAddress("https://vela.example.com"),
 	)
 	if err != nil {
-		t.Errorf("unable to create executor engine: %v", err)
+		t.Errorf("unable to create source service: %v", err)
 	}
 
 	// run test

--- a/source/github/driver_test.go
+++ b/source/github/driver_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package github
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-vela/types/constants"
+)
+
+func TestGitHub_Driver(t *testing.T) {
+	// setup types
+	want := constants.DriverGithub
+
+	_service, err := New(
+		WithAddress("https://github.com/"),
+		WithClientID("foo"),
+		WithClientSecret("bar"),
+		WithServerAddress("https://vela-server.example.com"),
+		WithStatusContext("continuous-integration/vela"),
+		WithWebUIAddress("https://vela.example.com"),
+	)
+	if err != nil {
+		t.Errorf("unable to create executor engine: %v", err)
+	}
+
+	// run test
+	got := _service.Driver()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Driver is %v, want %v", got, want)
+	}
+}

--- a/source/service.go
+++ b/source/service.go
@@ -14,6 +14,12 @@ import (
 // Service represents the interface for Vela integrating
 // with the different supported source providers.
 type Service interface {
+	// Service Interface Functions
+
+	// Driver defines a function that outputs
+	// the configured source driver.
+	Driver() string
+
 	// Authentication Source Interface Functions
 
 	// Authorize defines a function that uses the


### PR DESCRIPTION
This adds a `Driver()` function to the `go-vela/server/source.Service` interface:

https://github.com/go-vela/server/blob/f6d8431ff556e2f694f6bc96eabb15e74622bfea/source/service.go#L19-L21

And then we implement this function for each supported `source` service:

https://github.com/go-vela/server/blob/f6d8431ff556e2f694f6bc96eabb15e74622bfea/source/github/driver.go#L9-L12