### PR TITLE
feat(postgres): add secret database functions

### DIFF
--- a/database/postgres/secret.go
+++ b/database/postgres/secret.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"fmt"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetSecret gets a secret by type, org, name (repo or team) and secret name from the database.
+func (c *client) GetSecret(t, o, n, secretName string) (*library.Secret, error) {
+	logrus.Tracef("getting %s secret %s for %s/%s from the database", t, secretName, o, n)
+
+	var err error
+
+	// variable to store query results
+	s := new(database.Secret)
+
+	// send query to the database and store result in variable
+	switch t {
+	case constants.SecretOrg:
+		err = c.Postgres.
+			Table(constants.TableSecret).
+			Raw(dml.SelectOrgSecret, o, secretName).
+			Scan(s).Error
+	case constants.SecretRepo:
+		err = c.Postgres.
+			Table(constants.TableSecret).
+			Raw(dml.SelectRepoSecret, o, n, secretName).
+			Scan(s).Error
+	case constants.SecretShared:
+		err = c.Postgres.
+			Table(constants.TableSecret).
+			Raw(dml.SelectSharedSecret, o, n, secretName).
+			Scan(s).Error
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// decrypt the value for the secret
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#Secret.Decrypt
+	err = s.Decrypt(c.config.EncryptionKey)
+	if err != nil {
+		// ensures that the change is backwards compatible
+		// by logging the error instead of returning it
+		// which allows us to fetch unencrypted secrets
+		logrus.Errorf("unable to decrypt %s secret %s for %s/%s: %v", t, secretName, o, n, err)
+
+		// return the unencrypted secret
+		return s.ToLibrary(), nil
+	}
+
+	// return the decrypted secret
+	return s.ToLibrary(), nil
+}
+
+// CreateSecret creates a new secret in the database.
+func (c *client) CreateSecret(s *library.Secret) error {
+	logrus.Tracef("creating %s secret %s in the database", s.GetType(), s.GetName())
+
+	// cast to database type
+	secret := database.SecretFromLibrary(s)
+
+	// validate the necessary fields are populated
+	err := secret.Validate()
+	if err != nil {
+		return err
+	}
+
+	// encrypt the value for the secret
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#Secret.Encrypt
+	err = secret.Encrypt(c.config.EncryptionKey)
+	if err != nil {
+		return fmt.Errorf("unable to encrypt secret %s: %v", s.GetName(), err)
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableSecret).
+		Create(secret).Error
+}
+
+// UpdateSecret updates a secret in the database.
+func (c *client) UpdateSecret(s *library.Secret) error {
+	logrus.Tracef("updating %s secret %s in the database", s.GetType(), s.GetName())
+
+	// cast to database type
+	secret := database.SecretFromLibrary(s)
+
+	// validate the necessary fields are populated
+	err := secret.Validate()
+	if err != nil {
+		return err
+	}
+
+	// encrypt the value for the secret
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#Secret.Encrypt
+	err = secret.Encrypt(c.config.EncryptionKey)
+	if err != nil {
+		return fmt.Errorf("unable to encrypt secret %s: %v", s.GetName(), err)
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableSecret).
+		Save(secret).Error
+}
+
+// DeleteSecret deletes a secret by unique ID from the database.
+func (c *client) DeleteSecret(id int64) error {
+	logrus.Tracef("Deleting secret %d from the database", id)
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableSecret).
+		Exec(dml.DeleteSecret, id).Error
+}

--- a/database/postgres/secret_count.go
+++ b/database/postgres/secret_count.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetTypeSecretCount gets a count of secrets by type,
+// owner, and name (repo or team) from the database.
+func (c *client) GetTypeSecretCount(t, o, n string) (int64, error) {
+	logrus.Tracef("getting count of %s secrets for %s/%s from the database", t, o, n)
+
+	var err error
+
+	// variable to store query results
+	var s int64
+
+	// send query to the database and store result in variable
+	switch t {
+	case constants.SecretOrg:
+		err = c.Postgres.
+			Table(constants.TableSecret).
+			Raw(dml.SelectOrgSecretsCount, o).
+			Pluck("count", &s).Error
+	case constants.SecretRepo:
+		err = c.Postgres.
+			Table(constants.TableSecret).
+			Raw(dml.SelectRepoSecretsCount, o, n).
+			Pluck("count", &s).Error
+	case constants.SecretShared:
+		err = c.Postgres.
+			Table(constants.TableSecret).
+			Raw(dml.SelectSharedSecretsCount, o, n).
+			Pluck("count", &s).Error
+	}
+
+	return s, err
+}

