### PR TITLE
feat(sqlite): add vela resource ddl

### DIFF
--- a/database/sqlite/ddl/build.go
+++ b/database/sqlite/ddl/build.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateBuildTable represents a query to
+	// create the builds table for Vela.
+	CreateBuildTable = `
+CREATE TABLE
+IF NOT EXISTS
+builds (
+	id             INTEGER PRIMARY KEY AUTOINCREMENT,
+	repo_id        INTEGER,
+	number         INTEGER,
+	parent         INTEGER,
+	event          TEXT,
+	status         TEXT,
+	error          TEXT,
+	enqueued       INTEGER,
+	created        INTEGER,
+	started        INTEGER,
+	finished       INTEGER,
+	deploy         TEXT,
+	deploy_payload TEXT,
+	clone          TEXT,
+	source         TEXT,
+	title          TEXT,
+	message        TEXT,
+	'commit'       TEXT,
+	sender         TEXT,
+	author         TEXT,
+	email          TEXT,
+	link           TEXT,
+	branch         TEXT,
+	ref            TEXT,
+	base_ref       TEXT,
+	head_ref       TEXT,
+	host           TEXT,
+	runtime        TEXT,
+	distribution   TEXT,
+	timestamp      INTEGER,
+	UNIQUE(repo_id, number)
+);
+`
+
+	// CreateBuildRepoIDIndex represents a query to create an
+	// index on the builds table for the repo_id column.
+	CreateBuildRepoIDIndex = `
+CREATE INDEX
+IF NOT EXISTS
+builds_repo_id
+ON builds (repo_id);
+`
+
+	// CreateBuildStatusIndex represents a query to create an
+	// index on the builds table for the status column.
+	CreateBuildStatusIndex = `
+CREATE INDEX
+IF NOT EXISTS
+builds_status
+ON builds (status);
+`
+)

--- a/database/sqlite/ddl/hook.go
+++ b/database/sqlite/ddl/hook.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateHookTable represents a query to
+	// create the hooks table for Vela.
+	CreateHookTable = `
+CREATE TABLE
+IF NOT EXISTS
+hooks (
+	id        INTEGER PRIMARY KEY AUTOINCREMENT,
+	repo_id   INTEGER,
+	build_id  INTEGER,
+	number    INTEGER,
+	source_id TEXT,
+	created   INTEGER,
+	host      TEXT,
+	event     TEXT,
+	branch    TEXT,
+	error     TEXT,
+	status    TEXT,
+	link      TEXT,
+	UNIQUE(repo_id, build_id)
+);
+`
+
+	// CreateHookRepoIDIndex represents a query to create an
+	// index on the hooks table for the repo_id column.
+	CreateHookRepoIDIndex = `
+CREATE INDEX
+IF NOT EXISTS
+hooks_repo_id
+ON hooks (repo_id);
+`
+)

--- a/database/sqlite/ddl/log.go
+++ b/database/sqlite/ddl/log.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateLogTable represents a query to
+	// create the logs table for Vela.
+	CreateLogTable = `
+CREATE TABLE
+IF NOT EXISTS
+logs (
+	id            INTEGER PRIMARY KEY AUTOINCREMENT,
+	build_id      INTEGER,
+	repo_id       INTEGER,
+	service_id    INTEGER,
+	step_id       INTEGER,
+	data          BLOB,
+	UNIQUE(step_id),
+	UNIQUE(service_id)
+);
+`
+
+	// CreateLogBuildIDIndex represents a query to create an
+	// index on the logs table for the build_id column.
+	CreateLogBuildIDIndex = `
+CREATE INDEX
+IF NOT EXISTS
+logs_build_id
+ON logs (build_id);
+`
+)

--- a/database/sqlite/ddl/repo.go
+++ b/database/sqlite/ddl/repo.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateRepoTable represents a query to
+	// create the repos table for Vela.
+	CreateRepoTable = `
+CREATE TABLE
+IF NOT EXISTS
+repos (
+	id            INTEGER PRIMARY KEY AUTOINCREMENT,
+	user_id       INTEGER,
+	hash          TEXT,
+	org           TEXT,
+	name          TEXT,
+	full_name     TEXT,
+	link          TEXT,
+	clone         TEXT,
+	branch        TEXT,
+	timeout       INTEGER,
+	visibility    TEXT,
+	private       BOOLEAN,
+	trusted       BOOLEAN,
+	active        BOOLEAN,
+	allow_pull    BOOLEAN,
+	allow_push    BOOLEAN,
+	allow_deploy  BOOLEAN,
+	allow_tag     BOOLEAN,
+	allow_comment BOOLEAN,
+	UNIQUE(full_name)
+);
+`
+
+	// CreateRepoOrgNameIndex represents a query to create an
+	// index on the repos table for the org and name columns.
+	CreateRepoOrgNameIndex = `
+CREATE INDEX
+IF NOT EXISTS
+repos_org_name
+ON repos (org, name);
+`
+)

