### PR TITLE
feat(postgres): add user database functions

### DIFF
--- a/database/postgres/user.go
+++ b/database/postgres/user.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"fmt"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetUser gets a user by unique ID from the database.
+//
+// nolint: dupl // ignore false positive of duplicate code
+func (c *client) GetUser(id int64) (*library.User, error) {
+	logrus.Tracef("getting user %d from the database", id)
+
+	// variable to store query results
+	u := new(database.User)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableUser).
+		Raw(dml.SelectUser, id).
+		Scan(u).Error
+	if err != nil {
+		return nil, err
+	}
+
+	// decrypt the fields for the user
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#User.Decrypt
+	err = u.Decrypt(c.config.EncryptionKey)
+	if err != nil {
+		// ensures that the change is backwards compatible
+		// by logging the error instead of returning it
+		// which allows us to fetch unencrypted users
+		logrus.Errorf("unable to decrypt user %d: %v", id, err)
+
+		// return the unencrypted user
+		return u.ToLibrary(), nil
+	}
+
+	// return the decrypted user
+	return u.ToLibrary(), nil
+}
+
+// GetUserName gets a user by name from the database.
+//
+// nolint: dupl // ignore false positive of duplicate code
+func (c *client) GetUserName(name string) (*library.User, error) {
+	logrus.Tracef("getting user %s from the database", name)
+
+	// variable to store query results
+	u := new(database.User)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableUser).
+		Raw(dml.SelectUserName, name).
+		Scan(u).Error
+	if err != nil {
+		return nil, err
+	}
+
+	// decrypt the fields for the user
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#User.Decrypt
+	err = u.Decrypt(c.config.EncryptionKey)
+	if err != nil {
+		// ensures that the change is backwards compatible
+		// by logging the error instead of returning it
+		// which allows us to fetch unencrypted users
+		logrus.Errorf("unable to decrypt user %s: %v", name, err)
+
+		// return the unencrypted user
+		return u.ToLibrary(), nil
+	}
+
+	// return the decrypted user
+	return u.ToLibrary(), nil
+}
+
+// CreateUser creates a new user in the database.
+func (c *client) CreateUser(u *library.User) error {
+	logrus.Tracef("creating user %s from the database", u.GetName())
+
+	// cast to database type
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#UserFromLibrary
+	user := database.UserFromLibrary(u)
+
+	// validate the necessary fields are populated
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#User.Validate
+	err := user.Validate()
+	if err != nil {
+		return err
+	}
+
+	// encrypt the fields for the user
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#User.Encrypt
+	err = user.Encrypt(c.config.EncryptionKey)
+	if err != nil {
+		return fmt.Errorf("unable to encrypt user %s: %v", u.GetName(), err)
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableUser).
+		Create(user).Error
+}
+
+// UpdateUser updates a user in the database.
+func (c *client) UpdateUser(u *library.User) error {
+	logrus.Tracef("updating user %s from the database", u.GetName())
+
+	// cast to database type
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#UserFromLibrary
+	user := database.UserFromLibrary(u)
+
+	// validate the necessary fields are populated
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#User.Validate
+	err := user.Validate()
+	if err != nil {
+		return err
+	}
+
+	// encrypt the fields for the user
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#User.Encrypt
+	err = user.Encrypt(c.config.EncryptionKey)
+	if err != nil {
+		return fmt.Errorf("unable to encrypt user %s: %v", u.GetName(), err)
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableUser).
+		Save(user).Error
+}
+
+// DeleteUser deletes a user by unique ID from the database.
+func (c *client) DeleteUser(id int64) error {
+	logrus.Tracef("deleting user %d from the database", id)
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableUser).
+		Exec(dml.DeleteUser, id).Error
+}

--- a/database/postgres/user_count.go
+++ b/database/postgres/user_count.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetUserCount gets a list of all users from the database.
+func (c *client) GetUserCount() (int64, error) {
+	logrus.Trace("getting count of users from the database")
+
+	// variable to store query results
+	var u int64
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableUser).
+		Raw(dml.SelectUsersCount).
+		Pluck("count", &u).Error
+
+	return u, err
+}

--- a/database/postgres/user_count.go
+++ b/database/postgres/user_count.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// GetUserCount gets a list of all users from the database.
+// GetUserCount gets a count of all users from the database.
 func (c *client) GetUserCount() (int64, error) {
 	logrus.Trace("getting count of users from the database")
 

--- a/database/postgres/user_count_test.go
+++ b/database/postgres/user_count_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+)
+
+func TestPostgres_Client_GetUserCount(t *testing.T) {
+	// setup types
+	_userOne := testUser()
+	_userOne.SetID(1)
+	_userOne.SetName("foo")
+	_userOne.SetToken("bar")
+	_userOne.SetHash("baz")
+
+	_userTwo := testUser()
+	_userTwo.SetID(2)
+	_userTwo.SetName("bar")
+	_userTwo.SetToken("foo")
+	_userTwo.SetHash("baz")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectUsersCount).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    int64
+	}{
+		{
+			failure: false,
+			want:    2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetUserCount()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetUserCount should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetUserCount returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetUserCount is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/database/postgres/user_list.go
+++ b/database/postgres/user_list.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetUserList gets a list of all users from the database.
+//
+// nolint: dupl // ignore false positive of duplicate code
+func (c *client) GetUserList() ([]*library.User, error) {
+	logrus.Trace("listing users from the database")
+
+	// variable to store query results
+	u := new([]database.User)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableUser).
+		Raw(dml.ListUsers).
+		Scan(u).Error
+	if err != nil {
+		return nil, err
+	}
+
+	// variable we want to return
+	users := []*library.User{}
+	// iterate through all query results
+	for _, user := range *u {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := user
+
+		// decrypt the fields for the user
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/database#User.Decrypt
+		err = tmp.Decrypt(c.config.EncryptionKey)
+		if err != nil {
+			// ensures that the change is backwards compatible
+			// by logging the error instead of returning it
+			// which allows us to fetch unencrypted users
+			logrus.Errorf("unable to decrypt user %d: %v", tmp.ID.Int64, err)
+		}
+
+		// convert query result to library type
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/database#User.ToLibrary
+		users = append(users, tmp.ToLibrary())
+	}
+
+	return users, nil
+}
+
+// GetUserLiteList gets a lite list of all users from the database.
+func (c *client) GetUserLiteList(page, perPage int) ([]*library.User, error) {
+	logrus.Trace("listing lite users from the database")
+
+	// variable to store query results
+	u := new([]database.User)
+	// calculate offset for pagination through results
+	offset := (perPage * (page - 1))
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableUser).
+		Raw(dml.ListLiteUsers, perPage, offset).
+		Scan(u).Error
+
+	// variable we want to return
+	users := []*library.User{}
+	// iterate through all query results
+	for _, user := range *u {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := user
+
+		// convert query result to library type
+		users = append(users, tmp.ToLibrary())
+	}
+
+	return users, err
+}

