### PR TITLE
feat(postgres): add build database functions

### DIFF
--- a/database/postgres/build.go
+++ b/database/postgres/build.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"errors"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+
+	"gorm.io/gorm"
+)
+
+// GetBuild gets a build by number and repo ID from the database.
+func (c *client) GetBuild(number int, r *library.Repo) (*library.Build, error) {
+	logrus.Tracef("getting build %s/%d from the database", r.GetFullName(), number)
+
+	// variable to store query results
+	b := new(database.Build)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableBuild).
+		Raw(dml.SelectRepoBuild, r.GetID(), number).
+		Scan(b).Error
+
+	return b.ToLibrary(), err
+}
+
+// GetLastBuild gets the last build by repo ID from the database.
+func (c *client) GetLastBuild(r *library.Repo) (*library.Build, error) {
+	logrus.Tracef("getting last build for repo %s from the database", r.GetFullName())
+
+	// variable to store query results
+	b := new(database.Build)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableBuild).
+		Raw(dml.SelectLastRepoBuild, r.GetID()).
+		Scan(b).Error
+
+	// the record will not exist if it's a new repo
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+
+	return b.ToLibrary(), err
+}
+
+// GetLastBuildByBranch gets the last build by repo ID and branch from the database.
+func (c *client) GetLastBuildByBranch(r *library.Repo, branch string) (*library.Build, error) {
+	// nolint: lll // ignore long line length due to log message
+	logrus.Tracef("getting last build for repo %s on branch %s from the database", r.GetFullName(), branch)
+
+	// variable to store query results
+	b := new(database.Build)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableBuild).
+		Raw(dml.SelectLastRepoBuildByBranch, r.GetID(), branch).
+		Scan(b).Error
+
+	// the record will not exist if it's a new repo
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+
+	return b.ToLibrary(), err
+}
+
+// GetPendingAndRunningBuilds returns the list of pending
+// and running builds within the given timeframe.
+func (c *client) GetPendingAndRunningBuilds(after string) ([]*library.BuildQueue, error) {
+	logrus.Trace("getting pending and running builds from the database")
+
+	// variable to store query results
+	b := new([]database.BuildQueue)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableBuild).
+		Raw(dml.SelectPendingAndRunningBuilds, after).
+		Scan(b).Error
+
+	// variable we want to return
+	builds := []*library.BuildQueue{}
+
+	// iterate through all query results
+	for _, build := range *b {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := build
+
+		// convert query result to library type
+		builds = append(builds, tmp.ToLibrary())
+	}
+
+	return builds, err
+}
+
+// CreateBuild creates a new build in the database.
+func (c *client) CreateBuild(b *library.Build) error {
+	logrus.Tracef("creating build %d in the database", b.GetNumber())
+
+	// cast to database type
+	build := database.BuildFromLibrary(b)
+
+	// validate the necessary fields are populated
+	err := build.Validate()
+	if err != nil {
+		return err
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableBuild).
+		Create(build.Crop()).Error
+}
+
+// UpdateBuild updates a build in the database.
+func (c *client) UpdateBuild(b *library.Build) error {
+	logrus.Tracef("updating build %d in the database", b.GetNumber())
+
+	// cast to database type
+	build := database.BuildFromLibrary(b)
+
+	// validate the necessary fields are populated
+	err := build.Validate()
+	if err != nil {
+		return err
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableBuild).
+		Save(build.Crop()).Error
+}
+
+// DeleteBuild deletes a build by unique ID from the database.
+func (c *client) DeleteBuild(id int64) error {
+	logrus.Tracef("deleting build %d in the database", id)
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableBuild).
+		Exec(dml.DeleteBuild, id).Error
+}

