### PR TITLE
feat(postgres): add step database functions

### DIFF
--- a/database/postgres/step.go
+++ b/database/postgres/step.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetStep gets a step by number and build ID from the database.
+func (c *client) GetStep(number int, b *library.Build) (*library.Step, error) {
+	logrus.Tracef("getting step %d for build %d from the database", number, b.GetNumber())
+
+	// variable to store query results
+	s := new(database.Step)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableStep).
+		Raw(dml.SelectBuildStep, b.GetID(), number).
+		Scan(s).Error
+
+	return s.ToLibrary(), err
+}
+
+// CreateStep creates a new step in the database.
+func (c *client) CreateStep(s *library.Step) error {
+	logrus.Tracef("creating step %s in the database", s.GetName())
+
+	// cast to database type
+	step := database.StepFromLibrary(s)
+
+	// validate the necessary fields are populated
+	err := step.Validate()
+	if err != nil {
+		return err
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableStep).
+		Create(step).Error
+}
+
+// UpdateStep updates a step in the database.
+func (c *client) UpdateStep(s *library.Step) error {
+	logrus.Tracef("updating step %s in the database", s.GetName())
+
+	// cast to database type
+	step := database.StepFromLibrary(s)
+
+	// validate the necessary fields are populated
+	err := step.Validate()
+	if err != nil {
+		return err
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableStep).
+		Save(step).Error
+}
+
+// DeleteStep deletes a step by unique ID from the database.
+func (c *client) DeleteStep(id int64) error {
+	logrus.Tracef("deleting step %d from the database", id)
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableStep).
+		Exec(dml.DeleteStep, id).Error
+}

--- a/database/postgres/step_count.go
+++ b/database/postgres/step_count.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetBuildStepCount gets a count of all steps by build ID from the database.
+func (c *client) GetBuildStepCount(b *library.Build) (int64, error) {
+	logrus.Tracef("getting count of steps for build %d from the database", b.GetNumber())
+
+	// variable to store query results
+	var s int64
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableStep).
+		Raw(dml.SelectBuildStepsCount, b.GetID()).
+		Pluck("count", &s).Error
+
+	return s, err
+}
+
+// GetStepImageCount gets a count of all step images
+// and the count of their occurrence in the database.
+func (c *client) GetStepImageCount() (map[string]float64, error) {
+	logrus.Tracef("getting count of all images for steps from the database")
+
+	type imageCount struct {
+		Image string
+		Count int
+	}
+
+	// variable to store query results
+	images := new([]imageCount)
+	counts := make(map[string]float64)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableStep).
+		Raw(dml.SelectStepImagesCount).
+		Scan(images).Error
+
+	for _, image := range *images {
+		counts[image.Image] = float64(image.Count)
+	}
+
+	return counts, err
+}
+
+// GetStepStatusCount gets a list of all step statuses
+// and the count of their occurrence in the database.
+func (c *client) GetStepStatusCount() (map[string]float64, error) {
+	logrus.Trace("getting count of all statuses for steps from the database")
+
+	type statusCount struct {
+		Status string
+		Count  int
+	}
+
+	// variable to store query results
+	s := new([]statusCount)
+	counts := map[string]float64{
+		"pending": 0,
+		"failure": 0,
+		"killed":  0,
+		"running": 0,
+		"success": 0,
+	}
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableStep).
+		Raw(dml.SelectStepStatusesCount).
+		Scan(s).Error
+
+	for _, status := range *s {
+		counts[status.Status] = float64(status.Count)
+	}
+
+	return counts, err
+}

