### PR TITLE
feat(postgres): add hook database functions

### DIFF
--- a/database/postgres/hook.go
+++ b/database/postgres/hook.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"errors"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+
+	"gorm.io/gorm"
+)
+
+// GetHook gets a hook by number and repo ID from the database.
+func (c *client) GetHook(number int, r *library.Repo) (*library.Hook, error) {
+	logrus.Tracef("getting hook %s/%d from the database", r.GetFullName(), number)
+
+	// variable to store query results
+	h := new(database.Hook)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableHook).
+		Raw(dml.SelectRepoHook, r.GetID(), number).
+		Scan(h).Error
+
+	return h.ToLibrary(), err
+}
+
+// GetLastHook gets the last hook by repo ID from the database.
+func (c *client) GetLastHook(r *library.Repo) (*library.Hook, error) {
+	logrus.Tracef("getting last hook for repo %s from the database", r.GetFullName())
+
+	// variable to store query results
+	h := new(database.Hook)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableHook).
+		Raw(dml.SelectLastRepoHook, r.GetID()).
+		Scan(h).Error
+
+	// the record will not exist if it's a new repo
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+
+	return h.ToLibrary(), err
+}
+
+// CreateHook creates a new hook in the database.
+func (c *client) CreateHook(h *library.Hook) error {
+	logrus.Tracef("creating hook %d in the database", h.GetNumber())
+
+	// cast to database type
+	hook := database.HookFromLibrary(h)
+
+	// validate the necessary fields are populated
+	err := hook.Validate()
+	if err != nil {
+		return err
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableHook).
+		Create(hook).Error
+}
+
+// UpdateHook updates a hook in the database.
+func (c *client) UpdateHook(h *library.Hook) error {
+	logrus.Tracef("updating hook %d in the database", h.GetNumber())
+
+	// cast to database type
+	hook := database.HookFromLibrary(h)
+
+	// validate the necessary fields are populated
+	err := hook.Validate()
+	if err != nil {
+		return err
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableHook).
+		Save(hook).Error
+}
+
+// DeleteHook deletes a hook by unique ID from the database.
+func (c *client) DeleteHook(id int64) error {
+	logrus.Tracef("deleting hook %d in the database", id)
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableHook).
+		Exec(dml.DeleteHook, id).Error
+}

--- a/database/postgres/hook_count.go
+++ b/database/postgres/hook_count.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetRepoHookCount gets the count of webhooks by repo ID from the database.
+func (c *client) GetRepoHookCount(r *library.Repo) (int64, error) {
+	logrus.Tracef("getting count of hooks for repo %s from the database", r.GetFullName())
+
+	// variable to store query results
+	var h int64
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableHook).
+		Raw(dml.SelectRepoHookCount, r.GetID()).
+		Pluck("count", &h).Error
+
+	return h, err
+}

--- a/database/postgres/hook_count_test.go
+++ b/database/postgres/hook_count_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+)
+
+func TestPostgres_Client_GetRepoHookCount(t *testing.T) {
+	// setup types
+	_hookOne := testHook()
+	_hookOne.SetID(1)
+	_hookOne.SetRepoID(1)
+	_hookOne.SetBuildID(1)
+	_hookOne.SetNumber(1)
+	_hookOne.SetSourceID("c8da1302-07d6-11ea-882f-4893bca275b8")
+
+	_hookTwo := testHook()
+	_hookTwo.SetID(2)
+	_hookTwo.SetRepoID(1)
+	_hookTwo.SetBuildID(2)
+	_hookTwo.SetNumber(2)
+	_hookTwo.SetSourceID("c8da1302-07d6-11ea-882f-4893bca275b8")
+
+	_repo := testRepo()
+	_repo.SetID(1)
+	_repo.SetUserID(1)
+	_repo.SetOrg("foo")
+	_repo.SetName("bar")
+	_repo.SetFullName("foo/bar")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectRepoHookCount).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    int64
+	}{
+		{
+			failure: false,
+			want:    2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetRepoHookCount(_repo)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetRepoHookCount should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetRepoHookCount returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetRepoHookCount is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/database/postgres/hook_list.go
+++ b/database/postgres/hook_list.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetHookList gets a list of all hooks from the database.
+func (c *client) GetHookList() ([]*library.Hook, error) {
+	logrus.Trace("listing hooks from the database")
+
+	// variable to store query results
+	h := new([]database.Hook)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableHook).
+		Raw(dml.ListHooks).
+		Scan(h).Error
+
+	// variable we want to return
+	hooks := []*library.Hook{}
+	// iterate through all query results
+	for _, hook := range *h {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := hook
+
+		// convert query result to library type
+		hooks = append(hooks, tmp.ToLibrary())
+	}
+
+	return hooks, err
+}
+
+// GetRepoHookList gets a list of hooks by repo ID from the database.
+func (c *client) GetRepoHookList(r *library.Repo, page, perPage int) ([]*library.Hook, error) {
+	logrus.Tracef("listing hooks for repo %s from the database", r.GetFullName())
+
+	// variable to store query results
+	h := new([]database.Hook)
+	// calculate offset for pagination through results
+	offset := (perPage * (page - 1))
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableHook).
+		Raw(dml.ListRepoHooks, r.GetID(), perPage, offset).
+		Scan(h).Error
+
+	// variable we want to return
+	hooks := []*library.Hook{}
+	// iterate through all query results
+	for _, hook := range *h {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := hook
+
+		// convert query result to library type
+		hooks = append(hooks, tmp.ToLibrary())
+	}
+
+	return hooks, err
+}