--- a/database/sqlite/ddl/secret.go
+++ b/database/sqlite/ddl/secret.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateSecretTable represents a query to
+	// create the secrets table for Vela.
+	CreateSecretTable = `
+CREATE TABLE
+IF NOT EXISTS
+secrets (
+	id            INTEGER PRIMARY KEY AUTOINCREMENT,
+	type          TEXT,
+	org           TEXT,
+	repo          TEXT,
+	team          TEXT,
+	name          TEXT,
+	value         TEXT,
+	images        TEXT,
+	events        TEXT,
+	allow_command BOOLEAN,
+	UNIQUE(type, org, repo, name),
+	UNIQUE(type, org, team, name)
+);
+`
+
+	// CreateSecretTypeOrgRepo represents a query to create an
+	// index on the secrets table for the type, org and repo columns.
+	//
+	// nolint: gosec // ignore false positive
+	CreateSecretTypeOrgRepo = `
+CREATE INDEX
+IF NOT EXISTS
+secrets_type_org_repo
+ON secrets (type, org, repo);
+`
+
+	// CreateSecretTypeOrgTeam represents a query to create an
+	// index on the secrets table for the type, org and team columns.
+	//
+	// nolint: gosec // ignore false positive
+	CreateSecretTypeOrgTeam = `
+CREATE INDEX
+IF NOT EXISTS
+secrets_type_org_team
+ON secrets (type, org, team);
+`
+
+	// CreateSecretTypeOrg represents a query to create an
+	// index on the secrets table for the type, and org columns.
+	//
+	// nolint: gosec // ignore false positive
+	CreateSecretTypeOrg = `
+CREATE INDEX
+IF NOT EXISTS
+secrets_type_org
+ON secrets (type, org);
+`
+)

--- a/database/sqlite/ddl/service.go
+++ b/database/sqlite/ddl/service.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateServiceTable represents a query to
+	// create the services table for Vela.
+	CreateServiceTable = `
+CREATE TABLE
+IF NOT EXISTS
+services (
+	id            INTEGER PRIMARY KEY AUTOINCREMENT,
+	repo_id       INTEGER,
+	build_id      INTEGER,
+	number        INTEGER,
+	name          TEXT,
+	image         TEXT,
+	status        TEXT,
+	error         TEXT,
+	exit_code     INTEGER,
+	created       INTEGER,
+	started       INTEGER,
+	finished      INTEGER,
+	host          TEXT,
+	runtime       TEXT,
+	distribution  TEXT,
+	UNIQUE(build_id, number)
+);
+`
+)

--- a/database/sqlite/ddl/step.go
+++ b/database/sqlite/ddl/step.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateStepTable represents a query to
+	// create the steps table for Vela.
+	CreateStepTable = `
+CREATE TABLE
+IF NOT EXISTS
+steps (
+	id            INTEGER PRIMARY KEY AUTOINCREMENT,
+	repo_id       INTEGER,
+	build_id      INTEGER,
+	number        INTEGER,
+	name          TEXT,
+	image         TEXT,
+	stage         TEXT,
+	status        TEXT,
+	error         TEXT,
+	exit_code     INTEGER,
+	created       INTEGER,
+	started       INTEGER,
+	finished      INTEGER,
+	host          TEXT,
+	runtime       TEXT,
+	distribution  TEXT,
+	UNIQUE(build_id, number)
+);
+`
+)

--- a/database/sqlite/ddl/user.go
+++ b/database/sqlite/ddl/user.go
@@ -23,7 +23,7 @@ users (
 );
 `
 
-	// CreateRefreshIndex represents a query to create an
+	// CreateUserRefreshIndex represents a query to create an
 	// index on the users table for the refresh_token column.
 	CreateUserRefreshIndex = `
 CREATE INDEX

--- a/database/sqlite/ddl/user.go
+++ b/database/sqlite/ddl/user.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateUserTable represents a query to
+	// create the users table for Vela.
+	CreateUserTable = `
+CREATE TABLE
+IF NOT EXISTS
+users (
+	id             INTEGER PRIMARY KEY AUTOINCREMENT,
+	name           TEXT,
+	refresh_token  TEXT,
+	token          TEXT,
+	hash           TEXT,
+	favorites      TEXT,
+	active         BOOLEAN,
+	admin          BOOLEAN,
+	UNIQUE(name)
+);
+`
+
+	// CreateRefreshIndex represents a query to create an
+	// index on the users table for the refresh_token column.
+	CreateUserRefreshIndex = `
+CREATE INDEX
+IF NOT EXISTS
+users_refresh
+ON users (refresh_token);
+`
+)

--- a/database/sqlite/ddl/worker.go
+++ b/database/sqlite/ddl/worker.go
@@ -22,7 +22,7 @@ workers (
 );
 `
 
-	// CreateWorkersHostnameAddressIndex represents a query to create an
+	// CreateWorkerHostnameAddressIndex represents a query to create an
 	// index on the workers table for the hostname and address columns.
 	CreateWorkerHostnameAddressIndex = `
 CREATE INDEX

--- a/database/sqlite/ddl/worker.go
+++ b/database/sqlite/ddl/worker.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package ddl
+
+const (
+	// CreateWorkerTable represents a query to
+	// create the workers table for Vela.
+	CreateWorkerTable = `
+CREATE TABLE
+IF NOT EXISTS
+workers (
+	id              INTEGER PRIMARY KEY AUTOINCREMENT,
+	hostname        TEXT,
+	address         TEXT,
+	routes          TEXT,
+	active          TEXT,
+	last_checked_in	INTEGER,
+	build_limit     INTEGER,
+	UNIQUE(hostname)
+);
+`
+
+	// CreateWorkersHostnameAddressIndex represents a query to create an
+	// index on the workers table for the hostname and address columns.
+	CreateWorkerHostnameAddressIndex = `
+CREATE INDEX
+IF NOT EXISTS
+workers_hostname_address
+ON workers (hostname, address);
+`
+)


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-vela/server/pull/342

This adds the Sqlite [data definition language (DDL)](https://en.wikipedia.org/wiki/Data_definition_language) for Vela.

All of the DDL is contained in the `github.com/go-vela/server/database/sqlite/ddl` package.

The DDL was copied from [the existing `../../server/database/ddl/sqlite`](https://github.com/go-vela/server/tree/master/database/ddl/sqlite) old package structure.

This is an ongoing effort to make the `../../server/database` package conform to standards set in other packages.