### PR TITLE
fix(api): enable updating build enqueued field

### DIFF
--- a/api/build.go
+++ b/api/build.go
@@ -823,6 +823,11 @@ func UpdateBuild(c *gin.Context) {
 		b.SetError(input.GetError())
 	}
 
+	if input.GetEnqueued() > 0 {
+		// update enqueued if set
+		b.SetEnqueued(input.GetEnqueued())
+	}
+
 	if input.GetStarted() > 0 {
 		// update started if set
 		b.SetStarted(input.GetStarted())


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/144

This enables updating the `Enqueued` field for the `build` resource in Vela.

This should resolve part of the linked issue above where the `VELA_BUILD_ENQUEUED` environment variable is empty.