--- a/database/postgres/user_list_test.go
+++ b/database/postgres/user_list_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetUserList(t *testing.T) {
+	// setup types
+	_userOne := testUser()
+	_userOne.SetID(1)
+	_userOne.SetName("foo")
+	_userOne.SetToken("bar")
+	_userOne.SetHash("baz")
+
+	_userTwo := testUser()
+	_userTwo.SetID(2)
+	_userTwo.SetName("bar")
+	_userTwo.SetToken("foo")
+	_userTwo.SetHash("baz")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "name", "refresh_token", "token", "hash", "active", "admin"},
+	).AddRow(1, "foo", "", "bar", "baz", false, false).
+		AddRow(2, "bar", "", "foo", "baz", false, false)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListUsers).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.User
+	}{
+		{
+			failure: false,
+			want:    []*library.User{_userOne, _userTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetUserList()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetUserList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetUserList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetUserList is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetUserLiteList(t *testing.T) {
+	// setup types
+	_userOne := testUser()
+	_userOne.SetID(1)
+	_userOne.SetName("foo")
+
+	_userTwo := testUser()
+	_userTwo.SetID(2)
+	_userTwo.SetName("bar")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"id", "name"}).AddRow(1, "foo").AddRow(2, "bar")
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListLiteUsers).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.User
+	}{
+		{
+			failure: false,
+			want:    []*library.User{_userOne, _userTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetUserLiteList(1, 10)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetUserLiteList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetUserLiteList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetUserLiteList is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/database/postgres/user_test.go
+++ b/database/postgres/user_test.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetUser(t *testing.T) {
+	// setup types
+	_user := testUser()
+	_user.SetID(1)
+	_user.SetName("foo")
+	_user.SetToken("bar")
+	_user.SetHash("baz")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "name", "refresh_token", "token", "hash", "active", "admin"},
+	).AddRow(1, "foo", "", "bar", "baz", false, false)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectUser).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.User
+	}{
+		{
+			failure: false,
+			want:    _user,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetUser(1)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetUser should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetUser returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetUser is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_CreateUser(t *testing.T) {
+	// setup types
+	_user := testUser()
+	_user.SetID(1)
+	_user.SetName("foo")
+	_user.SetToken("bar")
+	_user.SetHash("baz")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"id"}).AddRow(1)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(`INSERT INTO "users" ("name","refresh_token","token","hash","active","admin","id") VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING "id"`).
+		WithArgs("foo", AnyArgument{}, AnyArgument{}, AnyArgument{}, false, false, 1).
+		WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.CreateUser(_user)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("CreateUser should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("CreateUser returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_UpdateUser(t *testing.T) {
+	// setup types
+	_user := testUser()
+	_user.SetID(1)
+	_user.SetName("foo")
+	_user.SetToken("bar")
+	_user.SetHash("baz")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query
+	_mock.ExpectExec(`UPDATE "users" SET "name"=$1,"refresh_token"=$2,"token"=$3,"hash"=$4,"active"=$5,"admin"=$6 WHERE "id" = $7`).
+		WithArgs("foo", AnyArgument{}, AnyArgument{}, AnyArgument{}, false, false, 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.UpdateUser(_user)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("UpdateUser should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("UpdateUser returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_DeleteUser(t *testing.T) {
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query
+	_mock.ExpectExec(dml.DeleteUser).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.DeleteUser(1)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("DeleteUser should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("DeleteUser returned err: %v", err)
+		}
+	}
+}
+
+// testUser is a test helper function to create a
+// library User type with all fields set to their
+// zero values.
+func testUser() *library.User {
+	i64 := int64(0)
+	str := ""
+	b := false
+	var arr []string
+
+	return &library.User{
+		ID:           &i64,
+		Name:         &str,
+		RefreshToken: &str,
+		Token:        &str,
+		Hash:         &str,
+		Favorites:    &arr,
+		Active:       &b,
+		Admin:        &b,
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-vela/server/pull/341

This adds a series of `user` functions to the `github.com/go-vela/server/database/postgres` client:

https://github.com/go-vela/server/blob/337b641b59daaa4cb2ae364591fcc327461277e0/database/database.go#L237-L262

These functions implemented are to ensure we satisfy the existing `database` interface above.

The code for these functions was copied from the old database client code:

https://github.com/go-vela/server/blob/master/database/user.go

> NOTE:
>
> Almost `2/3` of the LOC found in this change are related to the unit tests written for the various functions.