### PR TITLE
feat(postgres): add vela resource ddl

### DIFF
--- a/database/postgres/ddl/build.go
+++ b/database/postgres/ddl/build.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateBuildTable represents a query to
+	// create the builds table for Vela.
+	CreateBuildTable = `
+CREATE TABLE
+IF NOT EXISTS
+builds (
+	id             SERIAL PRIMARY KEY,
+	repo_id        INTEGER,
+	number         INTEGER,
+	parent         INTEGER,
+	event          VARCHAR(250),
+	status         VARCHAR(250),
+	error          VARCHAR(500),
+	enqueued       INTEGER,
+	created        INTEGER,
+	started        INTEGER,
+	finished       INTEGER,
+	deploy         VARCHAR(500),
+	deploy_payload VARCHAR(2000),
+	clone          VARCHAR(1000),
+	source         VARCHAR(1000),
+	title          VARCHAR(1000),
+	message        VARCHAR(2000),
+	commit         VARCHAR(500),
+	sender         VARCHAR(250),
+	author         VARCHAR(250),
+	email          VARCHAR(500),
+	link           VARCHAR(1000),
+	branch         VARCHAR(500),
+	ref            VARCHAR(500),
+	base_ref       VARCHAR(500),
+	head_ref       VARCHAR(500),
+	host           VARCHAR(250),
+	runtime        VARCHAR(250),
+	distribution   VARCHAR(250),
+	timestamp      INTEGER,
+	UNIQUE(repo_id, number)
+);
+`
+
+	// CreateBuildRepoIDIndex represents a query to create an
+	// index on the builds table for the repo_id column.
+	CreateBuildRepoIDIndex = `
+CREATE INDEX
+IF NOT EXISTS
+builds_repo_id
+ON builds (repo_id);
+`
+
+	// CreateBuildStatusIndex represents a query to create an
+	// index on the builds table for the status column.
+	CreateBuildStatusIndex = `
+CREATE INDEX
+IF NOT EXISTS
+builds_status
+ON builds (status);
+`
+)

--- a/database/postgres/ddl/hook.go
+++ b/database/postgres/ddl/hook.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateHookTable represents a query to
+	// create the hooks table for Vela.
+	CreateHookTable = `
+CREATE TABLE
+IF NOT EXISTS
+hooks (
+	id        SERIAL PRIMARY KEY,
+	repo_id   INTEGER,
+	build_id  INTEGER,
+	number    INTEGER,
+	source_id VARCHAR(250),
+	created   INTEGER,
+	host      VARCHAR(250),
+	event     VARCHAR(250),
+	branch    VARCHAR(500),
+	error     VARCHAR(500),
+	status    VARCHAR(250),
+	link      VARCHAR(1000),
+	UNIQUE(repo_id, number)
+);
+`
+
+	// CreateHookRepoIDIndex represents a query to create an
+	// index on the hooks table for the repo_id column.
+	CreateHookRepoIDIndex = `
+CREATE INDEX
+IF NOT EXISTS
+hooks_repo_id
+ON hooks (repo_id);
+`
+)

--- a/database/postgres/ddl/log.go
+++ b/database/postgres/ddl/log.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateLogTable represents a query to
+	// create the logs table for Vela.
+	CreateLogTable = `
+CREATE TABLE
+IF NOT EXISTS
+logs (
+	id            SERIAL PRIMARY KEY,
+	build_id      INTEGER,
+	repo_id       INTEGER,
+	service_id    INTEGER,
+	step_id       INTEGER,
+	data          BYTEA,
+	UNIQUE(step_id),
+	UNIQUE(service_id)
+);
+`
+
+	// CreateLogBuildIDIndex represents a query to create an
+	// index on the logs table for the build_id column.
+	CreateLogBuildIDIndex = `
+CREATE INDEX
+IF NOT EXISTS
+logs_build_id
+ON logs (build_id);
+`
+)

