### PR TITLE
feat(postgres): add log database functions

### DIFF
--- a/database/postgres/log.go
+++ b/database/postgres/log.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"fmt"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetBuildLogs gets a collection of logs for a build by unique ID from the database.
+func (c *client) GetBuildLogs(id int64) ([]*library.Log, error) {
+	logrus.Tracef("listing logs for build %d from the database", id)
+
+	// variable to store query results
+	l := new([]database.Log)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableLog).
+		Raw(dml.ListBuildLogs, id).
+		Scan(l).Error
+	if err != nil {
+		return nil, err
+	}
+
+	// variable we want to return
+	logs := []*library.Log{}
+	// iterate through all query results
+	for _, log := range *l {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := log
+
+		// decompress log data for the step
+		//
+		// https://pkg.go.dev/github.com/go-vela/types/database#Log.Decompress
+		err = tmp.Decompress()
+		if err != nil {
+			// ensures that the change is backwards compatible
+			// by logging the error instead of returning it
+			// which allows us to fetch uncompressed logs
+			logrus.Errorf("unable to decompress logs for build %d: %v", id, err)
+		}
+
+		// convert query result to library type
+		logs = append(logs, tmp.ToLibrary())
+	}
+
+	return logs, nil
+}
+
+// GetStepLog gets a log by unique ID from the database.
+//
+// nolint: dupl // ignore similar code with service
+func (c *client) GetStepLog(id int64) (*library.Log, error) {
+	logrus.Tracef("getting log for step %d from the database", id)
+
+	// variable to store query results
+	l := new(database.Log)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableLog).
+		Raw(dml.SelectStepLog, id).
+		Scan(l).Error
+	if err != nil {
+		return l.ToLibrary(), err
+	}
+
+	// decompress log data for the step
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#Log.Decompress
+	err = l.Decompress()
+	if err != nil {
+		// ensures that the change is backwards compatible
+		// by logging the error instead of returning it
+		// which allows us to fetch uncompressed logs
+		logrus.Errorf("unable to decompress logs for step %d: %v", id, err)
+
+		// return the uncompressed log
+		return l.ToLibrary(), nil
+	}
+
+	// return the decompressed log
+	return l.ToLibrary(), nil
+}
+
+// GetServiceLog gets a log by unique ID from the database.
+//
+// nolint: dupl // ignore similar code with step
+func (c *client) GetServiceLog(id int64) (*library.Log, error) {
+	logrus.Tracef("getting log for service %d from the database", id)
+
+	// variable to store query results
+	l := new(database.Log)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableLog).
+		Raw(dml.SelectServiceLog, id).
+		Scan(l).Error
+	if err != nil {
+		return l.ToLibrary(), err
+	}
+
+	// decompress log data for the service
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#Log.Decompress
+	err = l.Decompress()
+	if err != nil {
+		// ensures that the change is backwards compatible
+		// by logging the error instead of returning it
+		// which allowing us to fetch uncompressed logs
+		logrus.Errorf("unable to decompress logs for service %d: %v", id, err)
+
+		// return the uncompressed log
+		return l.ToLibrary(), nil
+	}
+
+	// return the decompressed log
+	return l.ToLibrary(), nil
+}
+
+// CreateLog creates a new log in the database.
+//
+// nolint: dupl // ignore false positive of duplicate code
+func (c *client) CreateLog(l *library.Log) error {
+	// check if the log entry is for a step
+	if l.GetStepID() > 0 {
+		logrus.Tracef("creating log for step %d in the database", l.GetStepID())
+	} else {
+		logrus.Tracef("creating log for service %d in the database", l.GetServiceID())
+	}
+
+	// cast to database type
+	log := database.LogFromLibrary(l)
+
+	// validate the necessary fields are populated
+	err := log.Validate()
+	if err != nil {
+		return err
+	}
+
+	// compress log data for the resource
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#Log.Compress
+	err = log.Compress(c.config.CompressionLevel)
+	if err != nil {
+		return fmt.Errorf("unable to compress logs for step %d: %v", l.GetStepID(), err)
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableLog).
+		Create(log).Error
+}
+
+// UpdateLog updates a log in the database.
+//
+// nolint: dupl // ignore false positive of duplicate code
+func (c *client) UpdateLog(l *library.Log) error {
+	// check if the log entry is for a step
+	if l.GetStepID() > 0 {
+		logrus.Tracef("updating log for step %d in the database", l.GetStepID())
+	} else {
+		logrus.Tracef("updating log for service %d in the database", l.GetServiceID())
+	}
+
+	// cast to database type
+	log := database.LogFromLibrary(l)
+
+	// validate the necessary fields are populated
+	err := log.Validate()
+	if err != nil {
+		return err
+	}
+
+	// compress log data for the resource
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#Log.Compress
+	err = log.Compress(c.config.CompressionLevel)
+	if err != nil {
+		return fmt.Errorf("unable to compress logs for step %d: %v", l.GetStepID(), err)
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableLog).
+		Save(log).Error
+}
+
+// DeleteLog deletes a log by unique ID from the database.
+func (c *client) DeleteLog(id int64) error {
+	logrus.Tracef("deleting log %d from the database", id)
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableLog).
+		Exec(dml.DeleteLog, id).Error
+}

