### PR TITLE
feat(postgres): add service database functions

### DIFF
--- a/database/postgres/service.go
+++ b/database/postgres/service.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetService gets a service by number and build ID from the database.
+func (c *client) GetService(number int, b *library.Build) (*library.Service, error) {
+	logrus.Tracef("getting service %d for build %d from the database", number, b.GetNumber())
+
+	// variable to store query results
+	s := new(database.Service)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableService).
+		Raw(dml.SelectBuildService, b.GetID(), number).
+		Scan(s).Error
+
+	return s.ToLibrary(), err
+}
+
+// CreateService creates a new service in the database.
+func (c *client) CreateService(s *library.Service) error {
+	logrus.Tracef("creating service %s in the database", s.GetName())
+
+	// cast to database type
+	service := database.ServiceFromLibrary(s)
+
+	// validate the necessary fields are populated
+	err := service.Validate()
+	if err != nil {
+		return err
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableService).
+		Create(service).Error
+}
+
+// UpdateService updates a service in the database.
+func (c *client) UpdateService(s *library.Service) error {
+	logrus.Tracef("updating service %s in the database", s.GetName())
+
+	// cast to database type
+	service := database.ServiceFromLibrary(s)
+
+	// validate the necessary fields are populated
+	err := service.Validate()
+	if err != nil {
+		return err
+	}
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableService).
+		Save(service).Error
+}
+
+// DeleteService deletes a service by unique ID from the database.
+func (c *client) DeleteService(id int64) error {
+	logrus.Tracef("deleting service %d from the database", id)
+
+	// send query to the database
+	return c.Postgres.
+		Table(constants.TableService).
+		Exec(dml.DeleteService, id).Error
+}

--- a/database/postgres/service_count.go
+++ b/database/postgres/service_count.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetBuildServiceCount gets a count of all services by build ID from the database.
+func (c *client) GetBuildServiceCount(b *library.Build) (int64, error) {
+	logrus.Tracef("getting count of services for build %d from the database", b.GetNumber())
+
+	// variable to store query results
+	var s int64
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableService).
+		Raw(dml.SelectBuildServicesCount, b.GetID()).
+		Pluck("count", &s).Error
+
+	return s, err
+}
+
+// GetServiceImageCount gets a count of all service images
+// and the count of their occurrence in the database.
+func (c *client) GetServiceImageCount() (map[string]float64, error) {
+	logrus.Tracef("getting count of all images for services from the database")
+
+	type imageCount struct {
+		Image string
+		Count int
+	}
+
+	// variable to store query results
+	images := new([]imageCount)
+	counts := make(map[string]float64)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableService).
+		Raw(dml.SelectServiceImagesCount).
+		Scan(images).Error
+
+	for _, image := range *images {
+		counts[image.Image] = float64(image.Count)
+	}
+
+	return counts, err
+}
+
+// GetServiceStatusCount gets a list of all service statuses
+// and the count of their occurrence in the database.
+func (c *client) GetServiceStatusCount() (map[string]float64, error) {
+	logrus.Trace("getting count of all statuses for services from the database")
+
+	type statusCount struct {
+		Status string
+		Count  int
+	}
+
+	// variable to store query results
+	s := new([]statusCount)
+	counts := map[string]float64{
+		"pending": 0,
+		"failure": 0,
+		"killed":  0,
+		"running": 0,
+		"success": 0,
+	}
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableService).
+		Raw(dml.SelectServiceStatusesCount).
+		Scan(s).Error
+
+	for _, status := range *s {
+		counts[status.Status] = float64(status.Count)
+	}
+
+	return counts, err
+}

