### PR TITLE
feat(postgres): add Ping() to verify database connection

### DIFF
--- a/database/postgres/ping.go
+++ b/database/postgres/ping.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Ping sends a "ping" request with backoff to the database.
+func (c *client) Ping() error {
+	logrus.Trace("sending ping requests to the database")
+
+	// create a loop to attempt ping requests 5 times
+	for i := 0; i < 5; i++ {
+		// capture database/sql database from gorm database
+		//
+		// https://pkg.go.dev/gorm.io/gorm#DB.DB
+		_sql, err := c.Postgres.DB()
+		if err != nil {
+			return err
+		}
+
+		// send ping request to database
+		//
+		// https://pkg.go.dev/database/sql#DB.Ping
+		err = _sql.Ping()
+		if err != nil {
+			logrus.Debugf("unable to ping database - retrying in %v", (time.Duration(i) * time.Second))
+
+			// sleep for loop iteration in seconds
+			time.Sleep(time.Duration(i) * time.Second)
+
+			// continue to next iteration of the loop
+			continue
+		}
+
+		// able to ping database so return with no error
+		return nil
+	}
+
+	return fmt.Errorf("unable to successfully ping database")
+}

--- a/database/postgres/ping_test.go
+++ b/database/postgres/ping_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"testing"
+)
+
+func TestPostgres_Client_Ping(t *testing.T) {
+	// setup types
+	_database, err := NewTest()
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+	defer func() {
+		_sql, _ := _database.Postgres.DB()
+		_sql.Close()
+	}()
+
+	_bad, err := NewTest()
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+	// close the bad database to simulate failures to ping
+	_sql, _ := _bad.Postgres.DB()
+	_sql.Close()
+
+	// setup tests
+	tests := []struct {
+		failure  bool
+		database *client
+	}{
+		{
+			failure:  false,
+			database: _database,
+		},
+		{
+			failure:  true,
+			database: _bad,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err = test.database.Ping()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("Ping should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("Ping returned err: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-vela/server/pull/341

This adds a `Ping()` function to the `github.com/go-vela/server/database/postgres` client:

https://github.com/go-vela/server/blob/6a3ce24c9d0dbf9dda7e60c4301c20531275a781/database/postgres/ping.go#L14-L47

This function will be used to verify the ability to connect to the configured Postgres database.

This previously was a private, helper function in the old database client:

https://github.com/go-vela/server/blob/d484bc571d698e7f6b142f2023d3533d1687e699/database/client.go#L167-L189