--- a/database/postgres/step_count_test.go
+++ b/database/postgres/step_count_test.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+)
+
+func TestPostgres_Client_GetBuildStepCount(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_build.SetID(1)
+	_build.SetRepoID(1)
+	_build.SetNumber(1)
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectBuildStepsCount).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    int64
+	}{
+		{
+			failure: false,
+			want:    2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetBuildStepCount(_build)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetBuildStepCount should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetBuildStepCount returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetBuildStepCount is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetStepImageCount(t *testing.T) {
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"image", "count"}).AddRow("foo", 0)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectStepImagesCount).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    map[string]float64
+	}{
+		{
+			failure: false,
+			want:    map[string]float64{"foo": 0},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetStepImageCount()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetStepImageCount should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetStepImageCount returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetStepImageCount is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetStepStatusCount(t *testing.T) {
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"status", "count"}).
+		AddRow("failure", 0).
+		AddRow("killed", 0).
+		AddRow("pending", 0).
+		AddRow("running", 0).
+		AddRow("success", 0)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectStepStatusesCount).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    map[string]float64
+	}{
+		{
+			failure: false,
+			want: map[string]float64{
+				"pending": 0,
+				"failure": 0,
+				"killed":  0,
+				"running": 0,
+				"success": 0,
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetStepStatusCount()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetStepStatusCount should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetStepStatusCount returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetStepStatusCount is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/database/postgres/step_list.go
+++ b/database/postgres/step_list.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+// nolint: dupl // ignore false positive of duplicate code
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetStepList gets a list of all steps from the database.
+func (c *client) GetStepList() ([]*library.Step, error) {
+	logrus.Trace("listing steps from the database")
+
+	// variable to store query results
+	s := new([]database.Step)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableStep).
+		Raw(dml.ListSteps).
+		Scan(s).Error
+
+	// variable we want to return
+	steps := []*library.Step{}
+	// iterate through all query results
+	for _, step := range *s {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := step
+
+		// convert query result to library type
+		steps = append(steps, tmp.ToLibrary())
+	}
+
+	return steps, err
+}
+
+// GetBuildStepList gets a list of steps by build ID from the database.
+func (c *client) GetBuildStepList(b *library.Build, page, perPage int) ([]*library.Step, error) {
+	logrus.Tracef("listing steps for build %d from the database", b.GetNumber())
+
+	// variable to store query results
+	s := new([]database.Step)
+	// calculate offset for pagination through results
+	offset := (perPage * (page - 1))
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableStep).
+		Raw(dml.ListBuildSteps, b.GetID(), perPage, offset).
+		Scan(s).Error
+
+	// variable we want to return
+	steps := []*library.Step{}
+	// iterate through all query results
+	for _, step := range *s {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := step
+
+		// convert query result to library type
+		steps = append(steps, tmp.ToLibrary())
+	}
+
+	return steps, err
+}

--- a/database/postgres/step_list_test.go
+++ b/database/postgres/step_list_test.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetStepList(t *testing.T) {
+	// setup types
+	_stepOne := testStep()
+	_stepOne.SetID(1)
+	_stepOne.SetRepoID(1)
+	_stepOne.SetBuildID(1)
+	_stepOne.SetNumber(1)
+	_stepOne.SetName("foo")
+	_stepOne.SetImage("bar")
+
+	_stepTwo := testStep()
+	_stepTwo.SetID(2)
+	_stepTwo.SetRepoID(1)
+	_stepTwo.SetBuildID(1)
+	_stepTwo.SetNumber(1)
+	_stepTwo.SetName("bar")
+	_stepTwo.SetImage("foo")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "repo_id", "build_id", "number", "name", "image", "stage", "status", "error", "exit_code", "created", "started", "finished", "host", "runtime", "distribution"},
+	).AddRow(1, 1, 1, 1, "foo", "bar", "", "", "", 0, 0, 0, 0, "", "", "").
+		AddRow(2, 1, 1, 1, "bar", "foo", "", "", "", 0, 0, 0, 0, "", "", "")
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListSteps).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Step
+	}{
+		{
+			failure: false,
+			want:    []*library.Step{_stepOne, _stepTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetStepList()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetStepList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetStepList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetStepList is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetBuildStepList(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_build.SetID(1)
+	_build.SetRepoID(1)
+	_build.SetNumber(1)
+
+	_stepOne := testStep()
+	_stepOne.SetID(1)
+	_stepOne.SetRepoID(1)
+	_stepOne.SetBuildID(1)
+	_stepOne.SetNumber(1)
+	_stepOne.SetName("foo")
+	_stepOne.SetImage("bar")
+
+	_stepTwo := testStep()
+	_stepTwo.SetID(2)
+	_stepTwo.SetRepoID(1)
+	_stepTwo.SetBuildID(1)
+	_stepTwo.SetNumber(1)
+	_stepTwo.SetName("bar")
+	_stepTwo.SetImage("foo")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "repo_id", "build_id", "number", "name", "image", "stage", "status", "error", "exit_code", "created", "started", "finished", "host", "runtime", "distribution"},
+	).AddRow(1, 1, 1, 1, "foo", "bar", "", "", "", 0, 0, 0, 0, "", "", "").
+		AddRow(2, 1, 1, 1, "bar", "foo", "", "", "", 0, 0, 0, 0, "", "", "")
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListBuildSteps).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Step
+	}{
+		{
+			failure: false,
+			want:    []*library.Step{_stepOne, _stepTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetBuildStepList(_build, 1, 10)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetBuildStepList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetBuildStepList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetBuildStepList is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/database/postgres/step_test.go
+++ b/database/postgres/step_test.go
@@ -240,46 +240,6 @@ func TestPostgres_Client_DeleteStep(t *testing.T) {
 	}
 }
 
-// testBuild is a test helper function to create a
-// library Build type with all fields set to their
-// zero values.
-func testBuild() *library.Build {
-	i64 := int64(0)
-	i := 0
-	str := ""
-
-	return &library.Build{
-		ID:           &i64,
-		RepoID:       &i64,
-		Number:       &i,
-		Parent:       &i,
-		Event:        &str,
-		Status:       &str,
-		Error:        &str,
-		Enqueued:     &i64,
-		Created:      &i64,
-		Started:      &i64,
-		Finished:     &i64,
-		Deploy:       &str,
-		Clone:        &str,
-		Source:       &str,
-		Title:        &str,
-		Message:      &str,
-		Commit:       &str,
-		Sender:       &str,
-		Author:       &str,
-		Email:        &str,
-		Link:         &str,
-		Branch:       &str,
-		Ref:          &str,
-		BaseRef:      &str,
-		HeadRef:      &str,
-		Host:         &str,
-		Runtime:      &str,
-		Distribution: &str,
-	}
-}
-
 // testStep is a test helper function to create a
 // library Step type with all fields set to their
 // zero values.

--- a/database/postgres/step_test.go
+++ b/database/postgres/step_test.go
@@ -1,0 +1,309 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetStep(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_build.SetID(1)
+	_build.SetRepoID(1)
+	_build.SetNumber(1)
+
+	_step := testStep()
+	_step.SetID(1)
+	_step.SetRepoID(1)
+	_step.SetBuildID(1)
+	_step.SetNumber(1)
+	_step.SetName("foo")
+	_step.SetImage("bar")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "repo_id", "build_id", "number", "name", "image", "stage", "status", "error", "exit_code", "created", "started", "finished", "host", "runtime", "distribution"},
+	).AddRow(1, 1, 1, 1, "foo", "bar", "", "", "", 0, 0, 0, 0, "", "", "")
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectBuildStep).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Step
+	}{
+		{
+			failure: false,
+			want:    _step,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetStep(1, _build)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetStep should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetStep returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetStep is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_CreateStep(t *testing.T) {
+	// setup types
+	_step := testStep()
+	_step.SetID(1)
+	_step.SetRepoID(1)
+	_step.SetBuildID(1)
+	_step.SetNumber(1)
+	_step.SetName("foo")
+	_step.SetImage("bar")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"id"}).AddRow(1)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(`INSERT INTO "steps" ("build_id","repo_id","number","name","image","stage","status","error","exit_code","created","started","finished","host","runtime","distribution","id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16) RETURNING "id"`).
+		WithArgs(1, 1, 1, "foo", "bar", "", "", "", nil, nil, nil, nil, "", "", "", 1).
+		WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.CreateStep(_step)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("CreateStep should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("CreateStep returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_UpdateStep(t *testing.T) {
+	// setup types
+	_step := testStep()
+	_step.SetID(1)
+	_step.SetRepoID(1)
+	_step.SetBuildID(1)
+	_step.SetNumber(1)
+	_step.SetName("foo")
+	_step.SetImage("bar")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query
+	_mock.ExpectExec(`UPDATE "steps" SET "build_id"=$1,"repo_id"=$2,"number"=$3,"name"=$4,"image"=$5,"stage"=$6,"status"=$7,"error"=$8,"exit_code"=$9,"created"=$10,"started"=$11,"finished"=$12,"host"=$13,"runtime"=$14,"distribution"=$15 WHERE "id" = $16`).
+		WithArgs(1, 1, 1, "foo", "bar", "", "", "", nil, nil, nil, nil, "", "", "", 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.UpdateStep(_step)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("UpdateStep should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("UpdateStep returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_DeleteStep(t *testing.T) {
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query
+	_mock.ExpectExec(dml.DeleteStep).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.DeleteStep(1)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("DeleteStep should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("DeleteStep returned err: %v", err)
+		}
+	}
+}
+
+// testBuild is a test helper function to create a
+// library Build type with all fields set to their
+// zero values.
+func testBuild() *library.Build {
+	i64 := int64(0)
+	i := 0
+	str := ""
+
+	return &library.Build{
+		ID:           &i64,
+		RepoID:       &i64,
+		Number:       &i,
+		Parent:       &i,
+		Event:        &str,
+		Status:       &str,
+		Error:        &str,
+		Enqueued:     &i64,
+		Created:      &i64,
+		Started:      &i64,
+		Finished:     &i64,
+		Deploy:       &str,
+		Clone:        &str,
+		Source:       &str,
+		Title:        &str,
+		Message:      &str,
+		Commit:       &str,
+		Sender:       &str,
+		Author:       &str,
+		Email:        &str,
+		Link:         &str,
+		Branch:       &str,
+		Ref:          &str,
+		BaseRef:      &str,
+		HeadRef:      &str,
+		Host:         &str,
+		Runtime:      &str,
+		Distribution: &str,
+	}
+}
+
+// testStep is a test helper function to create a
+// library Step type with all fields set to their
+// zero values.
+func testStep() *library.Step {
+	i64 := int64(0)
+	i := 0
+	str := ""
+
+	return &library.Step{
+		ID:           &i64,
+		BuildID:      &i64,
+		RepoID:       &i64,
+		Number:       &i,
+		Name:         &str,
+		Image:        &str,
+		Stage:        &str,
+		Status:       &str,
+		Error:        &str,
+		ExitCode:     &i,
+		Created:      &i64,
+		Started:      &i64,
+		Finished:     &i64,
+		Host:         &str,
+		Runtime:      &str,
+		Distribution: &str,
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-vela/server/pull/341

Dependent on https://github.com/go-vela/server/pull/373

This adds a series of `step` functions to the `github.com/go-vela/server/database/postgres` client:

https://github.com/go-vela/server/blob/15ee929684fba1a4fbd5c21e45d7cfe55adfc8b7/database/database.go#L173-L203

These functions implemented are to ensure we satisfy the existing `database` interface above.

The code for these functions was copied from the old database client code:

https://github.com/go-vela/server/blob/master/database/step.go

> NOTE:
>
> Almost `2/3` of the LOC found in this change are related to the unit tests written for the various functions.