### PR TITLE
refactor(database)!: switch to use postgres.New()

### DIFF
--- a/api/build.go
+++ b/api/build.go
@@ -362,7 +362,7 @@ func GetBuilds(c *gin.Context) {
 
 	// send API call to capture the list of builds for the repo (and event type if passed in)
 	if len(event) > 0 {
-		b, t, err = database.FromContext(c).GetRepoBuildListByEvent(r, page, perPage, event)
+		b, t, err = database.FromContext(c).GetRepoBuildListByEvent(r, event, page, perPage)
 	} else {
 		b, t, err = database.FromContext(c).GetRepoBuildList(r, page, perPage)
 	}
@@ -479,7 +479,7 @@ func GetOrgBuilds(c *gin.Context) {
 
 	// send API call to capture the list of builds for the org (and event type if passed in)
 	if len(event) > 0 {
-		b, t, err = database.FromContext(c).GetOrgBuildListByEvent(o, page, perPage, event)
+		b, t, err = database.FromContext(c).GetOrgBuildListByEvent(o, event, page, perPage)
 	} else {
 		b, t, err = database.FromContext(c).GetOrgBuildList(o, page, perPage)
 	}

--- a/cmd/vela-server/database.go
+++ b/cmd/vela-server/database.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/server/database"
+	"github.com/go-vela/server/database/postgres"
 	"github.com/go-vela/types/constants"
 
 	"github.com/sirupsen/logrus"
@@ -32,7 +33,18 @@ func setupDatabase(c *cli.Context) (database.Service, error) {
 // helper function to setup the Postgres database from the CLI arguments.
 func setupPostgres(c *cli.Context) (database.Service, error) {
 	logrus.Tracef("Creating %s database client from CLI configuration", constants.DriverPostgres)
-	return database.New(c)
+
+	// create new Postgres database service
+	//
+	// https://pkg.go.dev/github.com/go-vela/server/database/postgres?tab=doc#New
+	return postgres.New(
+		postgres.WithAddress(c.String("database.config")),
+		postgres.WithCompressionLevel(c.Int("database.compression.level")),
+		postgres.WithConnectionLife(c.Duration("database.connection.life")),
+		postgres.WithConnectionIdle(c.Int("database.connection.idle")),
+		postgres.WithConnectionOpen(c.Int("database.connection.open")),
+		postgres.WithEncryptionKey(c.String("database.encryption.key")),
+	)
 }
 
 // helper function to setup the Sqlite database from the CLI arguments.

--- a/database/build.go
+++ b/database/build.go
@@ -218,7 +218,7 @@ func (c *client) GetOrgBuildList(o string, page, perPage int) ([]*library.Build,
 // GetRepoBuildListByEvent gets a list of all builds by repo ID and event type from the database.
 //
 // nolint: lll // ignore long line length due to variable names
-func (c *client) GetRepoBuildListByEvent(r *library.Repo, page, perPage int, event string) ([]*library.Build, int64, error) {
+func (c *client) GetRepoBuildListByEvent(r *library.Repo, event string, page, perPage int) ([]*library.Build, int64, error) {
 	logrus.Tracef("Listing builds for repo %s from the database by event '%s'", r.GetFullName(), event)
 
 	// variables to store query results
@@ -261,7 +261,7 @@ func (c *client) GetRepoBuildListByEvent(r *library.Repo, page, perPage int, eve
 // GetOrgBuildListByEvent gets a list of all builds by org name and event type from the database.
 //
 // nolint: lll // ignore long line length due to variable names
-func (c *client) GetOrgBuildListByEvent(org string, page, perPage int, event string) ([]*library.Build, int64, error) {
+func (c *client) GetOrgBuildListByEvent(org, event string, page, perPage int) ([]*library.Build, int64, error) {
 	logrus.Tracef("Listing builds for repo %s from the database by event '%s'", org, event)
 
 	// variables to store query results

--- a/database/build_test.go
+++ b/database/build_test.go
@@ -468,7 +468,7 @@ func TestDatabase_Client_GetRepoBuildListByEvent(t *testing.T) {
 	_ = database.CreateBuild(bThree)
 
 	// run test
-	got, gotCount, err := database.GetRepoBuildListByEvent(r, 1, 1, "push")
+	got, gotCount, err := database.GetRepoBuildListByEvent(r, "push", 1, 1)
 
 	if err != nil {
 		t.Errorf("GetRepoBuildListByEvent returned err: %v", err)
@@ -520,7 +520,7 @@ func TestDatabase_Client_GetRepoBuildListByEvent_No_Results(t *testing.T) {
 	_ = database.CreateBuild(bTwo)
 
 	// run test
-	got, gotCount, err := database.GetRepoBuildListByEvent(r, 1, 1, "tag")
+	got, gotCount, err := database.GetRepoBuildListByEvent(r, "tag", 1, 1)
 
 	if err != nil {
 		t.Errorf("GetRepoBuildListByEvent returned err: %v", err)
@@ -817,7 +817,7 @@ func TestDatabase_Client_GetOrgBuildListByEvent(t *testing.T) {
 	_ = database.CreateBuild(bThree)
 
 	// run test
-	got, gotCount, err := database.GetOrgBuildListByEvent(r.GetOrg(), 1, 1, "push")
+	got, gotCount, err := database.GetOrgBuildListByEvent(r.GetOrg(), "push", 1, 1)
 
 	if err != nil {
 		t.Errorf("GetOrgBuildListByEvent returned err: %v", err)
@@ -881,7 +881,7 @@ func TestDatabase_Client_GetOrgBuildListByEvent_No_Results(t *testing.T) {
 	_ = database.CreateBuild(bTwo)
 
 	// run test
-	got, gotCount, err := database.GetOrgBuildListByEvent(r.GetOrg(), 1, 1, "tag")
+	got, gotCount, err := database.GetOrgBuildListByEvent(r.GetOrg(), "tag", 1, 1)
 
 	if err != nil {
 		t.Errorf("GetOrgBuildListByEvent returned err: %v", err)

--- a/database/database.go
+++ b/database/database.go
@@ -39,10 +39,10 @@ type Service interface {
 	GetOrgBuildList(string, int, int) ([]*library.Build, int64, error)
 	// GetRepoBuildListByEvent defines a function that
 	// gets a list of builds by repo ID and event type.
-	GetRepoBuildListByEvent(*library.Repo, int, int, string) ([]*library.Build, int64, error)
+	GetRepoBuildListByEvent(*library.Repo, string, int, int) ([]*library.Build, int64, error)
 	// GetOrgBuildListByEvent defines a function that
 	// gets a list of builds by org and event type.
-	GetOrgBuildListByEvent(string, int, int, string) ([]*library.Build, int64, error)
+	GetOrgBuildListByEvent(string, string, int, int) ([]*library.Build, int64, error)
 	// GetRepoBuildCount defines a function that
 	// gets the count of builds by repo ID.
 	GetRepoBuildCount(*library.Repo) (int64, error)


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-vela/server/pull/341

This updates the codebase to now utilize the `github.com/go-vela/server/database/postgres.New()` function:

https://github.com/go-vela/server/blob/82a4db624dd03940accdfd6d795be036271ca90e/cmd/vela-server/database.go#L33-L48

Along with this change, comes a small update to the order of values provided for two existing database functions:

https://github.com/go-vela/server/blob/82a4db624dd03940accdfd6d795be036271ca90e/database/database.go#L40-L45

In the old database client, these previously were declared like so:

https://github.com/go-vela/server/blob/7c7205ca14d4d99d976f8d35f5f97fd0aa3d7b8b/database/database.go#L40-L45

The two `int` values provided to those functions are `page` and `perPage` for API pagination.

The reason for this change has to do with updating these functions to be consistent with all other functions.

For all other functions, when providing the `page` and `perPage` arguments, we always declare those at the end:

https://github.com/go-vela/server/blob/breaking/refactor/database/postgres/database/database.go