### PR TITLE
feat: add secret.Driver() function

### DIFF
--- a/secret/native/driver.go
+++ b/secret/native/driver.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package native
+
+import "github.com/go-vela/types/constants"
+
+// Driver outputs the configured secret driver.
+func (c *client) Driver() string {
+	return constants.DriverNative
+}

--- a/secret/native/driver_test.go
+++ b/secret/native/driver_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package native
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-vela/server/database"
+	"github.com/go-vela/types/constants"
+)
+
+func TestNative_Driver(t *testing.T) {
+	// setup types
+	d, err := database.NewTest()
+	if err != nil {
+		t.Errorf("unable to create database service: %v", err)
+	}
+	defer d.Database.Close()
+
+	want := constants.DriverNative
+
+	_service, err := New(
+		WithDatabase(d),
+	)
+	if err != nil {
+		t.Errorf("unable to create secret service: %v", err)
+	}
+
+	// run test
+	got := _service.Driver()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Driver is %v, want %v", got, want)
+	}
+}

--- a/secret/service.go
+++ b/secret/service.go
@@ -9,6 +9,12 @@ import "github.com/go-vela/types/library"
 // Service represents the interface for Vela integrating
 // with the different supported secret providers.
 type Service interface {
+	// Service Interface Functions
+
+	// Driver defines a function that outputs
+	// the configured source driver.
+	Driver() string
+
 	// Get defines a function that captures a secret.
 	Get(string, string, string, string) (*library.Secret, error)
 	// List defines a function that captures a list of secrets.

--- a/secret/vault/driver.go
+++ b/secret/vault/driver.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package vault
+
+import "github.com/go-vela/types/constants"
+
+// Driver outputs the configured secret driver.
+func (c *client) Driver() string {
+	return constants.DriverVault
+}

--- a/secret/vault/driver_test.go
+++ b/secret/vault/driver_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package vault
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/go-vela/types/constants"
+)
+
+func TestVault_Driver(t *testing.T) {
+	// setup types
+	want := constants.DriverVault
+
+	// setup mock server
+	fake := httptest.NewServer(http.NotFoundHandler())
+	defer fake.Close()
+
+	type args struct {
+		version string
+		prefix  string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{"v1", args{version: "1", prefix: ""}},
+		{"v2", args{version: "2", prefix: ""}},
+		{"v2 with prefix", args{version: "2", prefix: "prefix"}},
+	}
+
+	// run tests
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_service, err := New(
+				WithAddress(fake.URL),
+				WithAuthMethod(""),
+				WithAWSRole(""),
+				WithPrefix(tt.args.prefix),
+				WithToken("foo"),
+				WithTokenDuration(0),
+				WithVersion(tt.args.version),
+			)
+			if err != nil {
+				t.Errorf("unable to create secret service: %v", err)
+			}
+
+			got := _service.Driver()
+
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("Driver is %v, want %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a `Driver()` function to the `go-vela/server/secret.Service` interface:

https://github.com/go-vela/server/blob/bae5e65e66561cf972bdde0aab515ad7f6fd520b/secret/service.go#L14-L16

And then we implement this function for each supported `secret` service:

https://github.com/go-vela/server/blob/bae5e65e66561cf972bdde0aab515ad7f6fd520b/secret/native/driver.go#L9-L12

https://github.com/go-vela/server/blob/bae5e65e66561cf972bdde0aab515ad7f6fd520b/secret/vault/driver.go#L9-L12