--- a/database/postgres/ddl/repo.go
+++ b/database/postgres/ddl/repo.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateRepoTable represents a query to
+	// create the repos table for Vela.
+	CreateRepoTable = `
+CREATE TABLE
+IF NOT EXISTS
+repos (
+	id            SERIAL PRIMARY KEY,
+	user_id       INTEGER,
+	hash          VARCHAR(500),
+	org           VARCHAR(250),
+	name          VARCHAR(250),
+	full_name     VARCHAR(500),
+	link          VARCHAR(1000),
+	clone         VARCHAR(1000),
+	branch        VARCHAR(250),
+	timeout       INTEGER,
+	visibility    TEXT,
+	private       BOOLEAN,
+	trusted       BOOLEAN,
+	active        BOOLEAN,
+	allow_pull    BOOLEAN,
+	allow_push    BOOLEAN,
+	allow_deploy  BOOLEAN,
+	allow_tag     BOOLEAN,
+	allow_comment BOOLEAN,
+	UNIQUE(full_name)
+);
+`
+
+	// CreateRepoOrgNameIndex represents a query to create an
+	// index on the repos table for the org and name columns.
+	CreateRepoOrgNameIndex = `
+CREATE INDEX
+IF NOT EXISTS
+repos_org_name
+ON repos (org, name);
+`
+)

--- a/database/postgres/ddl/secret.go
+++ b/database/postgres/ddl/secret.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateSecretTable represents a query to
+	// create the secrets table for Vela.
+	CreateSecretTable = `
+CREATE TABLE
+IF NOT EXISTS
+secrets (
+	id            SERIAL PRIMARY KEY,
+	type          VARCHAR(100),
+	org           VARCHAR(250),
+	repo          VARCHAR(250),
+	team          VARCHAR(250),
+	name          VARCHAR(250),
+	value         BYTEA,
+	images        VARCHAR(1000),
+	events        VARCHAR(1000),
+	allow_command BOOLEAN,
+	UNIQUE(type, org, repo, name),
+	UNIQUE(type, org, team, name)
+);
+`
+
+	// CreateSecretTypeOrgRepo represents a query to create an
+	// index on the secrets table for the type, org and repo columns.
+	//
+	// nolint: gosec // ignore false positive
+	CreateSecretTypeOrgRepo = `
+CREATE INDEX
+IF NOT EXISTS
+secrets_type_org_repo
+ON secrets (type, org, repo);
+`
+
+	// CreateSecretTypeOrgTeam represents a query to create an
+	// index on the secrets table for the type, org and team columns.
+	//
+	// nolint: gosec // ignore false positive
+	CreateSecretTypeOrgTeam = `
+CREATE INDEX
+IF NOT EXISTS
+secrets_type_org_team
+ON secrets (type, org, team);
+`
+
+	// CreateSecretTypeOrg represents a query to create an
+	// index on the secrets table for the type, and org columns.
+	//
+	// nolint: gosec // ignore false positive
+	CreateSecretTypeOrg = `
+CREATE INDEX
+IF NOT EXISTS
+secrets_type_org
+ON secrets (type, org);
+`
+)

--- a/database/postgres/ddl/service.go
+++ b/database/postgres/ddl/service.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateServiceTable represents a query to
+	// create the services table for Vela.
+	CreateServiceTable = `
+CREATE TABLE
+IF NOT EXISTS
+services (
+	id            SERIAL PRIMARY KEY,
+	repo_id       INTEGER,
+	build_id      INTEGER,
+	number        INTEGER,
+	name          VARCHAR(250),
+	image         VARCHAR(500),
+	status        VARCHAR(250),
+	error         VARCHAR(500),
+	exit_code     INTEGER,
+	created       INTEGER,
+	started       INTEGER,
+	finished      INTEGER,
+	host          VARCHAR(250),
+	runtime       VARCHAR(250),
+	distribution  VARCHAR(250),
+	UNIQUE(build_id, number)
+);
+`
+)

--- a/database/postgres/ddl/step.go
+++ b/database/postgres/ddl/step.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateStepTable represents a query to
+	// create the steps table for Vela.
+	CreateStepTable = `
+CREATE TABLE
+IF NOT EXISTS
+steps (
+	id            SERIAL PRIMARY KEY,
+	repo_id       INTEGER,
+	build_id      INTEGER,
+	number        INTEGER,
+	name          VARCHAR(250),
+	image         VARCHAR(500),
+	stage         VARCHAR(250),
+	status        VARCHAR(250),
+	error         VARCHAR(500),
+	exit_code     INTEGER,
+	created       INTEGER,
+	started       INTEGER,
+	finished      INTEGER,
+	host          VARCHAR(250),
+	runtime       VARCHAR(250),
+	distribution  VARCHAR(250),
+	UNIQUE(build_id, number)
+);
+`
+)