--- a/database/postgres/log_test.go
+++ b/database/postgres/log_test.go
@@ -1,0 +1,383 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetBuildLogs(t *testing.T) {
+	// setup types
+	_logOne := testLog()
+	_logOne.SetID(1)
+	_logOne.SetStepID(1)
+	_logOne.SetBuildID(1)
+	_logOne.SetRepoID(1)
+	_logOne.SetData([]byte{})
+
+	_logTwo := testLog()
+	_logTwo.SetID(2)
+	_logTwo.SetServiceID(1)
+	_logTwo.SetBuildID(1)
+	_logTwo.SetRepoID(1)
+	_logTwo.SetData([]byte{})
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "build_id", "repo_id", "service_id", "step_id", "data"},
+	).AddRow(1, 1, 1, 0, 1, []byte{}).AddRow(2, 1, 1, 1, 0, []byte{})
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListBuildLogs).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Log
+	}{
+		{
+			failure: false,
+			want:    []*library.Log{_logOne, _logTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetBuildLogs(1)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetBuildLogs should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetBuildLogs returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetBuildLogs is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetStepLog(t *testing.T) {
+	// setup types
+	_log := testLog()
+	_log.SetID(1)
+	_log.SetStepID(1)
+	_log.SetBuildID(1)
+	_log.SetRepoID(1)
+	_log.SetData([]byte{})
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "build_id", "repo_id", "service_id", "step_id", "data"},
+	).AddRow(1, 1, 1, 0, 1, []byte{})
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectStepLog).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Log
+	}{
+		{
+			failure: false,
+			want:    _log,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetStepLog(1)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetStepLog should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetStepLog returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetStepLog is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetServiceLog(t *testing.T) {
+	// setup types
+	_log := testLog()
+	_log.SetID(1)
+	_log.SetServiceID(1)
+	_log.SetBuildID(1)
+	_log.SetRepoID(1)
+	_log.SetData([]byte{})
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "build_id", "repo_id", "service_id", "step_id", "data"},
+	).AddRow(1, 1, 1, 1, 0, []byte{})
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectServiceLog).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Log
+	}{
+		{
+			failure: false,
+			want:    _log,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetServiceLog(1)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetServiceLog should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetServiceLog returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetServiceLog is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_CreateLog(t *testing.T) {
+	// setup types
+	_log := testLog()
+	_log.SetID(1)
+	_log.SetStepID(1)
+	_log.SetBuildID(1)
+	_log.SetRepoID(1)
+	_log.SetData([]byte{})
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"id"}).AddRow(1)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(`INSERT INTO "logs" ("build_id","repo_id","service_id","step_id","data","id") VALUES ($1,$2,$3,$4,$5,$6) RETURNING "id"`).
+		WithArgs(1, 1, nil, 1, AnyArgument{}, 1).
+		WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.CreateLog(_log)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("CreateLog should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("CreateLog returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_UpdateLog(t *testing.T) {
+	// setup types
+	_log := testLog()
+	_log.SetID(1)
+	_log.SetStepID(1)
+	_log.SetBuildID(1)
+	_log.SetRepoID(1)
+	_log.SetData([]byte{})
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query
+	_mock.ExpectExec(`UPDATE "logs" SET "build_id"=$1,"repo_id"=$2,"service_id"=$3,"step_id"=$4,"data"=$5 WHERE "id" = $6`).
+		WithArgs(1, 1, nil, 1, AnyArgument{}, 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.UpdateLog(_log)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("UpdateLog should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("UpdateLog returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_DeleteLog(t *testing.T) {
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query
+	_mock.ExpectExec(dml.DeleteLog).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.DeleteLog(1)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("DeleteLog should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("DeleteLog returned err: %v", err)
+		}
+	}
+}
+
+// testLog is a test helper function to create a
+// library Log type with all fields set to their
+// zero values.
+func testLog() *library.Log {
+	i64 := int64(0)
+	b := []byte{}
+
+	return &library.Log{
+		ID:        &i64,
+		BuildID:   &i64,
+		RepoID:    &i64,
+		ServiceID: &i64,
+		StepID:    &i64,
+		Data:      &b,
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-vela/server/pull/341

This adds a series of `log` functions to the `github.com/go-vela/server/database/postgres` client:

https://github.com/go-vela/server/blob/15ee929684fba1a4fbd5c21e45d7cfe55adfc8b7/database/database.go#L98-L117

These functions implemented are to ensure we satisfy the existing `database` interface above.

The code for these functions was copied from the old database client code:

https://github.com/go-vela/server/blob/master/database/log.go

> NOTE:
>
> Almost `2/3` of the LOC found in this change are related to the unit tests written for the various functions.