--- a/database/postgres/build_count.go
+++ b/database/postgres/build_count.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetBuildCount gets a count of all builds from the database.
+func (c *client) GetBuildCount() (int64, error) {
+	logrus.Trace("getting count of builds from the database")
+
+	// variable to store query results
+	var b int64
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableBuild).
+		Raw(dml.SelectBuildsCount).
+		Pluck("count", &b).Error
+
+	return b, err
+}
+
+// GetBuildCountByStatus gets a count of all builds by status from the database.
+func (c *client) GetBuildCountByStatus(status string) (int64, error) {
+	logrus.Tracef("getting count of builds by status %s from the database", status)
+
+	// variable to store query results
+	var b int64
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableBuild).
+		Raw(dml.SelectBuildsCountByStatus, status).
+		Pluck("count", &b).Error
+
+	return b, err
+}
+
+// GetOrgBuildCount gets the count of all builds by repo ID from the database.
+func (c *client) GetOrgBuildCount(org string) (int64, error) {
+	logrus.Tracef("getting count of builds for org %s from the database", org)
+
+	// variable to store query results
+	var b int64
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableBuild).
+		Raw(dml.SelectOrgBuildCount, org).
+		Pluck("count", &b).Error
+
+	return b, err
+}
+
+// GetOrgBuildCountByEvent gets the count of all builds by org name and event from the database.
+func (c *client) GetOrgBuildCountByEvent(org string, event string) (int64, error) {
+	logrus.Tracef("getting count of builds for org %s by event %s from the database", org, event)
+
+	// variable to store query results
+	var b int64
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableBuild).
+		Raw(dml.SelectOrgBuildCountByEvent, org, event).
+		Pluck("count", &b).Error
+
+	return b, err
+}
+
+// GetRepoBuildCount gets the count of all builds by repo ID from the database.
+func (c *client) GetRepoBuildCount(r *library.Repo) (int64, error) {
+	logrus.Tracef("getting count of builds for repo %s from the database", r.GetFullName())
+
+	// variable to store query results
+	var b int64
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableBuild).
+		Raw(dml.SelectRepoBuildCount, r.GetID()).
+		Pluck("count", &b).Error
+
+	return b, err
+}
+
+// GetRepoBuildCountByEvent gets the count of all builds by repo ID and event from the database.
+func (c *client) GetRepoBuildCountByEvent(r *library.Repo, event string) (int64, error) {
+	// nolint: lll // ignore long line length due to log message
+	logrus.Tracef("getting count of builds for repo %s by event %s from the database", r.GetFullName(), event)
+
+	// variable to store query results
+	var b int64
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableBuild).
+		Raw(dml.SelectRepoBuildCountByEvent, r.GetID(), event).
+		Pluck("count", &b).Error
+
+	return b, err
+}