--- a/database/postgres/service_count_test.go
+++ b/database/postgres/service_count_test.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+)
+
+func TestPostgres_Client_GetBuildServiceCount(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_build.SetID(1)
+	_build.SetRepoID(1)
+	_build.SetNumber(1)
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectBuildServicesCount).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    int64
+	}{
+		{
+			failure: false,
+			want:    2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetBuildServiceCount(_build)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetBuildServiceCount should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetBuildServiceCount returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetBuildServiceCount is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetServiceImageCount(t *testing.T) {
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"image", "count"}).AddRow("foo", 0)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectServiceImagesCount).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    map[string]float64
+	}{
+		{
+			failure: false,
+			want:    map[string]float64{"foo": 0},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetServiceImageCount()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetServiceImageCount should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetServiceImageCount returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetServiceImageCount is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetServiceStatusCount(t *testing.T) {
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"status", "count"}).
+		AddRow("failure", 0).
+		AddRow("killed", 0).
+		AddRow("pending", 0).
+		AddRow("running", 0).
+		AddRow("success", 0)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectServiceStatusesCount).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    map[string]float64
+	}{
+		{
+			failure: false,
+			want: map[string]float64{
+				"pending": 0,
+				"failure": 0,
+				"killed":  0,
+				"running": 0,
+				"success": 0,
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetServiceStatusCount()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetServiceStatusCount should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetServiceStatusCount returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetServiceStatusCount is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/database/postgres/service_list.go
+++ b/database/postgres/service_list.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+// nolint: dupl // ignore false positive of duplicate code
+package postgres
+
+import (
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetServiceList gets a list of all services from the database.
+func (c *client) GetServiceList() ([]*library.Service, error) {
+	logrus.Trace("listing services from the database")
+
+	// variable to store query results
+	s := new([]database.Service)
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableService).
+		Raw(dml.ListServices).
+		Scan(s).Error
+
+	// variable we want to return
+	services := []*library.Service{}
+	// iterate through all query results
+	for _, service := range *s {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := service
+
+		// convert query result to library type
+		services = append(services, tmp.ToLibrary())
+	}
+
+	return services, err
+}
+
+// GetBuildServiceList gets a list of services by build ID from the database.
+//
+// nolint: lll // ignore long line length due to parameters
+func (c *client) GetBuildServiceList(b *library.Build, page, perPage int) ([]*library.Service, error) {
+	logrus.Tracef("listing services for build %d from the database", b.GetNumber())
+
+	// variable to store query results
+	s := new([]database.Service)
+	// calculate offset for pagination through results
+	offset := (perPage * (page - 1))
+
+	// send query to the database and store result in variable
+	err := c.Postgres.
+		Table(constants.TableService).
+		Raw(dml.ListBuildServices, b.GetID(), perPage, offset).
+		Scan(s).Error
+
+	// variable we want to return
+	services := []*library.Service{}
+	// iterate through all query results
+	for _, service := range *s {
+		// https://golang.org/doc/faq#closures_and_goroutines
+		tmp := service
+
+		// convert query result to library type
+		services = append(services, tmp.ToLibrary())
+	}
+
+	return services, err
+}

--- a/database/postgres/service_list_test.go
+++ b/database/postgres/service_list_test.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetServiceList(t *testing.T) {
+	// setup types
+	_serviceOne := testService()
+	_serviceOne.SetID(1)
+	_serviceOne.SetRepoID(1)
+	_serviceOne.SetBuildID(1)
+	_serviceOne.SetNumber(1)
+	_serviceOne.SetName("foo")
+	_serviceOne.SetImage("bar")
+
+	_serviceTwo := testService()
+	_serviceTwo.SetID(2)
+	_serviceTwo.SetRepoID(1)
+	_serviceTwo.SetBuildID(1)
+	_serviceTwo.SetNumber(1)
+	_serviceTwo.SetName("bar")
+	_serviceTwo.SetImage("foo")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "repo_id", "build_id", "number", "name", "image", "status", "error", "exit_code", "created", "started", "finished", "host", "runtime", "distribution"},
+	).AddRow(1, 1, 1, 1, "foo", "bar", "", "", 0, 0, 0, 0, "", "", "").
+		AddRow(2, 1, 1, 1, "bar", "foo", "", "", 0, 0, 0, 0, "", "", "")
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListServices).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Service
+	}{
+		{
+			failure: false,
+			want:    []*library.Service{_serviceOne, _serviceTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetServiceList()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetServiceList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetServiceList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetServiceList is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_GetBuildServiceList(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_build.SetID(1)
+	_build.SetRepoID(1)
+	_build.SetNumber(1)
+
+	_serviceOne := testService()
+	_serviceOne.SetID(1)
+	_serviceOne.SetRepoID(1)
+	_serviceOne.SetBuildID(1)
+	_serviceOne.SetNumber(1)
+	_serviceOne.SetName("foo")
+	_serviceOne.SetImage("bar")
+
+	_serviceTwo := testService()
+	_serviceTwo.SetID(2)
+	_serviceTwo.SetRepoID(1)
+	_serviceTwo.SetBuildID(1)
+	_serviceTwo.SetNumber(1)
+	_serviceTwo.SetName("bar")
+	_serviceTwo.SetImage("foo")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "repo_id", "build_id", "number", "name", "image", "status", "error", "exit_code", "created", "started", "finished", "host", "runtime", "distribution"},
+	).AddRow(1, 1, 1, 1, "foo", "bar", "", "", 0, 0, 0, 0, "", "", "").
+		AddRow(2, 1, 1, 1, "bar", "foo", "", "", 0, 0, 0, 0, "", "", "")
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.ListBuildServices).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    []*library.Service
+	}{
+		{
+			failure: false,
+			want:    []*library.Service{_serviceOne, _serviceTwo},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetBuildServiceList(_build, 1, 10)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetBuildServiceList should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetBuildServiceList returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetBuildServiceList is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/database/postgres/service_test.go
+++ b/database/postgres/service_test.go
@@ -240,46 +240,6 @@ func TestPostgres_Client_DeleteService(t *testing.T) {
 	}
 }
 
-// testBuild is a test helper function to create a
-// library Build type with all fields set to their
-// zero values.
-func testBuild() *library.Build {
-	i64 := int64(0)
-	i := 0
-	str := ""
-
-	return &library.Build{
-		ID:           &i64,
-		RepoID:       &i64,
-		Number:       &i,
-		Parent:       &i,
-		Event:        &str,
-		Status:       &str,
-		Error:        &str,
-		Enqueued:     &i64,
-		Created:      &i64,
-		Started:      &i64,
-		Finished:     &i64,
-		Deploy:       &str,
-		Clone:        &str,
-		Source:       &str,
-		Title:        &str,
-		Message:      &str,
-		Commit:       &str,
-		Sender:       &str,
-		Author:       &str,
-		Email:        &str,
-		Link:         &str,
-		Branch:       &str,
-		Ref:          &str,
-		BaseRef:      &str,
-		HeadRef:      &str,
-		Host:         &str,
-		Runtime:      &str,
-		Distribution: &str,
-	}
-}
-
 // testService is a test helper function to create a
 // library Service type with all fields set to their
 // zero values.

--- a/database/postgres/service_test.go
+++ b/database/postgres/service_test.go
@@ -1,0 +1,308 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/go-vela/server/database/postgres/dml"
+	"github.com/go-vela/types/library"
+)
+
+func TestPostgres_Client_GetService(t *testing.T) {
+	// setup types
+	_build := testBuild()
+	_build.SetID(1)
+	_build.SetRepoID(1)
+	_build.SetNumber(1)
+
+	_service := testService()
+	_service.SetID(1)
+	_service.SetRepoID(1)
+	_service.SetBuildID(1)
+	_service.SetNumber(1)
+	_service.SetName("foo")
+	_service.SetImage("bar")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "repo_id", "build_id", "number", "name", "image", "status", "error", "exit_code", "created", "started", "finished", "host", "runtime", "distribution"},
+	).AddRow(1, 1, 1, 1, "foo", "bar", "", "", 0, 0, 0, 0, "", "", "")
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(dml.SelectBuildService).WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		want    *library.Service
+	}{
+		{
+			failure: false,
+			want:    _service,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := _database.GetService(1, _build)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("GetService should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("GetService returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("GetService is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestPostgres_Client_CreateService(t *testing.T) {
+	// setup types
+	_service := testService()
+	_service.SetID(1)
+	_service.SetRepoID(1)
+	_service.SetBuildID(1)
+	_service.SetNumber(1)
+	_service.SetName("foo")
+	_service.SetImage("bar")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// create expected return in mock
+	_rows := sqlmock.NewRows([]string{"id"}).AddRow(1)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(`INSERT INTO "services" ("build_id","repo_id","number","name","image","status","error","exit_code","created","started","finished","host","runtime","distribution","id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) RETURNING "id"`).
+		WithArgs(1, 1, 1, "foo", "bar", "", "", nil, nil, nil, nil, "", "", "", 1).
+		WillReturnRows(_rows)
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.CreateService(_service)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("CreateService should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("CreateService returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_UpdateService(t *testing.T) {
+	// setup types
+	_service := testService()
+	_service.SetID(1)
+	_service.SetRepoID(1)
+	_service.SetBuildID(1)
+	_service.SetNumber(1)
+	_service.SetName("foo")
+	_service.SetImage("bar")
+
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query
+	_mock.ExpectExec(`UPDATE "services" SET "build_id"=$1,"repo_id"=$2,"number"=$3,"name"=$4,"image"=$5,"status"=$6,"error"=$7,"exit_code"=$8,"created"=$9,"started"=$10,"finished"=$11,"host"=$12,"runtime"=$13,"distribution"=$14 WHERE "id" = $15`).
+		WithArgs(1, 1, 1, "foo", "bar", "", "", nil, nil, nil, nil, "", "", "", 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.UpdateService(_service)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("UpdateService should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("UpdateService returned err: %v", err)
+		}
+	}
+}
+
+func TestPostgres_Client_DeleteService(t *testing.T) {
+	// create the new fake sql database
+	_sql, _mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Errorf("unable to create new sql mock database: %v", err)
+	}
+	defer _sql.Close()
+
+	// ensure the mock expects the query
+	_mock.ExpectExec(dml.DeleteService).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// setup the database client
+	_database, err := NewTest(_sql)
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := _database.DeleteService(1)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("DeleteService should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("DeleteService returned err: %v", err)
+		}
+	}
+}
+
+// testBuild is a test helper function to create a
+// library Build type with all fields set to their
+// zero values.
+func testBuild() *library.Build {
+	i64 := int64(0)
+	i := 0
+	str := ""
+
+	return &library.Build{
+		ID:           &i64,
+		RepoID:       &i64,
+		Number:       &i,
+		Parent:       &i,
+		Event:        &str,
+		Status:       &str,
+		Error:        &str,
+		Enqueued:     &i64,
+		Created:      &i64,
+		Started:      &i64,
+		Finished:     &i64,
+		Deploy:       &str,
+		Clone:        &str,
+		Source:       &str,
+		Title:        &str,
+		Message:      &str,
+		Commit:       &str,
+		Sender:       &str,
+		Author:       &str,
+		Email:        &str,
+		Link:         &str,
+		Branch:       &str,
+		Ref:          &str,
+		BaseRef:      &str,
+		HeadRef:      &str,
+		Host:         &str,
+		Runtime:      &str,
+		Distribution: &str,
+	}
+}
+
+// testService is a test helper function to create a
+// library Service type with all fields set to their
+// zero values.
+func testService() *library.Service {
+	i64 := int64(0)
+	i := 0
+	str := ""
+
+	return &library.Service{
+		ID:           &i64,
+		BuildID:      &i64,
+		RepoID:       &i64,
+		Number:       &i,
+		Name:         &str,
+		Image:        &str,
+		Status:       &str,
+		Error:        &str,
+		ExitCode:     &i,
+		Created:      &i64,
+		Started:      &i64,
+		Finished:     &i64,
+		Host:         &str,
+		Runtime:      &str,
+		Distribution: &str,
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-vela/server/pull/341

Dependent on https://github.com/go-vela/server/pull/373

This adds a series of `service` functions to the `github.com/go-vela/server/database/postgres` client:

https://github.com/go-vela/server/blob/15ee929684fba1a4fbd5c21e45d7cfe55adfc8b7/database/database.go#L205-L235

These functions implemented are to ensure we satisfy the existing `database` interface above.

The code for these functions was copied from the old database client code:

https://github.com/go-vela/server/blob/master/database/service.go

> NOTE:
>
> Almost `2/3` of the LOC found in this change are related to the unit tests written for the various functions.