### PR TITLE
feat(postgres): add repo database functions

### DIFF
--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -5,6 +5,7 @@
 package postgres
 
 import (
+	"database/sql/driver"
 	"testing"
 	"time"
 )
@@ -51,4 +52,17 @@ func TestPostgres_New(t *testing.T) {
 			t.Errorf("New returned err: %v", err)
 		}
 	}
+}
+
+// This will be used with the github.com/DATA-DOG/go-sqlmock
+// library to compare values that are otherwise not easily
+// compared. These typically would be values generated before
+// adding or updating them in the database.
+//
+// https://github.com/DATA-DOG/go-sqlmock#matching-arguments-like-timetime
+type AnyArgument struct{}
+
+// Match satisfies sqlmock.Argument interface.
+func (a AnyArgument) Match(v driver.Value) bool {
+	return true
 }

--- a/database/postgres/repo.go
+++ b/database/postgres/repo.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"fmt"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetRepo gets a repo by org and name from the database.
+func (c *client) GetRepo(org, name string) (*library.Repo, error) {
+	logrus.Tracef("getting repo %s/%s from the database", org, name)
+
+	// variable to store query results
+	r := new(database.Repo)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableRepo).
+		Raw(dml.SelectRepo, org, name).
+		Scan(r).Error
+	if err != nil {
+		return nil, err
+	}
+
+	// decrypt the fields for the repo
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#Repo.Decrypt
+	err = r.Decrypt(c.config.EncryptionKey)
+	if err != nil {
+		// ensures that the change is backwards compatible
+		// by logging the error instead of returning it
+		// which allows us to fetch unencrypted repos
+		logrus.Errorf("unable to decrypt repo %s/%s: %v", org, name, err)
+
+		// return the unencrypted repo
+		return r.ToLibrary(), nil
+	}
+
+	// return the decrypted repo
+	return r.ToLibrary(), nil
+}
+
+// CreateRepo creates a new repo in the database.
+func (c *client) CreateRepo(r *library.Repo) error {
+	logrus.Tracef("creating repo %s in the database", r.GetFullName())
+
+	// cast to database type
+	repo := database.RepoFromLibrary(r)
+
+	// validate the necessary fields are populated
+	err := repo.Validate()
+	if err != nil {
+		return err
+	}
+
+	// encrypt the fields for the repo
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#Repo.Encrypt
+	err = repo.Encrypt(c.config.EncryptionKey)
+	if err != nil {
+		return fmt.Errorf("unable to encrypt repo %s: %v", r.GetFullName(), err)
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableRepo).
+		Create(repo).Error
+}
+
+// UpdateRepo updates a repo in the database.
+func (c *client) UpdateRepo(r *library.Repo) error {
+	logrus.Tracef("updating repo %s in the database", r.GetFullName())
+
+	// cast to database type
+	repo := database.RepoFromLibrary(r)
+
+	// validate the necessary fields are populated
+	err := repo.Validate()
+	if err != nil {
+		return err
+	}
+
+	// encrypt the fields for the repo
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#Repo.Encrypt
+	err = repo.Encrypt(c.config.EncryptionKey)
+	if err != nil {
+		return fmt.Errorf("unable to encrypt repo %s: %v", r.GetFullName(), err)
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableRepo).
+		Save(repo).Error
+}
+
+// DeleteRepo deletes a repo by unique ID from the database.
+func (c *client) DeleteRepo(id int64) error {
+	logrus.Tracef("deleting repo %d in the database", id)
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableRepo).
+		Exec(dml.DeleteRepo, id).Error
+}

