### PR TITLE
feat(sqlite): add setupDatabase() to setup connections

### DIFF
--- a/database/sqlite/sqlite.go
+++ b/database/sqlite/sqlite.go
@@ -63,6 +63,12 @@ func New(opts ...ClientOpt) (*client, error) {
 	// set the Sqlite database client in the Sqlite client
 	c.Sqlite = _sqlite
 
+	// setup database with proper configuration
+	err = setupDatabase(c)
+	if err != nil {
+		return nil, err
+	}
+
 	return c, nil
 }
 
@@ -78,6 +84,9 @@ func NewTest() (*client, error) {
 	// create new fields
 	c.config = &config{
 		CompressionLevel: 3,
+		ConnectionLife:   30 * time.Minute,
+		ConnectionIdle:   2,
+		ConnectionOpen:   0,
 		EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
 	}
 	c.Sqlite = new(gorm.DB)
@@ -96,4 +105,39 @@ func NewTest() (*client, error) {
 	c.Sqlite = _sqlite
 
 	return c, nil
+}
+
+// setupDatabase is a helper function to setup
+// the database with the proper configuration.
+func setupDatabase(c *client) error {
+	// capture database/sql database from gorm database
+	//
+	// https://pkg.go.dev/gorm.io/gorm#DB.DB
+	_sql, err := c.Sqlite.DB()
+	if err != nil {
+		return err
+	}
+
+	// set the maximum amount of time a connection may be reused
+	//
+	// https://golang.org/pkg/database/sql/#DB.SetConnMaxLifetime
+	_sql.SetConnMaxLifetime(c.config.ConnectionLife)
+
+	// set the maximum number of connections in the idle connection pool
+	//
+	// https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns
+	_sql.SetMaxIdleConns(c.config.ConnectionIdle)
+
+	// set the maximum number of open connections to the database
+	//
+	// https://golang.org/pkg/database/sql/#DB.SetMaxOpenConns
+	_sql.SetMaxOpenConns(c.config.ConnectionOpen)
+
+	// verify connection to the database
+	err = c.Ping()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/database/sqlite/sqlite_test.go
+++ b/database/sqlite/sqlite_test.go
@@ -52,3 +52,39 @@ func TestSqlite_New(t *testing.T) {
 		}
 	}
 }
+
+func TestSqlite_setupDatabase(t *testing.T) {
+	// setup types
+
+	// setup the test database client
+	_database, err := NewTest()
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+	defer func() { _sql, _ := _database.Sqlite.DB(); _sql.Close() }()
+
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := setupDatabase(_database)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("setupDatabase should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("setupDatabase returned err: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Leftover work for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-vela/server/pull/342

This adds a `setupDatabase()` helper function to the `github.com/go-vela/server/database/sqlite` client:

https://github.com/go-vela/server/blob/98dbcb5221347113ed349e4193350761ca3dddd3/database/sqlite/sqlite.go#L110-L143

This function will be used to setup the database connections with their intended settings:

* https://golang.org/pkg/database/sql/#DB.SetConnMaxLifetime
* https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns
* https://golang.org/pkg/database/sql/#DB.SetMaxOpenConns

This previously was a private, helper function in the old database client which I've slightly modified:

https://github.com/go-vela/server/blob/b7742462653923b5e1c263e8f8f6695e15c81964/database/client.go#L143-L165

> NOTE: The addition of the `createTables()` and the `createIndexes()` helper functions will be added in a different PR.