--- a/database/postgres/ddl/user.go
+++ b/database/postgres/ddl/user.go
@@ -23,9 +23,9 @@ users (
 );
 `
 
-	// CreateRefreshIndex represents a query to create an
+	// CreateUserRefreshIndex represents a query to create an
 	// index on the users table for the refresh_token column.
-	CreateUsersRefreshIndex = `
+	CreateUserRefreshIndex = `
 CREATE INDEX
 IF NOT EXISTS
 users_refresh

--- a/database/postgres/ddl/user.go
+++ b/database/postgres/ddl/user.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateUserTable represents a query to
+	// create the users table for Vela.
+	CreateUserTable = `
+CREATE TABLE
+IF NOT EXISTS
+users (
+	id             SERIAL PRIMARY KEY,
+	name           VARCHAR(250),
+	refresh_token  VARCHAR(500),
+	token          VARCHAR(500),
+	hash           VARCHAR(500),
+	favorites      VARCHAR(5000),
+	active         BOOLEAN,
+	admin          BOOLEAN,
+	UNIQUE(name)
+);
+`
+
+	// CreateRefreshIndex represents a query to create an
+	// index on the users table for the refresh_token column.
+	CreateRefreshIndex = `
+CREATE INDEX
+IF NOT EXISTS
+users_refresh
+ON users (refresh_token);
+`
+)

--- a/database/postgres/ddl/user.go
+++ b/database/postgres/ddl/user.go
@@ -25,7 +25,7 @@ users (
 
 	// CreateRefreshIndex represents a query to create an
 	// index on the users table for the refresh_token column.
-	CreateRefreshIndex = `
+	CreateUsersRefreshIndex = `
 CREATE INDEX
 IF NOT EXISTS
 users_refresh

--- a/database/postgres/ddl/worker.go
+++ b/database/postgres/ddl/worker.go
@@ -22,7 +22,7 @@ workers (
 );
 `
 
-	// CreateWorkersHostnameAddressIndex represents a query to create an
+	// CreateWorkerHostnameAddressIndex represents a query to create an
 	// index on the workers table for the hostname and address columns.
 	CreateWorkerHostnameAddressIndex = `
 CREATE INDEX

--- a/database/postgres/ddl/worker.go
+++ b/database/postgres/ddl/worker.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateWorkerTable represents a query to
+	// create the workers table for Vela.
+	CreateWorkerTable = `
+CREATE TABLE
+IF NOT EXISTS
+workers (
+	id               SERIAL PRIMARY KEY,
+	hostname         VARCHAR(250),
+	address          VARCHAR(250),
+	routes           VARCHAR(1000),
+	active           BOOLEAN,
+	last_checked_in  INTEGER,
+	build_limit      INTEGER,
+	UNIQUE(hostname)
+);
+`
+
+	// CreateWorkersHostnameAddressIndex represents a query to create an
+	// index on the workers table for the hostname and address columns.
+	CreateWorkersHostnameAddressIndex = `
+CREATE INDEX
+IF NOT EXISTS
+workers_hostname_address
+ON workers (hostname, address);
+`
+)

--- a/database/postgres/ddl/worker.go
+++ b/database/postgres/ddl/worker.go
@@ -24,7 +24,7 @@ workers (
 
 	// CreateWorkersHostnameAddressIndex represents a query to create an
 	// index on the workers table for the hostname and address columns.
-	CreateWorkersHostnameAddressIndex = `
+	CreateWorkerHostnameAddressIndex = `
 CREATE INDEX
 IF NOT EXISTS
 workers_hostname_address


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-vela/server/pull/341

This adds the Postgres [data definition language (DDL)](https://en.wikipedia.org/wiki/Data_definition_language) for Vela.

All of the DDL is contained in the `github.com/go-vela/server/database/postgres/ddl` package.

The DDL was copied from [the existing `../../server/database/ddl/postgres`](https://github.com/go-vela/server/tree/master/database/ddl/postgres) old package structure.

This is an ongoing effort to make the `../../server/database` package conform to standards set in other packages.