--- a/database/postgres/secret_count_test.go
+++ b/database/postgres/secret_count_test.go
@@ -1,0 +1,224 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+)
+
+func TestPostgres_Client_GetTypeSecretCount_Org(t *testing.T) {
+	// setup types
+	_secretOne := testSecret()
+	_secretOne.SetID(1)
+	_secretOne.SetOrg("foo")
+	_secretOne.SetRepo("*")
+	_secretOne.SetName("baz")
+	_secretOne.SetValue("foob")
+	_secretOne.SetType("org")
+
+	_secretTwo := testSecret()
+	_secretTwo.SetID(1)
+	_secretTwo.SetOrg("foo")
+	_secretTwo.SetRepo("*")
+	_secretTwo.SetName("foob")
+	_secretTwo.SetValue("baz")
+	_secretTwo.SetType("org")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectOrgSecretsCount).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    int64
+	}{
+		{
+			failure: false,
+			want:    2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetTypeSecretCount("org", "foo", "*")
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetTypeSecretCount should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetTypeSecretCount returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetTypeSecretCount is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetTypeSecretCount_Repo(t *testing.T) {
+	// setup types
+	_secretOne := testSecret()
+	_secretOne.SetID(1)
+	_secretOne.SetOrg("foo")
+	_secretOne.SetRepo("bar")
+	_secretOne.SetName("baz")
+	_secretOne.SetValue("foob")
+	_secretOne.SetType("repo")
+
+	_secretTwo := testSecret()
+	_secretTwo.SetID(1)
+	_secretTwo.SetOrg("foo")
+	_secretTwo.SetRepo("bar")
+	_secretTwo.SetName("foob")
+	_secretTwo.SetValue("baz")
+	_secretTwo.SetType("repo")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectRepoSecretsCount).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    int64
+	}{
+		{
+			failure: false,
+			want:    2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetTypeSecretCount("repo", "foo", "bar")
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetTypeSecretCount should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetTypeSecretCount returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetTypeSecretCount is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetTypeSecretCount_Shared(t *testing.T) {
+	// setup types
+	_secretOne := testSecret()
+	_secretOne.SetID(1)
+	_secretOne.SetOrg("foo")
+	_secretOne.SetTeam("bar")
+	_secretOne.SetName("baz")
+	_secretOne.SetValue("foob")
+	_secretOne.SetType("shared")
+
+	_secretTwo := testSecret()
+	_secretTwo.SetID(1)
+	_secretTwo.SetOrg("foo")
+	_secretTwo.SetTeam("bar")
+	_secretTwo.SetName("foob")
+	_secretTwo.SetValue("baz")
+	_secretTwo.SetType("shared")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectSharedSecretsCount).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    int64
+	}{
+		{
+			failure: false,
+			want:    2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetTypeSecretCount("shared", "foo", "bar")
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetTypeSecretCount should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetTypeSecretCount returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetTypeSecretCount is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/database/postgres/secret_list.go
+++ b/database/postgres/secret_list.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetSecretList gets a list of all secrets from the database.
+//
+// nolint: dupl // ignore false positive of duplicate code
+func (c *client) GetSecretList() ([]*library.Secret, error) {
+	logrus.Tracef("listing secrets from the database")
+
+	// variable to store query results
+	s := new([]database.Secret)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableSecret).
+		Raw(dml.ListSecrets).
+		Scan(s).Error
+	if err != nil {
+		return nil, err
+	}
+
+	// variable we want to return
+	secrets := []*library.Secret{}
+	// iterate through all query results
+	for _, secret := range *s {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := secret
+
+		// decrypt the value for the secret
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/database#Secret.Decrypt
+		err = tmp.Decrypt(c.config.EncryptionKey)
+		if err != nil {
+			// ensures that the change is backwards compatible
+			// by logging the error instead of returning it
+			// which allows us to fetch unencrypted secrets
+			logrus.Errorf("unable to decrypt secret %d: %v", tmp.ID.Int64, err)
+		}
+
+		// convert query result to library type
+		secrets = append(secrets, tmp.ToLibrary())
+	}
+
+	return secrets, nil
+}
+
+// GetTypeSecretList gets a list of secrets by type,
+// owner, and name (repo or team) from the database.
+func (c *client) GetTypeSecretList(t, o, n string, page, perPage int) ([]*library.Secret, error) {
+	logrus.Tracef("listing %s secrets for %s/%s from the database", t, o, n)
+
+	var err error
+
+	// variable to store query results
+	s := new([]database.Secret)
+	// calculate offset for pagination through results
+	offset := (perPage * (page - 1))
+
+	// send query to the database and store result in variable
+	switch t {
+	case constants.SecretOrg:
+		err = c.Postgres.
+			Table(constants.TableSecret).
+			Raw(dml.ListOrgSecrets, o, perPage, offset).
+			Scan(s).Error
+	case constants.SecretRepo:
+		err = c.Postgres.
+			Table(constants.TableSecret).
+			Raw(dml.ListRepoSecrets, o, n, perPage, offset).
+			Scan(s).Error
+	case constants.SecretShared:
+		err = c.Postgres.
+			Table(constants.TableSecret).
+			Raw(dml.ListSharedSecrets, o, n, perPage, offset).
+			Scan(s).Error
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// variable we want to return
+	secrets := []*library.Secret{}
+	// iterate through all query results
+	for _, secret := range *s {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := secret
+
+		// decrypt the value for the secret
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/database#Secret.Decrypt
+		err = tmp.Decrypt(c.config.EncryptionKey)
+		if err != nil {
+			// ensures that the change is backwards compatible
+			// by logging the error instead of returning it
+			// which allows us to fetch unencrypted secrets
+			logrus.Errorf("unable to decrypt secret %d: %v", tmp.ID.Int64, err)
+		}
+
+		// convert query result to library type
+		secrets = append(secrets, tmp.ToLibrary())
+	}
+
+	return secrets, nil
+}

--- a/database/postgres/secret_list_test.go
+++ b/database/postgres/secret_list_test.go
@@ -1,0 +1,307 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetSecretList(t *testing.T) {
+	// setup types
+	_secretOne := testSecret()
+	_secretOne.SetID(1)
+	_secretOne.SetOrg("foo")
+	_secretOne.SetRepo("bar")
+	_secretOne.SetName("baz")
+	_secretOne.SetValue("foob")
+	_secretOne.SetType("repo")
+
+	_secretTwo := testSecret()
+	_secretTwo.SetID(1)
+	_secretTwo.SetOrg("foo")
+	_secretTwo.SetRepo("bar")
+	_secretTwo.SetName("foob")
+	_secretTwo.SetValue("baz")
+	_secretTwo.SetType("repo")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "type", "org", "repo", "team", "name", "value", "images", "events", "allow_command"},
+	).AddRow(1, "repo", "foo", "bar", "", "baz", "foob", nil, nil, false).
+		AddRow(1, "repo", "foo", "bar", "", "foob", "baz", nil, nil, false)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListSecrets).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Secret
+	}{
+		{
+			failure: false,
+			want:    []*library.Secret{_secretOne, _secretTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetSecretList()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetSecretList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetSecretList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetSecretList is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetTypeSecretList_Org(t *testing.T) {
+	// setup types
+	_secretOne := testSecret()
+	_secretOne.SetID(1)
+	_secretOne.SetOrg("foo")
+	_secretOne.SetRepo("*")
+	_secretOne.SetName("baz")
+	_secretOne.SetValue("bar")
+	_secretOne.SetType("org")
+
+	_secretTwo := testSecret()
+	_secretTwo.SetID(1)
+	_secretTwo.SetOrg("foo")
+	_secretTwo.SetRepo("*")
+	_secretTwo.SetName("bar")
+	_secretTwo.SetValue("baz")
+	_secretTwo.SetType("org")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "type", "org", "repo", "team", "name", "value", "images", "events", "allow_command"},
+	).AddRow(1, "org", "foo", "*", "", "baz", "bar", nil, nil, false).
+		AddRow(1, "org", "foo", "*", "", "bar", "baz", nil, nil, false)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListOrgSecrets).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Secret
+	}{
+		{
+			failure: false,
+			want:    []*library.Secret{_secretOne, _secretTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetTypeSecretList("org", "foo", "*", 1, 10)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetTypeSecretList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetTypeSecretList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetTypeSecretList is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetTypeSecretList_Repo(t *testing.T) {
+	// setup types
+	_secretOne := testSecret()
+	_secretOne.SetID(1)
+	_secretOne.SetOrg("foo")
+	_secretOne.SetRepo("bar")
+	_secretOne.SetName("baz")
+	_secretOne.SetValue("foob")
+	_secretOne.SetType("repo")
+
+	_secretTwo := testSecret()
+	_secretTwo.SetID(1)
+	_secretTwo.SetOrg("foo")
+	_secretTwo.SetRepo("bar")
+	_secretTwo.SetName("foob")
+	_secretTwo.SetValue("baz")
+	_secretTwo.SetType("repo")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "type", "org", "repo", "team", "name", "value", "images", "events", "allow_command"},
+	).AddRow(1, "repo", "foo", "bar", "", "baz", "foob", nil, nil, false).
+		AddRow(1, "repo", "foo", "bar", "", "foob", "baz", nil, nil, false)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListRepoSecrets).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Secret
+	}{
+		{
+			failure: false,
+			want:    []*library.Secret{_secretOne, _secretTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetTypeSecretList("repo", "foo", "bar", 1, 10)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetTypeSecretList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetTypeSecretList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetTypeSecretList is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetTypeSecretList_Shared(t *testing.T) {
+	// setup types
+	_secretOne := testSecret()
+	_secretOne.SetID(1)
+	_secretOne.SetOrg("foo")
+	_secretOne.SetTeam("bar")
+	_secretOne.SetName("baz")
+	_secretOne.SetValue("foob")
+	_secretOne.SetType("shared")
+
+	_secretTwo := testSecret()
+	_secretTwo.SetID(1)
+	_secretTwo.SetOrg("foo")
+	_secretTwo.SetTeam("bar")
+	_secretTwo.SetName("foob")
+	_secretTwo.SetValue("baz")
+	_secretTwo.SetType("shared")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "type", "org", "repo", "team", "name", "value", "images", "events", "allow_command"},
+	).AddRow(1, "shared", "foo", "", "bar", "baz", "foob", nil, nil, false).
+		AddRow(1, "shared", "foo", "", "bar", "foob", "baz", nil, nil, false)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListSharedSecrets).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Secret
+	}{
+		{
+			failure: false,
+			want:    []*library.Secret{_secretOne, _secretTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetTypeSecretList("shared", "foo", "bar", 1, 10)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetTypeSecretList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetTypeSecretList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetTypeSecretList is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/database/postgres/secret_test.go
+++ b/database/postgres/secret_test.go
@@ -1,0 +1,390 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetSecret_Org(t *testing.T) {
+	// setup types
+	_secret := testSecret()
+	_secret.SetID(1)
+	_secret.SetOrg("foo")
+	_secret.SetRepo("*")
+	_secret.SetName("bar")
+	_secret.SetValue("baz")
+	_secret.SetType("org")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "type", "org", "repo", "team", "name", "value", "images", "events", "allow_command"},
+	).AddRow(1, "org", "foo", "*", "", "bar", "baz", nil, nil, false)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectOrgSecret).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Secret
+	}{
+		{
+			failure: false,
+
+			want: _secret,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetSecret("org", "foo", "*", "bar")
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetSecret should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetSecret returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetSecret is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetSecret_Repo(t *testing.T) {
+	// setup types
+	_secret := testSecret()
+	_secret.SetID(1)
+	_secret.SetOrg("foo")
+	_secret.SetRepo("bar")
+	_secret.SetName("baz")
+	_secret.SetValue("foob")
+	_secret.SetType("repo")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "type", "org", "repo", "team", "name", "value", "images", "events", "allow_command"},
+	).AddRow(1, "repo", "foo", "bar", "", "baz", "foob", nil, nil, false)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectRepoSecret).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Secret
+	}{
+		{
+			failure: false,
+
+			want: _secret,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetSecret("repo", "foo", "bar", "baz")
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetSecret should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetSecret returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetSecret is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetSecret_Shared(t *testing.T) {
+	// setup types
+	_secret := testSecret()
+	_secret.SetID(1)
+	_secret.SetOrg("foo")
+	_secret.SetTeam("bar")
+	_secret.SetName("baz")
+	_secret.SetValue("foob")
+	_secret.SetType("shared")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "type", "org", "repo", "team", "name", "value", "images", "events", "allow_command"},
+	).AddRow(1, "shared", "foo", "", "bar", "baz", "foob", nil, nil, false)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectSharedSecret).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Secret
+	}{
+		{
+			failure: false,
+
+			want: _secret,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetSecret("shared", "foo", "bar", "baz")
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetSecret should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetSecret returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetSecret is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_CreateSecret(t *testing.T) {
+	// setup types
+	_secret := testSecret()
+	_secret.SetID(1)
+	_secret.SetOrg("foo")
+	_secret.SetRepo("bar")
+	_secret.SetName("baz")
+	_secret.SetValue("foob")
+	_secret.SetType("repo")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"id"}).AddRow(1)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(`INSERT INTO "secrets" ("org","repo","team","name","value","type","allow_command","id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING "id"`).
+		WithArgs("foo", "bar", "", "baz", AnyArgument{}, "repo", false, 1).
+		WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.CreateSecret(_secret)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("CreateSecret should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("CreateSecret returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_UpdateSecret(t *testing.T) {
+	// setup types
+	_secret := testSecret()
+	_secret.SetID(1)
+	_secret.SetOrg("foo")
+	_secret.SetRepo("bar")
+	_secret.SetName("baz")
+	_secret.SetValue("foob")
+	_secret.SetType("repo")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query
+	_mock.ExpectExec(`UPDATE "secrets" SET "org"=$1,"repo"=$2,"team"=$3,"name"=$4,"value"=$5,"type"=$6,"allow_command"=$7 WHERE "id" = $8`).
+		WithArgs("foo", "bar", "", "baz", AnyArgument{}, "repo", false, 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.UpdateSecret(_secret)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("UpdateSecret should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("UpdateSecret returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_DeleteSecret(t *testing.T) {
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query
+	_mock.ExpectExec(dml.DeleteSecret).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.DeleteSecret(1)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("DeleteSecret should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("DeleteSecret returned err: %v", err)
+		}
+	}
+}
+
+// testSecret is a test helper function to create a
+// library Secret type with all fields set to their
+// zero values.
+func testSecret() *library.Secret {
+	i64 := int64(0)
+	str := ""
+	booL := false
+	var arr []string
+
+	return &library.Secret{
+		ID:           &i64,
+		Org:          &str,
+		Repo:         &str,
+		Team:         &str,
+		Name:         &str,
+		Value:        &str,
+		Type:         &str,
+		Images:       &arr,
+		Events:       &arr,
+		AllowCommand: &booL,
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-vela/server/pull/341

This adds a series of `secret` functions to the `github.com/go-vela/server/database/postgres` client:

https://github.com/go-vela/server/blob/b904e4cab231ca0b54ec7ba862edb4820e5a04dc/database/database.go#L149-L171

These functions implemented are to ensure we satisfy the existing `database` interface above.

The code for these functions was copied from the old database client code:

https://github.com/go-vela/server/blob/master/database/secret.go

> NOTE:
>
> Almost `3/4` of the LOC found in this change are related to the unit tests written for the various functions.