### PR TITLE
feat(postgres): add worker database functions

### DIFF
--- a/database/postgres/worker.go
+++ b/database/postgres/worker.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetWorker gets a worker by hostname from the database.
+func (c *client) GetWorker(hostname string) (*library.Worker, error) {
+	logrus.Tracef("getting worker %s from the database", hostname)
+
+	// variable to store query results
+	w := new(database.Worker)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableWorker).
+		Raw(dml.SelectWorker, hostname).
+		Scan(w).Error
+
+	return w.ToLibrary(), err
+}
+
+// GetWorker gets a worker by address from the database.
+func (c *client) GetWorkerByAddress(address string) (*library.Worker, error) {
+	logrus.Tracef("getting worker %s from the database", address)
+
+	// variable to store query results
+	w := new(database.Worker)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableWorker).
+		Raw(dml.SelectWorkerByAddress, address).
+		Scan(w).Error
+
+	return w.ToLibrary(), err
+}
+
+// CreateWorker creates a new worker in the database.
+func (c *client) CreateWorker(w *library.Worker) error {
+	logrus.Tracef("creating worker %s in the database", w.GetHostname())
+
+	// cast to database type
+	worker := database.WorkerFromLibrary(w)
+
+	// validate the necessary fields are populated
+	err := worker.Validate()
+	if err != nil {
+		return err
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableWorker).
+		Create(worker).Error
+}
+
+// UpdateWorker updates a worker in the database.
+func (c *client) UpdateWorker(w *library.Worker) error {
+	logrus.Tracef("updating worker %s in the database", w.GetHostname())
+
+	// cast to database type
+	worker := database.WorkerFromLibrary(w)
+
+	// validate the necessary fields are populated
+	err := worker.Validate()
+	if err != nil {
+		return err
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableWorker).
+		Save(worker).Error
+}
+
+// DeleteWorker deletes a worker by unique ID from the database.
+func (c *client) DeleteWorker(id int64) error {
+	logrus.Tracef("deleting worker %d in the database", id)
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableWorker).
+		Exec(dml.DeleteWorker, id).Error
+}

--- a/database/postgres/worker_count.go
+++ b/database/postgres/worker_count.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetWorkerCount gets a count of all workers from the database.
+func (c *client) GetWorkerCount() (int64, error) {
+	logrus.Trace("getting count of workers from the database")
+
+	// variable to store query results
+	var w int64
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableWorker).
+		Raw(dml.SelectWorkersCount).
+		Pluck("count", &w).Error
+
+	return w, err
+}