--- a/database/postgres/repo_count.go
+++ b/database/postgres/repo_count.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetRepoCount gets a count of all repos from the database.
+func (c *client) GetRepoCount() (int64, error) {
+	logrus.Trace("getting count of repos from the database")
+
+	// variable to store query results
+	var r int64
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableRepo).
+		Raw(dml.SelectReposCount).
+		Pluck("count", &r).Error
+
+	return r, err
+}
+
+// GetUserRepoCount gets a count of all repos for a specific user from the database.
+func (c *client) GetUserRepoCount(u *library.User) (int64, error) {
+	logrus.Tracef("getting count of repos for user %s in the database", u.GetName())
+
+	// variable to store query results
+	var r []int64
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableRepo).
+		Raw(dml.SelectUserReposCount, u.GetID()).
+		Pluck("count", &r).Error
+
+	return r[0], err
+}

--- a/database/postgres/repo_count_test.go
+++ b/database/postgres/repo_count_test.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetRepoCount(t *testing.T) {
+	// setup types
+	_repoOne := testRepo()
+	_repoOne.SetID(1)
+	_repoOne.SetUserID(1)
+	_repoOne.SetHash("baz")
+	_repoOne.SetOrg("foo")
+	_repoOne.SetName("bar")
+	_repoOne.SetFullName("foo/bar")
+	_repoOne.SetVisibility("public")
+
+	_repoTwo := testRepo()
+	_repoTwo.SetID(1)
+	_repoTwo.SetUserID(1)
+	_repoTwo.SetHash("baz")
+	_repoTwo.SetOrg("bar")
+	_repoTwo.SetName("foo")
+	_repoTwo.SetFullName("bar/foo")
+	_repoTwo.SetVisibility("public")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectReposCount).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    int64
+	}{
+		{
+			failure: false,
+			want:    2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetRepoCount()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetRepoCount should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetRepoCount returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetRepoCount is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetUserRepoCount(t *testing.T) {
+	// setup types
+	_repoOne := testRepo()
+	_repoOne.SetID(1)
+	_repoOne.SetUserID(1)
+	_repoOne.SetHash("baz")
+	_repoOne.SetOrg("foo")
+	_repoOne.SetName("bar")
+	_repoOne.SetFullName("foo/bar")
+	_repoOne.SetVisibility("public")
+
+	_repoTwo := testRepo()
+	_repoTwo.SetID(1)
+	_repoTwo.SetUserID(1)
+	_repoTwo.SetHash("baz")
+	_repoTwo.SetOrg("bar")
+	_repoTwo.SetName("foo")
+	_repoTwo.SetFullName("bar/foo")
+	_repoTwo.SetVisibility("public")
+
+	_user := new(library.User)
+	_user.SetID(1)
+	_user.SetName("foo")
+	_user.SetToken("bar")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectUserReposCount).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    int64
+	}{
+		{
+			failure: false,
+			want:    2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetUserRepoCount(_user)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetUserRepoCount should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetUserRepoCount returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetUserRepoCount is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/database/postgres/repo_list.go
+++ b/database/postgres/repo_list.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetRepoList gets a list of all repos from the database.
+func (c *client) GetRepoList() ([]*library.Repo, error) {
+	logrus.Trace("listing repos from the database")
+
+	// variable to store query results
+	r := new([]database.Repo)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableRepo).
+		Raw(dml.ListRepos).
+		Scan(r).Error
+	if err != nil {
+		return nil, err
+	}
+
+	// variable we want to return
+	repos := []*library.Repo{}
+	// iterate through all query results
+	for _, repo := range *r {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := repo
+
+		// decrypt the fields for the repo
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/database#Repo.Decrypt
+		err = tmp.Decrypt(c.config.EncryptionKey)
+		if err != nil {
+			// ensures that the change is backwards compatible
+			// by logging the error instead of returning it
+			// which allows us to fetch unencrypted repos
+			logrus.Errorf("unable to decrypt repo %d: %v", tmp.ID.Int64, err)
+		}
+
+		// convert query result to library type
+		repos = append(repos, tmp.ToLibrary())
+	}
+
+	return repos, nil
+}
+
+// GetOrgRepoList gets a list of all repos by org from the database.
+func (c *client) GetOrgRepoList(org string, page, perPage int) ([]*library.Repo, error) {
+	logrus.Tracef("getting repos for org %s from the database", org)
+
+	// variable to store query results
+	r := new([]database.Repo)
+
+	// calculate offset for pagination through results
+	offset := (perPage * (page - 1))
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableRepo).
+		Raw(dml.ListOrgRepos, org, perPage, offset).
+		Scan(r).Error
+	if err != nil {
+		return nil, err
+	}
+
+	// variable we want to return
+	repos := []*library.Repo{}
+	// iterate through all query results
+	for _, repo := range *r {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := repo
+
+		// decrypt the fields for the repo
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/database#Repo.Decrypt
+		err = tmp.Decrypt(c.config.EncryptionKey)
+		if err != nil {
+			// ensures that the change is backwards compatible
+			// by logging the error instead of returning it
+			// which allows us to fetch unencrypted repos
+			logrus.Errorf("unable to decrypt repo %d: %v", tmp.ID.Int64, err)
+		}
+
+		// convert query result to library type
+		repos = append(repos, tmp.ToLibrary())
+	}
+
+	return repos, nil
+}
+
+// GetUserRepoList gets a list of all repos by user ID from the database.
+func (c *client) GetUserRepoList(u *library.User, page, perPage int) ([]*library.Repo, error) {
+	logrus.Tracef("listing repos for user %s from the database", u.GetName())
+
+	// variable to store query results
+	r := new([]database.Repo)
+	// calculate offset for pagination through results
+	offset := (perPage * (page - 1))
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableRepo).
+		Raw(dml.ListUserRepos, u.GetID(), perPage, offset).
+		Scan(r).Error
+	if err != nil {
+		return nil, err
+	}
+
+	// variable we want to return
+	repos := []*library.Repo{}
+	// iterate through all query results
+	for _, repo := range *r {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := repo
+
+		// decrypt the fields for the repo
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/database#Repo.Decrypt
+		err = tmp.Decrypt(c.config.EncryptionKey)
+		if err != nil {
+			// ensures that the change is backwards compatible
+			// by logging the error instead of returning it
+			// which allows us to fetch unencrypted repos
+			logrus.Errorf("unable to decrypt repo %d: %v", tmp.ID.Int64, err)
+		}
+
+		// convert query result to library type
+		repos = append(repos, tmp.ToLibrary())
+	}
+
+	return repos, nil
+}

