### PR TITLE
refactor: switch to using secret.New()

### DIFF
--- a/cmd/vela-server/main.go
+++ b/cmd/vela-server/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-vela/pkg-queue/queue"
+	"github.com/go-vela/server/secret"
 	"github.com/go-vela/server/version"
 	"github.com/go-vela/types/constants"
 	"github.com/sirupsen/logrus"
@@ -158,51 +159,6 @@ func main() {
 			Usage:   "AES-256 key for encrypting and decrypting values",
 		},
 
-		// Secret Flags
-
-		&cli.BoolFlag{
-			EnvVars: []string{"VELA_SECRET_VAULT", "SECRET_VAULT"},
-			Name:    "vault-driver",
-			Usage:   "vault secret driver",
-		},
-		&cli.StringFlag{
-			EnvVars: []string{"VELA_SECRET_VAULT_ADDR", "SECRET_VAULT_ADDR"},
-			Name:    "vault-addr",
-			Usage:   "vault address for storing secrets",
-		},
-		&cli.StringFlag{
-			EnvVars: []string{"VELA_SECRET_VAULT_TOKEN", "SECRET_VAULT_TOKEN"},
-			Name:    "vault-token",
-			Usage:   "vault token for storing secrets",
-		},
-		&cli.StringFlag{
-			EnvVars: []string{"VELA_SECRET_VAULT_VERSION", "SECRET_VAULT_VERSION"},
-			Name:    "vault-version",
-			Usage:   "vault k/v backend version to utilize",
-			Value:   "2",
-		},
-		&cli.StringFlag{
-			EnvVars: []string{"VELA_SECRET_VAULT_PREFIX", "SECRET_VAULT_PREFIX"},
-			Name:    "vault-prefix",
-			Usage:   "vault prefix for k/v secrets. e.g. secret/data/<prefix>/<path>",
-		},
-		&cli.StringFlag{
-			EnvVars: []string{"VELA_SECRET_VAULT_AUTH_METHOD", "SECRET_VAULT_AUTH_METHOD"},
-			Name:    "vault-auth-method",
-			Usage:   "auth method to utilize to obtain token",
-		},
-		&cli.StringFlag{
-			EnvVars: []string{"VELA_SECRET_VAULT_AWS_ROLE", "SECRET_VAULT_AWS_ROLE"},
-			Name:    "vault-aws-role",
-			Usage:   "vault role to connect to the auth/aws/login endpoint with",
-		},
-		&cli.DurationFlag{
-			EnvVars: []string{"VELA_SECRET_VAULT_RENEWAL", "SECRET_VAULT_RENEWAL"},
-			Name:    "vault-renewal",
-			Usage:   "frequency which the vault token should be renewed",
-			Value:   30 * time.Minute,
-		},
-
 		// Source Flags
 
 		&cli.StringFlag{
@@ -269,6 +225,10 @@ func main() {
 	// Queue Flags
 
 	app.Flags = append(app.Flags, queue.Flags...)
+
+	// Secret Flags
+
+	app.Flags = append(app.Flags, secret.Flags...)
 
 	// set logrus to log in JSON format
 	logrus.SetFormatter(&logrus.JSONFormatter{})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,9 @@ services:
       QUEUE_DRIVER: redis
       QUEUE_ADDR: 'redis://redis:6379'
       QUEUE_ROUTES: 'docker,local,docker:local'
+      SECRET_VAULT: 'true'
+      SECRET_VAULT_ADDR: 'http://vault:8200'
+      SECRET_VAULT_TOKEN: vela
       VELA_ADDR: 'http://localhost:8080'
       VELA_WEBUI_ADDR: 'http://localhost:8888'
       VELA_DATABASE_DRIVER: postgres
@@ -33,10 +36,6 @@ services:
       VELA_LOG_LEVEL: trace
       VELA_SECRET: 'zB7mrKDTZqNeNTD8z47yG4DHywspAh'
       VELA_SOURCE_DRIVER: github
-      VELA_SECRET_NATIVE_KEY: 'C639A572E14D5075C526FDDD43E4ECF6'
-      VELA_SECRET_VAULT: 'true'
-      VELA_SECRET_VAULT_ADDR: 'http://vault:8200'
-      VELA_SECRET_VAULT_TOKEN: vela
       VELA_REFRESH_TOKEN_DURATION: 5m
       VELA_ACCESS_TOKEN_DURATION: 1m
       VELA_DISABLE_WEBHOOK_VALIDATION: 'true'

--- a/secret/flags.go
+++ b/secret/flags.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package secret
+
+import (
+	"time"
+
+	"github.com/urfave/cli/v2"
+)
+
+// Flags represents all supported command line
+// interface (CLI) flags for the source.
+//
+// https://pkg.go.dev/github.com/urfave/cli?tab=doc#Flag
+var Flags = []cli.Flag{
+
+	// Logger Flags
+
+	&cli.StringFlag{
+		EnvVars: []string{"VELA_SECRET_LOG_FORMAT", "SECRET_LOG_FORMAT", "VELA_LOG_FORMAT"},
+		Name:    "secret.log.format",
+		Usage:   "format of logs to output",
+		Value:   "json",
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"VELA_SECRET_LOG_LEVEL", "SECRET_LOG_LEVEL", "VELA_LOG_LEVEL"},
+		Name:    "secret.log.level",
+		Usage:   "level of logs to output",
+		Value:   "info",
+	},
+
+	// Secret Flags
+
+	&cli.BoolFlag{
+		EnvVars: []string{"VELA_SECRET_VAULT", "SECRET_VAULT"},
+		Name:    "secret.vault.driver",
+		Usage:   "enables the vault secret driver",
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"VELA_SECRET_VAULT_ADDR", "SECRET_VAULT_ADDR"},
+		Name:    "secret.vault.addr",
+		Usage:   "fully qualified url (<scheme>://<host>) for the vault system",
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"VELA_SECRET_VAULT_AUTH_METHOD", "SECRET_VAULT_AUTH_METHOD"},
+		Name:    "secret.vault.auth-method",
+		Usage:   "authentication method used to obtain token from vault system",
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"VELA_SECRET_VAULT_AWS_ROLE", "SECRET_VAULT_AWS_ROLE"},
+		Name:    "secret.vault.aws-role",
+		Usage:   "vault role used to connect to the auth/aws/login endpoint",
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"VELA_SECRET_VAULT_PREFIX", "SECRET_VAULT_PREFIX"},
+		Name:    "secret.vault.prefix",
+		Usage:   "prefix for k/v secrets in vault system e.g. secret/data/<prefix>/<path>",
+	},
+	&cli.DurationFlag{
+		EnvVars: []string{"VELA_SECRET_VAULT_RENEWAL", "SECRET_VAULT_RENEWAL"},
+		Name:    "secret.vault.renewal",
+		Usage:   "frequency which the vault token should be renewed",
+		Value:   30 * time.Minute,
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"VELA_SECRET_VAULT_TOKEN", "SECRET_VAULT_TOKEN"},
+		Name:    "secret.vault.token",
+		Usage:   "token used to access vault system",
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"VELA_SECRET_VAULT_VERSION", "SECRET_VAULT_VERSION"},
+		Name:    "secret.vault.version",
+		Usage:   "version for the kv backend for the vault system",
+		Value:   "2",
+	},
+}