--- a/database/postgres/worker_count_test.go
+++ b/database/postgres/worker_count_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+)
+
+func TestPostgres_Client_GetWorkerCount(t *testing.T) {
+	// setup types
+	_workerOne := testWorker()
+	_workerOne.SetID(1)
+	_workerOne.SetHostname("worker_0")
+	_workerOne.SetAddress("localhost")
+	_workerOne.SetActive(true)
+
+	_workerTwo := testWorker()
+	_workerTwo.SetID(2)
+	_workerTwo.SetHostname("worker_1")
+	_workerTwo.SetAddress("localhost")
+	_workerTwo.SetActive(true)
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectWorkersCount).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    int64
+	}{
+		{
+			failure: false,
+			want:    2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetWorkerCount()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetWorkerCount should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetWorkerCount returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetWorkerCount is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/database/postgres/worker_list.go
+++ b/database/postgres/worker_list.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetWorkerList gets a list of all workers from the database.
+func (c *client) GetWorkerList() ([]*library.Worker, error) {
+	logrus.Trace("listing workers from the database")
+
+	// variable to store query results
+	w := new([]database.Worker)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableWorker).
+		Raw(dml.ListWorkers).
+		Scan(w).Error
+
+	// variable we want to return
+	workers := []*library.Worker{}
+	// iterate through all query results
+	for _, worker := range *w {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := worker
+
+		// convert query result to library type
+		workers = append(workers, tmp.ToLibrary())
+	}
+
+	return workers, err
+}

--- a/database/postgres/worker_list_test.go
+++ b/database/postgres/worker_list_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetWorkerList(t *testing.T) {
+	// setup types
+	_workerOne := testWorker()
+	_workerOne.SetID(1)
+	_workerOne.SetHostname("worker_0")
+	_workerOne.SetAddress("localhost")
+	_workerOne.SetActive(true)
+
+	_workerTwo := testWorker()
+	_workerTwo.SetID(2)
+	_workerTwo.SetHostname("worker_1")
+	_workerTwo.SetAddress("localhost")
+	_workerTwo.SetActive(true)
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "hostname", "address", "active", "last_checked_in", "build_limit"},
+	).AddRow(1, "worker_0", "localhost", true, 0, 0).
+		AddRow(2, "worker_1", "localhost", true, 0, 0)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListWorkers).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Worker
+	}{
+		{
+			failure: false,
+			want:    []*library.Worker{_workerOne, _workerTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetWorkerList()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetWorkerList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetWorkerList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetWorkerList is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/database/postgres/worker_test.go
+++ b/database/postgres/worker_test.go
@@ -1,0 +1,312 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetWorker(t *testing.T) {
+	// setup types
+	_worker := testWorker()
+	_worker.SetID(1)
+	_worker.SetHostname("worker_0")
+	_worker.SetAddress("localhost")
+	_worker.SetActive(true)
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "hostname", "address", "active", "last_checked_in", "build_limit"},
+	).AddRow(1, "worker_0", "localhost", true, 0, 0)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectWorker).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Worker
+	}{
+		{
+			failure: false,
+			want:    _worker,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetWorker("worker_0")
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetWorker should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetWorker returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetWorker is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetWorkerByAddress(t *testing.T) {
+	// setup types
+	_worker := testWorker()
+	_worker.SetID(1)
+	_worker.SetHostname("worker_0")
+	_worker.SetAddress("localhost")
+	_worker.SetActive(true)
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "hostname", "address", "active", "last_checked_in", "build_limit"},
+	).AddRow(1, "worker_0", "localhost", true, 0, 0)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectWorkerByAddress).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Worker
+	}{
+		{
+			failure: false,
+			want:    _worker,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetWorkerByAddress("localhost")
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetWorkerByAddress should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetWorkerByAddress returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetWorkerByAddress is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_CreateWorker(t *testing.T) {
+	// setup types
+	_worker := testWorker()
+	_worker.SetID(1)
+	_worker.SetHostname("worker_0")
+	_worker.SetAddress("localhost")
+	_worker.SetActive(true)
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"id"}).AddRow(1)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(`INSERT INTO "workers" ("hostname","address","active","last_checked_in","build_limit","id") VALUES ($1,$2,$3,$4,$5,$6) RETURNING "id"`).
+		WithArgs("worker_0", "localhost", true, nil, nil, 1).
+		WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.CreateWorker(_worker)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("CreateWorker should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("CreateWorker returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_UpdateWorker(t *testing.T) {
+	// setup types
+	_worker := testWorker()
+	_worker.SetID(1)
+	_worker.SetHostname("worker_0")
+	_worker.SetAddress("localhost")
+	_worker.SetActive(true)
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query  "id", "hostname", "address", "active", "last_checked_in", "build_limit"
+	_mock.ExpectExec(`UPDATE "workers" SET "hostname"=$1,"address"=$2,"active"=$3,"last_checked_in"=$4,"build_limit"=$5 WHERE "id" = $6`).
+		WithArgs("worker_0", "localhost", true, nil, nil, 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.UpdateWorker(_worker)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("UpdateWorker should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("UpdateWorker returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_DeleteWorker(t *testing.T) {
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query
+	_mock.ExpectExec(dml.DeleteWorker).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.DeleteWorker(1)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("DeleteWorker should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("DeleteWorker returned err: %v", err)
+		}
+	}
+}
+
+// testWorker is a test helper function to create a
+// library Worker type with all fields set to their
+// zero values.
+func testWorker() *library.Worker {
+	i64 := int64(0)
+	str := ""
+	b := false
+	var arr []string
+
+	return &library.Worker{
+		ID:            &i64,
+		Hostname:      &str,
+		Address:       &str,
+		Routes:        &arr,
+		Active:        &b,
+		LastCheckedIn: &i64,
+		BuildLimit:    &i64,
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-vela/server/pull/341

This adds a series of `worker` functions to the `github.com/go-vela/server/database/postgres` client:

https://github.com/go-vela/server/blob/337b641b59daaa4cb2ae364591fcc327461277e0/database/database.go#L264-L286

These functions implemented are to ensure we satisfy the existing `database` interface above.

The code for these functions was copied from the old database client code:

https://github.com/go-vela/server/blob/master/database/worker.go

> NOTE:
>
> Almost `2/3` of the LOC found in this change are related to the unit tests written for the various functions.