### PR TITLE
feat: use BuildQueue{} from go-vela/types

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -57,7 +57,7 @@ type Service interface {
 	GetOrgBuildCountByEvent(string, string) (int64, error)
 	// GetPendingAndRunningBuilds defines a function that
 	// gets the list of pending and running builds.
-	GetPendingAndRunningBuilds(string) ([]*BuildQueue, error)
+	GetPendingAndRunningBuilds(string) ([]*library.BuildQueue, error)
 	// CreateBuild defines a function that
 	// creates a new build.
 	CreateBuild(*library.Build) error

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-playground/assert/v2 v2.0.1
 	github.com/go-vela/compiler v0.7.4
 	github.com/go-vela/pkg-queue v0.7.5-0.20210402170103-bcd9ababfe88
-	github.com/go-vela/types v0.7.5-0.20210318123941-b75a8b07bd29
+	github.com/go-vela/types v0.7.5-0.20210419140302-437df36fc4f4
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-github/v35 v35.0.0
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/go-vela/pkg-queue v0.7.5-0.20210402170103-bcd9ababfe88/go.mod h1:AcS5
 github.com/go-vela/sdk-go v0.7.4 h1:OXUR8LZzO8kBmNY3yRuFojcmjWaMoK1s2q5iIpu5vhg=
 github.com/go-vela/sdk-go v0.7.4/go.mod h1:I1K3LpWOnfsJUhHXJf7DpwR9zVz4h65hRXzQ5IOxPuo=
 github.com/go-vela/types v0.7.4/go.mod h1:/IsyxCijlz8BArRxBfrfRv7BBe/hmJGtVWegkS3ooJU=
-github.com/go-vela/types v0.7.5-0.20210318123941-b75a8b07bd29 h1:aw+YkCE8kZGfjP8l0ZwR1O8EImtnxgZBEU0SOyiJG1Y=
-github.com/go-vela/types v0.7.5-0.20210318123941-b75a8b07bd29/go.mod h1:+8dhX0scCZxD+yjmWUz0EiZggwidMa8MDPEemPSu1bU=
+github.com/go-vela/types v0.7.5-0.20210419140302-437df36fc4f4 h1:iGPjT8P0p1G3UnNVkupbkex5L4BCji45NhC5qqXCzgU=
+github.com/go-vela/types v0.7.5-0.20210419140302-437df36fc4f4/go.mod h1:+8dhX0scCZxD+yjmWUz0EiZggwidMa8MDPEemPSu1bU=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=


### PR DESCRIPTION
Based off of https://github.com/go-vela/sdk-go/pull/97#pullrequestreview-625404169

Related to https://github.com/go-vela/mock/pull/111 and https://github.com/go-vela/types/pull/167

This updates the `github.com/go-vela/server/database` package to use the `BuildQueue{}` type from `github.com/go-vela/types`