--- a/database/postgres/hook_list_test.go
+++ b/database/postgres/hook_list_test.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetHookList(t *testing.T) {
+	// setup types
+	_hookOne := testHook()
+	_hookOne.SetID(1)
+	_hookOne.SetRepoID(1)
+	_hookOne.SetBuildID(1)
+	_hookOne.SetNumber(1)
+	_hookOne.SetSourceID("c8da1302-07d6-11ea-882f-4893bca275b8")
+
+	_hookTwo := testHook()
+	_hookTwo.SetID(2)
+	_hookTwo.SetRepoID(1)
+	_hookTwo.SetBuildID(2)
+	_hookTwo.SetNumber(2)
+	_hookTwo.SetSourceID("c8da1302-07d6-11ea-882f-4893bca275b8")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "repo_id", "build_id", "number", "source_id", "created", "host", "event", "branch", "error", "status", "link"},
+	).AddRow(1, 1, 1, 1, "c8da1302-07d6-11ea-882f-4893bca275b8", 0, "", "", "", "", "", "").
+		AddRow(2, 1, 2, 2, "c8da1302-07d6-11ea-882f-4893bca275b8", 0, "", "", "", "", "", "")
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListHooks).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Hook
+	}{
+		{
+			failure: false,
+			want:    []*library.Hook{_hookOne, _hookTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetHookList()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetHookList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetHookList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetHookList is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetRepoHookList(t *testing.T) {
+	// setup types
+	_hookOne := testHook()
+	_hookOne.SetID(1)
+	_hookOne.SetRepoID(1)
+	_hookOne.SetBuildID(1)
+	_hookOne.SetNumber(1)
+	_hookOne.SetSourceID("c8da1302-07d6-11ea-882f-4893bca275b8")
+
+	_hookTwo := testHook()
+	_hookTwo.SetID(2)
+	_hookTwo.SetRepoID(1)
+	_hookTwo.SetBuildID(2)
+	_hookTwo.SetNumber(2)
+	_hookTwo.SetSourceID("c8da1302-07d6-11ea-882f-4893bca275b8")
+
+	_repo := testRepo()
+	_repo.SetID(1)
+	_repo.SetUserID(1)
+	_repo.SetOrg("foo")
+	_repo.SetName("bar")
+	_repo.SetFullName("foo/bar")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "repo_id", "build_id", "number", "source_id", "created", "host", "event", "branch", "error", "status", "link"},
+	).AddRow(1, 1, 1, 1, "c8da1302-07d6-11ea-882f-4893bca275b8", 0, "", "", "", "", "", "").
+		AddRow(2, 1, 2, 2, "c8da1302-07d6-11ea-882f-4893bca275b8", 0, "", "", "", "", "", "")
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListRepoHooks).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Hook
+	}{
+		{
+			failure: false,
+			want:    []*library.Hook{_hookOne, _hookTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetRepoHookList(_repo, 1, 10)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetRepoHookList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetRepoHookList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetRepoHookList is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/database/postgres/hook_test.go
+++ b/database/postgres/hook_test.go
@@ -1,0 +1,334 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetHook(t *testing.T) {
+	// setup types
+	_repo := testRepo()
+	_repo.SetID(1)
+	_repo.SetUserID(1)
+	_repo.SetOrg("foo")
+	_repo.SetName("bar")
+	_repo.SetFullName("foo/bar")
+
+	_hook := testHook()
+	_hook.SetID(1)
+	_hook.SetRepoID(1)
+	_hook.SetBuildID(1)
+	_hook.SetNumber(1)
+	_hook.SetSourceID("c8da1302-07d6-11ea-882f-4893bca275b8")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "repo_id", "build_id", "number", "source_id", "created", "host", "event", "branch", "error", "status", "link"},
+	).AddRow(1, 1, 1, 1, "c8da1302-07d6-11ea-882f-4893bca275b8", 0, "", "", "", "", "", "")
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectRepoHook).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Hook
+	}{
+		{
+			failure: false,
+			want:    _hook,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetHook(1, _repo)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetHook should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetHook returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetHook is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetLastHook(t *testing.T) {
+	// setup types
+	_repo := testRepo()
+	_repo.SetID(1)
+	_repo.SetUserID(1)
+	_repo.SetOrg("foo")
+	_repo.SetName("bar")
+	_repo.SetFullName("foo/bar")
+
+	_hook := testHook()
+	_hook.SetID(1)
+	_hook.SetRepoID(1)
+	_hook.SetBuildID(1)
+	_hook.SetNumber(1)
+	_hook.SetSourceID("c8da1302-07d6-11ea-882f-4893bca275b8")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "repo_id", "build_id", "number", "source_id", "created", "host", "event", "branch", "error", "status", "link"},
+	).AddRow(1, 1, 1, 1, "c8da1302-07d6-11ea-882f-4893bca275b8", 0, "", "", "", "", "", "")
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectLastRepoHook).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Hook
+	}{
+		{
+			failure: false,
+			want:    _hook,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetLastHook(_repo)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetLastHook should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetLastHook returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetLastHook is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_CreateHook(t *testing.T) {
+	// setup types
+	_hook := testHook()
+	_hook.SetID(1)
+	_hook.SetRepoID(1)
+	_hook.SetBuildID(1)
+	_hook.SetNumber(1)
+	_hook.SetSourceID("c8da1302-07d6-11ea-882f-4893bca275b8")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"id"}).AddRow(1)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(`INSERT INTO "hooks" ("repo_id","build_id","number","source_id","created","host","event","branch","error","status","link","id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12) RETURNING "id"`).
+		WithArgs(1, 1, 1, "c8da1302-07d6-11ea-882f-4893bca275b8", nil, "", "", "", "", "", "", 1).
+		WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.CreateHook(_hook)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("CreateHook should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("CreateHook returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_UpdateHook(t *testing.T) {
+	// setup types
+	_hook := testHook()
+	_hook.SetID(1)
+	_hook.SetRepoID(1)
+	_hook.SetBuildID(1)
+	_hook.SetNumber(1)
+	_hook.SetSourceID("c8da1302-07d6-11ea-882f-4893bca275b8")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query
+	_mock.ExpectExec(`UPDATE "hooks" SET "repo_id"=$1,"build_id"=$2,"number"=$3,"source_id"=$4,"created"=$5,"host"=$6,"event"=$7,"branch"=$8,"error"=$9,"status"=$10,"link"=$11 WHERE "id" = $12`).
+		WithArgs(1, 1, 1, "c8da1302-07d6-11ea-882f-4893bca275b8", nil, "", "", "", "", "", "", 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.UpdateHook(_hook)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("UpdateHook should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("UpdateHook returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_DeleteHook(t *testing.T) {
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query
+	_mock.ExpectExec(dml.DeleteHook).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.DeleteHook(1)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("DeleteHook should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("DeleteHook returned err: %v", err)
+		}
+	}
+}
+
+// testHook is a test helper function to create a
+// library Hook type with all fields set to their
+// zero values.
+func testHook() *library.Hook {
+	i := 0
+	i64 := int64(0)
+	str := ""
+
+	return &library.Hook{
+		ID:       &i64,
+		RepoID:   &i64,
+		BuildID:  &i64,
+		Number:   &i,
+		SourceID: &str,
+		Created:  &i64,
+		Host:     &str,
+		Event:    &str,
+		Branch:   &str,
+		Error:    &str,
+		Status:   &str,
+		Link:     &str,
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-vela/server/pull/341

This adds a series of `hook` functions to the `github.com/go-vela/server/database/postgres` client:

https://github.com/go-vela/server/blob/b904e4cab231ca0b54ec7ba862edb4820e5a04dc/database/database.go#L71-L96

These functions implemented are to ensure we satisfy the existing `database` interface above.

The code for these functions was copied from the old database client code:

https://github.com/go-vela/server/blob/master/database/hook.go

> NOTE:
>
> Almost `2/3` of the LOC found in this change are related to the unit tests written for the various functions.