--- a/database/postgres/repo_list_test.go
+++ b/database/postgres/repo_list_test.go
@@ -1,0 +1,245 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetRepoList(t *testing.T) {
+	// setup types
+	_repoOne := testRepo()
+	_repoOne.SetID(1)
+	_repoOne.SetUserID(1)
+	_repoOne.SetHash("baz")
+	_repoOne.SetOrg("foo")
+	_repoOne.SetName("bar")
+	_repoOne.SetFullName("foo/bar")
+	_repoOne.SetVisibility("public")
+
+	_repoTwo := testRepo()
+	_repoTwo.SetID(1)
+	_repoTwo.SetUserID(1)
+	_repoTwo.SetHash("baz")
+	_repoTwo.SetOrg("bar")
+	_repoTwo.SetName("foo")
+	_repoTwo.SetFullName("bar/foo")
+	_repoTwo.SetVisibility("public")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "user_id", "hash", "org", "name", "full_name", "link", "clone", "branch", "timeout", "visibility", "private", "trusted", "active", "allow_pull", "allow_push", "allow_deploy", "allow_tag", "allow_comment"},
+	).AddRow(1, 1, "baz", "foo", "bar", "foo/bar", "", "", "", 0, "public", false, false, false, false, false, false, false, false).
+		AddRow(1, 1, "baz", "bar", "foo", "bar/foo", "", "", "", 0, "public", false, false, false, false, false, false, false, false)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListRepos).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Repo
+	}{
+		{
+			failure: false,
+			want:    []*library.Repo{_repoOne, _repoTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetRepoList()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetRepoList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetRepoList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetRepoList is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetOrgRepoList(t *testing.T) {
+	// setup types
+	_repoOne := testRepo()
+	_repoOne.SetID(1)
+	_repoOne.SetUserID(1)
+	_repoOne.SetHash("baz")
+	_repoOne.SetOrg("foo")
+	_repoOne.SetName("bar")
+	_repoOne.SetFullName("foo/bar")
+	_repoOne.SetVisibility("public")
+
+	_repoTwo := testRepo()
+	_repoTwo.SetID(1)
+	_repoTwo.SetUserID(1)
+	_repoTwo.SetHash("baz")
+	_repoTwo.SetOrg("foo")
+	_repoTwo.SetName("baz")
+	_repoTwo.SetFullName("foo/baz")
+	_repoTwo.SetVisibility("public")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "user_id", "hash", "org", "name", "full_name", "link", "clone", "branch", "timeout", "visibility", "private", "trusted", "active", "allow_pull", "allow_push", "allow_deploy", "allow_tag", "allow_comment"},
+	).AddRow(1, 1, "baz", "foo", "bar", "foo/bar", "", "", "", 0, "public", false, false, false, false, false, false, false, false).
+		AddRow(1, 1, "baz", "foo", "baz", "foo/baz", "", "", "", 0, "public", false, false, false, false, false, false, false, false)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListOrgRepos).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Repo
+	}{
+		{
+			failure: false,
+			want:    []*library.Repo{_repoOne, _repoTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetOrgRepoList("foo", 1, 10)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetOrgRepoList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetOrgRepoList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetOrgRepoList is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetUserRepoList(t *testing.T) {
+	// setup types
+	_repoOne := testRepo()
+	_repoOne.SetID(1)
+	_repoOne.SetUserID(1)
+	_repoOne.SetHash("baz")
+	_repoOne.SetOrg("foo")
+	_repoOne.SetName("bar")
+	_repoOne.SetFullName("foo/bar")
+	_repoOne.SetVisibility("public")
+
+	_repoTwo := testRepo()
+	_repoTwo.SetID(1)
+	_repoTwo.SetUserID(1)
+	_repoTwo.SetHash("baz")
+	_repoTwo.SetOrg("bar")
+	_repoTwo.SetName("foo")
+	_repoTwo.SetFullName("bar/foo")
+	_repoTwo.SetVisibility("public")
+
+	_user := new(library.User)
+	_user.SetID(1)
+	_user.SetName("foo")
+	_user.SetToken("bar")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "user_id", "hash", "org", "name", "full_name", "link", "clone", "branch", "timeout", "visibility", "private", "trusted", "active", "allow_pull", "allow_push", "allow_deploy", "allow_tag", "allow_comment"},
+	).AddRow(1, 1, "baz", "foo", "bar", "foo/bar", "", "", "", 0, "public", false, false, false, false, false, false, false, false).
+		AddRow(1, 1, "baz", "bar", "foo", "bar/foo", "", "", "", 0, "public", false, false, false, false, false, false, false, false)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListUserRepos).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Repo
+	}{
+		{
+			failure: false,
+			want:    []*library.Repo{_repoOne, _repoTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetUserRepoList(_user, 1, 10)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetUserRepoList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetUserRepoList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetUserRepoList is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/database/postgres/repo_test.go
+++ b/database/postgres/repo_test.go
@@ -1,0 +1,272 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetRepo(t *testing.T) {
+	// setup types
+	_repo := testRepo()
+	_repo.SetID(1)
+	_repo.SetUserID(1)
+	_repo.SetHash("baz")
+	_repo.SetOrg("foo")
+	_repo.SetName("bar")
+	_repo.SetFullName("foo/bar")
+	_repo.SetVisibility("public")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "user_id", "hash", "org", "name", "full_name", "link", "clone", "branch", "timeout", "visibility", "private", "trusted", "active", "allow_pull", "allow_push", "allow_deploy", "allow_tag", "allow_comment"},
+	).AddRow(1, 1, "baz", "foo", "bar", "foo/bar", "", "", "", 0, "public", false, false, false, false, false, false, false, false)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectRepo).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Repo
+	}{
+		{
+			failure: false,
+			want:    _repo,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetRepo("foo", "bar")
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetRepo should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetRepo returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetRepo is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_CreateRepo(t *testing.T) {
+	// setup types
+	_repo := testRepo()
+	_repo.SetID(1)
+	_repo.SetUserID(1)
+	_repo.SetHash("baz")
+	_repo.SetOrg("foo")
+	_repo.SetName("bar")
+	_repo.SetFullName("foo/bar")
+	_repo.SetVisibility("public")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"id"}).AddRow(1)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(`INSERT INTO "repos" ("user_id","hash","org","name","full_name","link","clone","branch","timeout","visibility","private","trusted","active","allow_pull","allow_push","allow_deploy","allow_tag","allow_comment","id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19) RETURNING "id"`).
+		WithArgs(1, AnyArgument{}, "foo", "bar", "foo/bar", "", "", "", AnyArgument{}, "public", false, false, false, false, false, false, false, false, 1).
+		WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Repo
+	}{
+		{
+			failure: false,
+			want:    _repo,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.CreateRepo(_repo)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("CreateRepo should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("CreateRepo returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_UpdateRepo(t *testing.T) {
+	// setup types
+	_repo := testRepo()
+	_repo.SetID(1)
+	_repo.SetUserID(1)
+	_repo.SetHash("baz")
+	_repo.SetOrg("foo")
+	_repo.SetName("bar")
+	_repo.SetFullName("foo/bar")
+	_repo.SetVisibility("public")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query
+	_mock.ExpectExec(`UPDATE "repos" SET "user_id"=$1,"hash"=$2,"org"=$3,"name"=$4,"full_name"=$5,"link"=$6,"clone"=$7,"branch"=$8,"timeout"=$9,"visibility"=$10,"private"=$11,"trusted"=$12,"active"=$13,"allow_pull"=$14,"allow_push"=$15,"allow_deploy"=$16,"allow_tag"=$17,"allow_comment"=$18 WHERE "id" = $19`).
+		WithArgs(1, AnyArgument{}, "foo", "bar", "foo/bar", "", "", "", AnyArgument{}, "public", false, false, false, false, false, false, false, false, 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.UpdateRepo(_repo)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("UpdateRepo should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("UpdateRepo returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_DeleteRepo(t *testing.T) {
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query
+	_mock.ExpectExec(dml.DeleteRepo).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.DeleteRepo(1)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("DeleteRepo should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("DeleteRepo returned err: %v", err)
+		}
+	}
+}
+
+// testRepo is a test helper function to create a
+// library Repo type with all fields set to their
+// zero values.
+func testRepo() *library.Repo {
+	i64 := int64(0)
+	str := ""
+	b := false
+
+	return &library.Repo{
+		ID:           &i64,
+		UserID:       &i64,
+		Hash:         &str,
+		Org:          &str,
+		Name:         &str,
+		FullName:     &str,
+		Link:         &str,
+		Clone:        &str,
+		Branch:       &str,
+		Timeout:      &i64,
+		Visibility:   &str,
+		Private:      &b,
+		Trusted:      &b,
+		Active:       &b,
+		AllowPull:    &b,
+		AllowPush:    &b,
+		AllowDeploy:  &b,
+		AllowTag:     &b,
+		AllowComment: &b,
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-vela/server/pull/341

This adds a series of `repo` functions to the `github.com/go-vela/server/database/postgres` client:

https://github.com/go-vela/server/blob/4e365dbf2bda64b3f958b9a7e61d353d4900824b/database/database.go#L119-L147

These functions implemented are to ensure we satisfy the existing `database` interface above.

The code for these functions were copied from the old database client code:

https://github.com/go-vela/server/blob/master/database/repo.go

> NOTE:
>
> Almost `3/4` of the LOC found in this change are related to the unit tests written for the various functions.