--- a/database/postgres/build_count_test.go
+++ b/database/postgres/build_count_test.go
@@ -1,0 +1,428 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+)
+
+func TestPostgres_Client_GetBuildCount(t *testing.T) {
+	// setup types
+	_buildOne := testBuild()
+	_buildOne.SetID(1)
+	_buildOne.SetRepoID(1)
+	_buildOne.SetNumber(1)
+	_buildOne.SetDeployPayload(nil)
+
+	_buildTwo := testBuild()
+	_buildTwo.SetID(2)
+	_buildTwo.SetRepoID(1)
+	_buildTwo.SetNumber(2)
+	_buildTwo.SetDeployPayload(nil)
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectBuildsCount).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    int64
+	}{
+		{
+			failure: false,
+			want:    2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetBuildCount()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetBuildCount should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetBuildCount returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetBuildCount is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetBuildCountByStatus(t *testing.T) {
+	// setup types
+	_buildOne := testBuild()
+	_buildOne.SetID(1)
+	_buildOne.SetRepoID(1)
+	_buildOne.SetNumber(1)
+	_buildOne.SetDeployPayload(nil)
+
+	_buildTwo := testBuild()
+	_buildTwo.SetID(2)
+	_buildTwo.SetRepoID(1)
+	_buildTwo.SetNumber(2)
+	_buildTwo.SetDeployPayload(nil)
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectBuildsCountByStatus).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    int64
+	}{
+		{
+			failure: false,
+			want:    2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetBuildCountByStatus("running")
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetBuildCountByStatus should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetBuildCountByStatus returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetBuildCountByStatus is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetOrgBuildCount(t *testing.T) {
+	// setup types
+	_buildOne := testBuild()
+	_buildOne.SetID(1)
+	_buildOne.SetRepoID(1)
+	_buildOne.SetNumber(1)
+	_buildOne.SetDeployPayload(nil)
+
+	_buildTwo := testBuild()
+	_buildTwo.SetID(2)
+	_buildTwo.SetRepoID(1)
+	_buildTwo.SetNumber(2)
+	_buildTwo.SetDeployPayload(nil)
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectOrgBuildCount).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    int64
+	}{
+		{
+			failure: false,
+			want:    2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetOrgBuildCount("foo")
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetOrgBuildCount should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetOrgBuildCount returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetOrgBuildCount is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetOrgBuildCountByEvent(t *testing.T) {
+	// setup types
+	_buildOne := testBuild()
+	_buildOne.SetID(1)
+	_buildOne.SetRepoID(1)
+	_buildOne.SetNumber(1)
+	_buildOne.SetDeployPayload(nil)
+
+	_buildTwo := testBuild()
+	_buildTwo.SetID(2)
+	_buildTwo.SetRepoID(1)
+	_buildTwo.SetNumber(2)
+	_buildTwo.SetDeployPayload(nil)
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectOrgBuildCountByEvent).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    int64
+	}{
+		{
+			failure: false,
+			want:    2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetOrgBuildCountByEvent("foo", "push")
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetOrgBuildCountByEvent should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetOrgBuildCountByEvent returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetOrgBuildCountByEvent is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetRepoBuildCount(t *testing.T) {
+	// setup types
+	_buildOne := testBuild()
+	_buildOne.SetID(1)
+	_buildOne.SetRepoID(1)
+	_buildOne.SetNumber(1)
+	_buildOne.SetDeployPayload(nil)
+
+	_buildTwo := testBuild()
+	_buildTwo.SetID(2)
+	_buildTwo.SetRepoID(1)
+	_buildTwo.SetNumber(2)
+	_buildTwo.SetDeployPayload(nil)
+
+	_repo := testRepo()
+	_repo.SetID(1)
+	_repo.SetUserID(1)
+	_repo.SetHash("baz")
+	_repo.SetOrg("foo")
+	_repo.SetName("bar")
+	_repo.SetFullName("foo/bar")
+	_repo.SetVisibility("public")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectRepoBuildCount).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    int64
+	}{
+		{
+			failure: false,
+			want:    2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetRepoBuildCount(_repo)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetRepoBuildCount should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetRepoBuildCount returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetRepoBuildCount is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetRepoBuildCountByEvent(t *testing.T) {
+	// setup types
+	_buildOne := testBuild()
+	_buildOne.SetID(1)
+	_buildOne.SetRepoID(1)
+	_buildOne.SetNumber(1)
+	_buildOne.SetDeployPayload(nil)
+
+	_buildTwo := testBuild()
+	_buildTwo.SetID(2)
+	_buildTwo.SetRepoID(1)
+	_buildTwo.SetNumber(2)
+	_buildTwo.SetDeployPayload(nil)
+
+	_repo := testRepo()
+	_repo.SetID(1)
+	_repo.SetUserID(1)
+	_repo.SetHash("baz")
+	_repo.SetOrg("foo")
+	_repo.SetName("bar")
+	_repo.SetFullName("foo/bar")
+	_repo.SetVisibility("public")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectRepoBuildCountByEvent).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    int64
+	}{
+		{
+			failure: false,
+			want:    2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetRepoBuildCountByEvent(_repo, "push")
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetRepoBuildCountByEvent should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetRepoBuildCountByEvent returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetRepoBuildCountByEvent is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/database/postgres/build_list.go
+++ b/database/postgres/build_list.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetBuildList gets a list of all builds from the database.
+func (c *client) GetBuildList() ([]*library.Build, error) {
+	logrus.Trace("listing builds from the database")
+
+	// variable to store query results
+	b := new([]database.Build)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableBuild).
+		Raw(dml.ListBuilds).
+		Scan(b).Error
+
+	// variable we want to return
+	builds := []*library.Build{}
+	// iterate through all query results
+	for _, build := range *b {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := build
+
+		// convert query result to library type
+		builds = append(builds, tmp.ToLibrary())
+	}
+
+	return builds, err
+}
+
+// GetOrgBuildList gets a list of all builds by org name from the database.
+func (c *client) GetOrgBuildList(org string, page, perPage int) ([]*library.Build, int64, error) {
+	logrus.Tracef("listing builds for org %s from the database", org)
+
+	// variable to store query results
+	b := new([]database.Build)
+	builds := []*library.Build{}
+	count := int64(0)
+
+	// // count the results
+	count, err := c.GetOrgBuildCount(org)
+
+	if err != nil {
+		return builds, 0, err
+	}
+
+	// short-circuit if there are no results
+	if count == 0 {
+		return builds, 0, nil
+	}
+
+	// calculate offset for pagination through results
+	offset := (perPage * (page - 1))
+
+	// send query to the database and store result in variable
+	err = c.Postgres.
+		Table(constants.TableBuild).
+		Raw(dml.ListOrgBuilds, org, perPage, offset).
+		Scan(b).Error
+
+	// iterate through all query results
+	for _, build := range *b {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := build
+
+		// convert query result to library type
+		builds = append(builds, tmp.ToLibrary())
+	}
+
+	return builds, count, err
+}
+
+// GetOrgBuildListByEvent gets a list of all builds by org name and event type from the database.
+//
+// nolint: lll // ignore long line length due to variable names
+func (c *client) GetOrgBuildListByEvent(org, event string, page, perPage int) ([]*library.Build, int64, error) {
+	logrus.Tracef("listing builds for org %s by event %s from the database", org, event)
+
+	// variables to store query results
+	b := new([]database.Build)
+	builds := []*library.Build{}
+	count := int64(0)
+
+	// count the results
+	count, err := c.GetOrgBuildCountByEvent(org, event)
+	if err != nil {
+		return builds, 0, err
+	}
+
+	// short-circuit if there are no results
+	if count == 0 {
+		return builds, 0, nil
+	}
+
+	// calculate offset for pagination through results
+	offset := (perPage * (page - 1))
+
+	// send query to the database and store result in variable
+	err = c.Postgres.
+		Table(constants.TableBuild).
+		Raw(dml.ListOrgBuildsByEvent, org, event, perPage, offset).
+		Scan(b).Error
+
+	// iterate through all query results
+	for _, build := range *b {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := build
+
+		// convert query result to library type
+		builds = append(builds, tmp.ToLibrary())
+	}
+
+	return builds, count, err
+}
+
+// GetRepoBuildList gets a list of all builds by repo ID from the database.
+//
+// nolint: lll // ignore long line length due to variable names
+func (c *client) GetRepoBuildList(r *library.Repo, page, perPage int) ([]*library.Build, int64, error) {
+	logrus.Tracef("listing builds for repo %s from the database", r.GetFullName())
+
+	// variable to store query results
+	b := new([]database.Build)
+	builds := []*library.Build{}
+	count := int64(0)
+
+	// count the results
+	count, err := c.GetRepoBuildCount(r)
+	if err != nil {
+		return builds, 0, err
+	}
+
+	// short-circuit if there are no results
+	if count == 0 {
+		return builds, 0, nil
+	}
+
+	// calculate offset for pagination through results
+	offset := (perPage * (page - 1))
+
+	// send query to the database and store result in variable
+	err = c.Postgres.
+		Table(constants.TableBuild).
+		Raw(dml.ListRepoBuilds, r.GetID(), perPage, offset).
+		Scan(b).Error
+
+	// iterate through all query results
+	for _, build := range *b {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := build
+
+		// convert query result to library type
+		builds = append(builds, tmp.ToLibrary())
+	}
+
+	return builds, count, err
+}
+
+// GetRepoBuildListByEvent gets a list of all builds by repo ID and event type from the database.
+//
+// nolint: lll // ignore long line length due to variable names
+func (c *client) GetRepoBuildListByEvent(r *library.Repo, event string, page, perPage int) ([]*library.Build, int64, error) {
+	logrus.Tracef("listing builds for repo %s by event %s from the database", r.GetFullName(), event)
+
+	// variables to store query results
+	b := new([]database.Build)
+	builds := []*library.Build{}
+	count := int64(0)
+
+	// count the results
+	count, err := c.GetRepoBuildCountByEvent(r, event)
+	if err != nil {
+		return builds, 0, err
+	}
+
+	// short-circuit if there are no results
+	if count == 0 {
+		return builds, 0, nil
+	}
+
+	// calculate offset for pagination through results
+	offset := (perPage * (page - 1))
+
+	// send query to the database and store result in variable
+	err = c.Postgres.
+		Table(constants.TableBuild).
+		Raw(dml.ListRepoBuildsByEvent, r.GetID(), event, perPage, offset).
+		Scan(b).Error
+
+	// iterate through all query results
+	for _, build := range *b {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := build
+
+		// convert query result to library type
+		builds = append(builds, tmp.ToLibrary())
+	}
+
+	return builds, count, err
+}

--- a/database/postgres/build_list_test.go
+++ b/database/postgres/build_list_test.go
@@ -1,0 +1,402 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetBuildList(t *testing.T) {
+	// setup types
+	_buildOne := testBuild()
+	_buildOne.SetID(1)
+	_buildOne.SetRepoID(1)
+	_buildOne.SetNumber(1)
+	_buildOne.SetDeployPayload(nil)
+
+	_buildTwo := testBuild()
+	_buildTwo.SetID(2)
+	_buildTwo.SetRepoID(1)
+	_buildTwo.SetNumber(2)
+	_buildTwo.SetDeployPayload(nil)
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "repo_id", "number", "parent", "event", "status", "error", "enqueued", "created", "started", "finished", "deploy", "deploy_payload", "clone", "source", "title", "message", "commit", "sender", "author", "email", "link", "branch", "ref", "base_ref", "head_ref", "host", "runtime", "distribution", "timestamp"},
+	).AddRow(1, 1, 1, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0).
+		AddRow(2, 1, 2, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListBuilds).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Build
+	}{
+		{
+			failure: false,
+			want:    []*library.Build{_buildOne, _buildTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetBuildList()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetBuildList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetBuildList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetBuildList is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetOrgBuildList(t *testing.T) {
+	// setup types
+	_buildOne := testBuild()
+	_buildOne.SetID(1)
+	_buildOne.SetRepoID(1)
+	_buildOne.SetNumber(1)
+	_buildOne.SetDeployPayload(nil)
+
+	_buildTwo := testBuild()
+	_buildTwo.SetID(2)
+	_buildTwo.SetRepoID(1)
+	_buildTwo.SetNumber(2)
+	_buildTwo.SetDeployPayload(nil)
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectOrgBuildCount).WillReturnRows(_rows)
+
+	// create expected return in mock
+	_rows = sqlmock.NewRows(
+		[]string{"id", "repo_id", "number", "parent", "event", "status", "error", "enqueued", "created", "started", "finished", "deploy", "deploy_payload", "clone", "source", "title", "message", "commit", "sender", "author", "email", "link", "branch", "ref", "base_ref", "head_ref", "host", "runtime", "distribution", "timestamp"},
+	).AddRow(1, 1, 1, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0).
+		AddRow(2, 1, 2, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListOrgBuilds).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Build
+	}{
+		{
+			failure: false,
+			want:    []*library.Build{_buildOne, _buildTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, _, err := _database.GetOrgBuildList("foo", 1, 10)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetOrgBuildList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetOrgBuildList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetOrgBuildList is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetOrgBuildListByEvent(t *testing.T) {
+	// setup types
+	_buildOne := testBuild()
+	_buildOne.SetID(1)
+	_buildOne.SetRepoID(1)
+	_buildOne.SetNumber(1)
+	_buildOne.SetDeployPayload(nil)
+
+	_buildTwo := testBuild()
+	_buildTwo.SetID(2)
+	_buildTwo.SetRepoID(1)
+	_buildTwo.SetNumber(2)
+	_buildTwo.SetDeployPayload(nil)
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectOrgBuildCountByEvent).WillReturnRows(_rows)
+
+	// create expected return in mock
+	_rows = sqlmock.NewRows(
+		[]string{"id", "repo_id", "number", "parent", "event", "status", "error", "enqueued", "created", "started", "finished", "deploy", "deploy_payload", "clone", "source", "title", "message", "commit", "sender", "author", "email", "link", "branch", "ref", "base_ref", "head_ref", "host", "runtime", "distribution", "timestamp"},
+	).AddRow(1, 1, 1, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0).
+		AddRow(2, 1, 2, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListOrgBuildsByEvent).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Build
+	}{
+		{
+			failure: false,
+			want:    []*library.Build{_buildOne, _buildTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, _, err := _database.GetOrgBuildListByEvent("foo", "push", 1, 10)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetOrgBuildListByEvent should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetOrgBuildListByEvent returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetOrgBuildListByEvent is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetRepoBuildList(t *testing.T) {
+	// setup types
+	_buildOne := testBuild()
+	_buildOne.SetID(1)
+	_buildOne.SetRepoID(1)
+	_buildOne.SetNumber(1)
+	_buildOne.SetDeployPayload(nil)
+
+	_buildTwo := testBuild()
+	_buildTwo.SetID(2)
+	_buildTwo.SetRepoID(1)
+	_buildTwo.SetNumber(2)
+	_buildTwo.SetDeployPayload(nil)
+
+	_repo := testRepo()
+	_repo.SetID(1)
+	_repo.SetUserID(1)
+	_repo.SetHash("baz")
+	_repo.SetOrg("foo")
+	_repo.SetName("bar")
+	_repo.SetFullName("foo/bar")
+	_repo.SetVisibility("public")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectRepoBuildCount).WillReturnRows(_rows)
+
+	// create expected return in mock
+	_rows = sqlmock.NewRows(
+		[]string{"id", "repo_id", "number", "parent", "event", "status", "error", "enqueued", "created", "started", "finished", "deploy", "deploy_payload", "clone", "source", "title", "message", "commit", "sender", "author", "email", "link", "branch", "ref", "base_ref", "head_ref", "host", "runtime", "distribution", "timestamp"},
+	).AddRow(1, 1, 1, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0).
+		AddRow(2, 1, 2, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListRepoBuilds).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Build
+	}{
+		{
+			failure: false,
+			want:    []*library.Build{_buildOne, _buildTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, _, err := _database.GetRepoBuildList(_repo, 1, 10)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetRepoBuildList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetRepoBuildList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetRepoBuildList is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetRepoBuildListByEvent(t *testing.T) {
+	// setup types
+	_buildOne := testBuild()
+	_buildOne.SetID(1)
+	_buildOne.SetRepoID(1)
+	_buildOne.SetNumber(1)
+	_buildOne.SetDeployPayload(nil)
+
+	_buildTwo := testBuild()
+	_buildTwo.SetID(2)
+	_buildTwo.SetRepoID(1)
+	_buildTwo.SetNumber(2)
+	_buildTwo.SetDeployPayload(nil)
+
+	_repo := testRepo()
+	_repo.SetID(1)
+	_repo.SetUserID(1)
+	_repo.SetHash("baz")
+	_repo.SetOrg("foo")
+	_repo.SetName("bar")
+	_repo.SetFullName("foo/bar")
+	_repo.SetVisibility("public")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectRepoBuildCountByEvent).WillReturnRows(_rows)
+
+	// create expected return in mock
+	_rows = sqlmock.NewRows(
+		[]string{"id", "repo_id", "number", "parent", "event", "status", "error", "enqueued", "created", "started", "finished", "deploy", "deploy_payload", "clone", "source", "title", "message", "commit", "sender", "author", "email", "link", "branch", "ref", "base_ref", "head_ref", "host", "runtime", "distribution", "timestamp"},
+	).AddRow(1, 1, 1, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0).
+		AddRow(2, 1, 2, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListRepoBuildsByEvent).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Build
+	}{
+		{
+			failure: false,
+			want:    []*library.Build{_buildOne, _buildTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, _, err := _database.GetRepoBuildListByEvent(_repo, "push", 1, 10)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetRepoBuildListByEvent should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetRepoBuildListByEvent returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetRepoBuildListByEvent is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/database/postgres/build_test.go
+++ b/database/postgres/build_test.go
@@ -1,0 +1,505 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetBuild(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_build.SetID(1)
+	_build.SetRepoID(1)
+	_build.SetNumber(1)
+	_build.SetDeployPayload(nil)
+
+	_repo := testRepo()
+	_repo.SetID(1)
+	_repo.SetUserID(1)
+	_repo.SetHash("baz")
+	_repo.SetOrg("foo")
+	_repo.SetName("bar")
+	_repo.SetFullName("foo/bar")
+	_repo.SetVisibility("public")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "repo_id", "number", "parent", "event", "status", "error", "enqueued", "created", "started", "finished", "deploy", "deploy_payload", "clone", "source", "title", "message", "commit", "sender", "author", "email", "link", "branch", "ref", "base_ref", "head_ref", "host", "runtime", "distribution", "timestamp"},
+	).AddRow(1, 1, 1, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectRepoBuild).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Build
+	}{
+		{
+			failure: false,
+			want:    _build,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetBuild(1, _repo)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetBuild should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetBuild returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetBuild is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetLastBuild(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_build.SetID(1)
+	_build.SetRepoID(1)
+	_build.SetNumber(1)
+	_build.SetDeployPayload(nil)
+
+	_repo := testRepo()
+	_repo.SetID(1)
+	_repo.SetUserID(1)
+	_repo.SetHash("baz")
+	_repo.SetOrg("foo")
+	_repo.SetName("bar")
+	_repo.SetFullName("foo/bar")
+	_repo.SetVisibility("public")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "repo_id", "number", "parent", "event", "status", "error", "enqueued", "created", "started", "finished", "deploy", "deploy_payload", "clone", "source", "title", "message", "commit", "sender", "author", "email", "link", "branch", "ref", "base_ref", "head_ref", "host", "runtime", "distribution", "timestamp"},
+	).AddRow(1, 1, 1, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectLastRepoBuild).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Build
+	}{
+		{
+			failure: false,
+			want:    _build,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetLastBuild(_repo)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetLastBuild should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetLastBuild returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetLastBuild is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetLastBuildByBranch(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_build.SetID(1)
+	_build.SetRepoID(1)
+	_build.SetNumber(1)
+	_build.SetDeployPayload(nil)
+
+	_repo := testRepo()
+	_repo.SetID(1)
+	_repo.SetUserID(1)
+	_repo.SetHash("baz")
+	_repo.SetOrg("foo")
+	_repo.SetName("bar")
+	_repo.SetFullName("foo/bar")
+	_repo.SetVisibility("public")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "repo_id", "number", "parent", "event", "status", "error", "enqueued", "created", "started", "finished", "deploy", "deploy_payload", "clone", "source", "title", "message", "commit", "sender", "author", "email", "link", "branch", "ref", "base_ref", "head_ref", "host", "runtime", "distribution", "timestamp"},
+	).AddRow(1, 1, 1, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectLastRepoBuildByBranch).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Build
+	}{
+		{
+			failure: false,
+			want:    _build,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetLastBuildByBranch(_repo, "master")
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetLastBuildByBranch should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetLastBuildByBranch returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetLastBuildByBranch is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetPendingAndRunningBuilds(t *testing.T) {
+	// setup types
+	_buildOne := new(library.BuildQueue)
+	_buildOne.SetCreated(0)
+	_buildOne.SetFullName("")
+	_buildOne.SetNumber(1)
+	_buildOne.SetStatus("")
+
+	_buildTwo := new(library.BuildQueue)
+	_buildTwo.SetCreated(0)
+	_buildTwo.SetFullName("")
+	_buildTwo.SetNumber(2)
+	_buildTwo.SetStatus("")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"created", "full_name", "number", "status"}).
+		AddRow(0, "", 1, "").
+		AddRow(0, "", 2, "")
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectPendingAndRunningBuilds).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.BuildQueue
+	}{
+		{
+			failure: false,
+			want:    []*library.BuildQueue{_buildOne, _buildTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetPendingAndRunningBuilds("")
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetPendingAndRunningBuilds should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetPendingAndRunningBuilds returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetPendingAndRunningBuilds is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_CreateBuild(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_build.SetID(1)
+	_build.SetRepoID(1)
+	_build.SetNumber(1)
+
+	_repo := testRepo()
+	_repo.SetID(1)
+	_repo.SetUserID(1)
+	_repo.SetHash("baz")
+	_repo.SetOrg("foo")
+	_repo.SetName("bar")
+	_repo.SetFullName("foo/bar")
+	_repo.SetVisibility("public")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"id"}).AddRow(1)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(`INSERT INTO "builds" ("repo_id","number","parent","event","status","error","enqueued","created","started","finished","deploy","deploy_payload","clone","source","title","message","commit","sender","author","email","link","branch","ref","base_ref","head_ref","host","runtime","distribution","id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29) RETURNING "id"`).
+		WithArgs(1, 1, nil, "", "", "", nil, nil, nil, nil, "", AnyArgument{}, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 1).
+		WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.CreateBuild(_build)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("CreateBuild should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("CreateBuild returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_UpdateBuild(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_build.SetID(1)
+	_build.SetRepoID(1)
+	_build.SetNumber(1)
+
+	_repo := testRepo()
+	_repo.SetID(1)
+	_repo.SetUserID(1)
+	_repo.SetHash("baz")
+	_repo.SetOrg("foo")
+	_repo.SetName("bar")
+	_repo.SetFullName("foo/bar")
+	_repo.SetVisibility("public")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query
+	_mock.ExpectExec(`UPDATE "builds" SET "repo_id"=$1,"number"=$2,"parent"=$3,"event"=$4,"status"=$5,"error"=$6,"enqueued"=$7,"created"=$8,"started"=$9,"finished"=$10,"deploy"=$11,"deploy_payload"=$12,"clone"=$13,"source"=$14,"title"=$15,"message"=$16,"commit"=$17,"sender"=$18,"author"=$19,"email"=$20,"link"=$21,"branch"=$22,"ref"=$23,"base_ref"=$24,"head_ref"=$25,"host"=$26,"runtime"=$27,"distribution"=$28 WHERE "id" = $29`).
+		WithArgs(1, 1, nil, "", "", "", nil, nil, nil, nil, "", AnyArgument{}, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.UpdateBuild(_build)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("UpdateBuild should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("UpdateBuild returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_DeleteBuild(t *testing.T) {
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query
+	_mock.ExpectExec(dml.DeleteBuild).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.DeleteBuild(1)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("DeleteBuild should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("DeleteBuild returned err: %v", err)
+		}
+	}
+}
+
+// testBuild is a test helper function to create a
+// library Build type with all fields set to their
+// zero values.
+func testBuild() *library.Build {
+	i64 := int64(0)
+	i := 0
+	str := ""
+
+	return &library.Build{
+		ID:           &i64,
+		RepoID:       &i64,
+		Number:       &i,
+		Parent:       &i,
+		Event:        &str,
+		Status:       &str,
+		Error:        &str,
+		Enqueued:     &i64,
+		Created:      &i64,
+		Started:      &i64,
+		Finished:     &i64,
+		Deploy:       &str,
+		Clone:        &str,
+		Source:       &str,
+		Title:        &str,
+		Message:      &str,
+		Commit:       &str,
+		Sender:       &str,
+		Author:       &str,
+		Email:        &str,
+		Link:         &str,
+		Branch:       &str,
+		Ref:          &str,
+		BaseRef:      &str,
+		HeadRef:      &str,
+		Host:         &str,
+		Runtime:      &str,
+		Distribution: &str,
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-vela/server/pull/341

This adds a series of `build` functions to the `github.com/go-vela/server/database/postgres` client:

https://github.com/go-vela/server/blob/b904e4cab231ca0b54ec7ba862edb4820e5a04dc/database/database.go#L14-L69

These functions implemented are to ensure we satisfy the existing `database` interface above.

The code for these functions was copied from the old database client code:

https://github.com/go-vela/server/blob/master/database/build.go

> NOTE:
>
> Almost `3/4` of the LOC found in this change are related to the unit tests written for the various functions.