--- a/secret/flags.go
+++ b/secret/flags.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Flags represents all supported command line
-// interface (CLI) flags for the source.
+// interface (CLI) flags for the secret.
 //
 // https://pkg.go.dev/github.com/urfave/cli?tab=doc#Flag
 var Flags = []cli.Flag{

--- a/secret/secret_test.go
+++ b/secret/secret_test.go
@@ -18,22 +18,6 @@ func TestSecret_New(t *testing.T) {
 	}
 	defer _database.Database.Close()
 
-	_native := &Setup{
-		Driver:   "native",
-		Database: _database,
-	}
-
-	_vault := &Setup{
-		Driver:        "vault",
-		Address:       "https://vault.example.com",
-		AuthMethod:    "",
-		AwsRole:       "",
-		Prefix:        "bar",
-		Token:         "baz",
-		TokenDuration: 0,
-		Version:       "1",
-	}
-
 	// setup tests
 	tests := []struct {
 		failure bool
@@ -41,11 +25,23 @@ func TestSecret_New(t *testing.T) {
 	}{
 		{
 			failure: false,
-			setup:   _native,
+			setup: &Setup{
+				Driver:   "native",
+				Database: _database,
+			},
 		},
 		{
 			failure: false,
-			setup:   _vault,
+			setup: &Setup{
+				Driver:        "vault",
+				Address:       "https://vault.example.com",
+				AuthMethod:    "",
+				AwsRole:       "",
+				Prefix:        "bar",
+				Token:         "baz",
+				TokenDuration: 0,
+				Version:       "1",
+			},
 		},
 		{
 			failure: true,

--- a/secret/secret_test.go
+++ b/secret/secret_test.go
@@ -5,13 +5,12 @@
 package secret
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/go-vela/server/database"
 )
 
-func TestSource_New(t *testing.T) {
+func TestSecret_New(t *testing.T) {
 	// setup types
 	_database, err := database.NewTest()
 	if err != nil {
@@ -19,41 +18,34 @@ func TestSource_New(t *testing.T) {
 	}
 	defer _database.Database.Close()
 
+	_native := &Setup{
+		Driver:   "native",
+		Database: _database,
+	}
+
+	_vault := &Setup{
+		Driver:        "vault",
+		Address:       "https://vault.example.com",
+		AuthMethod:    "",
+		AwsRole:       "",
+		Prefix:        "bar",
+		Token:         "baz",
+		TokenDuration: 0,
+		Version:       "1",
+	}
+
 	// setup tests
 	tests := []struct {
 		failure bool
 		setup   *Setup
-		want    Service
 	}{
 		{
-			failure: true,
-			setup: &Setup{
-				Driver:   "native",
-				Database: _database,
-			},
-			want: nil,
+			failure: false,
+			setup:   _native,
 		},
 		{
-			failure: true,
-			setup: &Setup{
-				Driver:        "vault",
-				Address:       "https://vault.example.com",
-				AuthMethod:    "aws",
-				AwsRole:       "foo",
-				Prefix:        "bar",
-				Token:         "baz",
-				TokenDuration: 0,
-				Version:       "1",
-			},
-			want: nil,
-		},
-		{
-			failure: true,
-			setup: &Setup{
-				Driver:   "native",
-				Database: nil,
-			},
-			want: nil,
+			failure: false,
+			setup:   _vault,
 		},
 		{
 			failure: true,
@@ -67,13 +59,12 @@ func TestSource_New(t *testing.T) {
 				TokenDuration: 0,
 				Version:       "1",
 			},
-			want: nil,
 		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		got, err := New(test.setup)
+		_, err := New(test.setup)
 
 		if test.failure {
 			if err == nil {
@@ -85,10 +76,6 @@ func TestSource_New(t *testing.T) {
 
 		if err != nil {
 			t.Errorf("New returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("New is %v, want %v", got, test.want)
 		}
 	}
 }

--- a/secret/setup.go
+++ b/secret/setup.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/go-vela/server/database"
+	"github.com/go-vela/server/secret/native"
+	"github.com/go-vela/server/secret/vault"
 	"github.com/go-vela/types/constants"
 
 	"github.com/sirupsen/logrus"
@@ -48,7 +50,12 @@ type Setup struct {
 func (s *Setup) Native() (Service, error) {
 	logrus.Trace("creating native secret client from setup")
 
-	return nil, fmt.Errorf("unsupported secret driver: %s", constants.DriverNative)
+	// create new native secret service
+	//
+	// https://pkg.go.dev/github.com/go-vela/server/secret/native?tab=doc#New
+	return native.New(
+		native.WithDatabase(s.Database),
+	)
 }
 
 // Vault creates and returns a Vela service capable of
@@ -56,7 +63,18 @@ func (s *Setup) Native() (Service, error) {
 func (s *Setup) Vault() (Service, error) {
 	logrus.Trace("creating vault secret client from setup")
 
-	return nil, fmt.Errorf("unsupported secret driver: %s", constants.DriverVault)
+	// create new Vault secret service
+	//
+	// https://pkg.go.dev/github.com/go-vela/server/secret/vault?tab=doc#New
+	return vault.New(
+		vault.WithAddress(s.Address),
+		vault.WithAuthMethod(s.AuthMethod),
+		vault.WithAWSRole(s.AwsRole),
+		vault.WithPrefix(s.Prefix),
+		vault.WithToken(s.Token),
+		vault.WithTokenDuration(s.TokenDuration),
+		vault.WithVersion(s.Version),
+	)
 }
 
 // Validate verifies the necessary fields for the


### PR DESCRIPTION
Related to https://github.com/go-vela/server/pull/316, https://github.com/go-vela/server/pull/317 and https://github.com/go-vela/server/pull/318

This updates the codebase to now utilize the `secret.New()` function call and `secret.Setup{}` type:

https://github.com/go-vela/server/blob/52e69904bb77f3258f550528b2568cf14dc74cf7/cmd/vela-server/secret.go#L17-L65

Along with this change, moved the flags for the `secret` package into the `secret.Flags{}` type:

https://github.com/go-vela/server/blob/52e69904bb77f3258f550528b2568cf14dc74cf7/secret/flags.go#L13-L78

> NOTE: The following flags are modified with this change:
> 
> * `vault-driver` -> `secret.vault.driver`
> * `vault-addr` -> `secret.vault.addr`
> * `vault-auth-method` -> `secret.vault.auth-method`
> * `vault-aws-role` -> `secret.vault.aws-role`
> * `vault-prefix` -> `secret.vault.prefix`
> * `vault-renewal` -> `secret.vault.renewal`
> * `vault-token` -> `secret.vault.token`

Also included in this change is the refactoring of some tests and fixing the names for some tests.