### PR TITLE
feat(sqlite): add createTables() to create database tables

### DIFF
--- a/database/sqlite/build_test.go
+++ b/database/sqlite/build_test.go
@@ -5,28 +5,11 @@
 package sqlite
 
 import (
-	"log"
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/server/database/sqlite/ddl"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
-
-func init() {
-	// setup the test database client
-	_database, err := NewTest()
-	if err != nil {
-		log.Fatalf("unable to create new sqlite test database: %v", err)
-	}
-
-	// create the build table
-	err = _database.Sqlite.Exec(ddl.CreateBuildTable).Error
-	if err != nil {
-		log.Fatalf("unable to create %s table: %v", constants.TableBuild, err)
-	}
-}
 
 func TestSqlite_Client_GetBuild(t *testing.T) {
 	// setup types

--- a/database/sqlite/hook_test.go
+++ b/database/sqlite/hook_test.go
@@ -5,28 +5,11 @@
 package sqlite
 
 import (
-	"log"
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/server/database/sqlite/ddl"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
-
-func init() {
-	// setup the test database client
-	_database, err := NewTest()
-	if err != nil {
-		log.Fatalf("unable to create new sqlite test database: %v", err)
-	}
-
-	// create the hook table
-	err = _database.Sqlite.Exec(ddl.CreateHookTable).Error
-	if err != nil {
-		log.Fatalf("unable to create %s table: %v", constants.TableHook, err)
-	}
-}
 
 func TestSqlite_Client_GetHook(t *testing.T) {
 	// setup types

--- a/database/sqlite/log_test.go
+++ b/database/sqlite/log_test.go
@@ -5,28 +5,11 @@
 package sqlite
 
 import (
-	"log"
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/server/database/sqlite/ddl"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
-
-func init() {
-	// setup the test database client
-	_database, err := NewTest()
-	if err != nil {
-		log.Fatalf("unable to create new sqlite test database: %v", err)
-	}
-
-	// create the log table
-	err = _database.Sqlite.Exec(ddl.CreateLogTable).Error
-	if err != nil {
-		log.Fatalf("unable to create %s table: %v", constants.TableLog, err)
-	}
-}
 
 func TestSqlite_Client_GetBuildLogs(t *testing.T) {
 	// setup types

--- a/database/sqlite/secret_test.go
+++ b/database/sqlite/secret_test.go
@@ -5,28 +5,11 @@
 package sqlite
 
 import (
-	"log"
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/server/database/sqlite/ddl"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
-
-func init() {
-	// setup the test database client
-	_database, err := NewTest()
-	if err != nil {
-		log.Fatalf("unable to create new sqlite test database: %v", err)
-	}
-
-	// create the secret table
-	err = _database.Sqlite.Exec(ddl.CreateSecretTable).Error
-	if err != nil {
-		log.Fatalf("unable to create %s table: %v", constants.TableSecret, err)
-	}
-}
 
 func TestSqlite_Client_GetSecret_Org(t *testing.T) {
 	// setup types

--- a/database/sqlite/service_test.go
+++ b/database/sqlite/service_test.go
@@ -5,28 +5,11 @@
 package sqlite
 
 import (
-	"log"
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/server/database/sqlite/ddl"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
-
-func init() {
-	// setup the test database client
-	_database, err := NewTest()
-	if err != nil {
-		log.Fatalf("unable to create new sqlite test database: %v", err)
-	}
-
-	// create the service table
-	err = _database.Sqlite.Exec(ddl.CreateServiceTable).Error
-	if err != nil {
-		log.Fatalf("unable to create %s table: %v", constants.TableService, err)
-	}
-}
 
 func TestSqlite_Client_GetService(t *testing.T) {
 	// setup types

--- a/database/sqlite/sqlite.go
+++ b/database/sqlite/sqlite.go
@@ -109,6 +109,12 @@ func NewTest() (*client, error) {
 
 	c.Sqlite = _sqlite
 
+	// create the tables in the database
+	err = createTables(c)
+	if err != nil {
+		return nil, err
+	}
+
 	return c, nil
 }
 

--- a/database/sqlite/sqlite.go
+++ b/database/sqlite/sqlite.go
@@ -5,7 +5,12 @@
 package sqlite
 
 import (
+	"fmt"
 	"time"
+
+	"github.com/go-vela/server/database/sqlite/ddl"
+	"github.com/go-vela/types/constants"
+	"github.com/sirupsen/logrus"
 
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -137,6 +142,74 @@ func setupDatabase(c *client) error {
 	err = c.Ping()
 	if err != nil {
 		return err
+	}
+
+	// create the tables in the database
+	err = createTables(c)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// createTables is a helper function to setup
+// the database with the necessary tables.
+func createTables(c *client) error {
+	logrus.Trace("creating data tables in the sqlite database")
+
+	// create the builds table
+	err := c.Sqlite.Exec(ddl.CreateBuildTable).Error
+	if err != nil {
+		return fmt.Errorf("unable to create %s table: %v", constants.TableBuild, err)
+	}
+
+	// create the hooks table
+	err = c.Sqlite.Exec(ddl.CreateHookTable).Error
+	if err != nil {
+		return fmt.Errorf("unable to create %s table: %v", constants.TableHook, err)
+	}
+
+	// create the logs table
+	err = c.Sqlite.Exec(ddl.CreateLogTable).Error
+	if err != nil {
+		return fmt.Errorf("unable to create %s table: %v", constants.TableLog, err)
+	}
+
+	// create the repos table
+	err = c.Sqlite.Exec(ddl.CreateRepoTable).Error
+	if err != nil {
+		return fmt.Errorf("unable to create %s table: %v", constants.TableRepo, err)
+	}
+
+	// create the secrets table
+	err = c.Sqlite.Exec(ddl.CreateSecretTable).Error
+	if err != nil {
+		return fmt.Errorf("unable to create %s table: %v", constants.TableSecret, err)
+	}
+
+	// create the services table
+	err = c.Sqlite.Exec(ddl.CreateServiceTable).Error
+	if err != nil {
+		return fmt.Errorf("unable to create %s table: %v", constants.TableService, err)
+	}
+
+	// create the steps table
+	err = c.Sqlite.Exec(ddl.CreateStepTable).Error
+	if err != nil {
+		return fmt.Errorf("unable to create %s table: %v", constants.TableStep, err)
+	}
+
+	// create the users table
+	err = c.Sqlite.Exec(ddl.CreateUserTable).Error
+	if err != nil {
+		return fmt.Errorf("unable to create %s table: %v", constants.TableUser, err)
+	}
+
+	// create the workers table
+	err = c.Sqlite.Exec(ddl.CreateWorkerTable).Error
+	if err != nil {
+		return fmt.Errorf("unable to create %s table: %v", constants.TableWorker, err)
 	}
 
 	return nil

--- a/database/sqlite/sqlite.go
+++ b/database/sqlite/sqlite.go
@@ -63,6 +63,12 @@ func New(opts ...ClientOpt) (*client, error) {
 	// set the Sqlite database client in the Sqlite client
 	c.Sqlite = _sqlite
 
+	// setup database with proper configuration
+	err = setupDatabase(c)
+	if err != nil {
+		return nil, err
+	}
+
 	return c, nil
 }
 
@@ -78,6 +84,9 @@ func NewTest() (*client, error) {
 	// create new fields
 	c.config = &config{
 		CompressionLevel: 3,
+		ConnectionLife:   30 * time.Minute,
+		ConnectionIdle:   2,
+		ConnectionOpen:   0,
 		EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
 	}
 	c.Sqlite = new(gorm.DB)
@@ -96,4 +105,39 @@ func NewTest() (*client, error) {
 	c.Sqlite = _sqlite
 
 	return c, nil
+}
+
+// setupDatabase is a helper function to setup
+// the database with the proper configuration.
+func setupDatabase(c *client) error {
+	// capture database/sql database from gorm database
+	//
+	// https://pkg.go.dev/gorm.io/gorm#DB.DB
+	_sql, err := c.Sqlite.DB()
+	if err != nil {
+		return err
+	}
+
+	// set the maximum amount of time a connection may be reused
+	//
+	// https://golang.org/pkg/database/sql/#DB.SetConnMaxLifetime
+	_sql.SetConnMaxLifetime(c.config.ConnectionLife)
+
+	// set the maximum number of connections in the idle connection pool
+	//
+	// https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns
+	_sql.SetMaxIdleConns(c.config.ConnectionIdle)
+
+	// set the maximum number of open connections to the database
+	//
+	// https://golang.org/pkg/database/sql/#DB.SetMaxOpenConns
+	_sql.SetMaxOpenConns(c.config.ConnectionOpen)
+
+	// verify connection to the database
+	err = c.Ping()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/database/sqlite/sqlite_test.go
+++ b/database/sqlite/sqlite_test.go
@@ -52,3 +52,39 @@ func TestSqlite_New(t *testing.T) {
 		}
 	}
 }
+
+func TestSqlite_setupDatabase(t *testing.T) {
+	// setup types
+
+	// setup the test database client
+	_database, err := NewTest()
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+	defer func() { _sql, _ := _database.Sqlite.DB(); _sql.Close() }()
+
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := setupDatabase(_database)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("setupDatabase should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("setupDatabase returned err: %v", err)
+		}
+	}
+}

--- a/database/sqlite/sqlite_test.go
+++ b/database/sqlite/sqlite_test.go
@@ -59,7 +59,7 @@ func TestSqlite_setupDatabase(t *testing.T) {
 	// setup the test database client
 	_database, err := NewTest()
 	if err != nil {
-		t.Errorf("unable to create new postgres test database: %v", err)
+		t.Errorf("unable to create new sqlite test database: %v", err)
 	}
 	defer func() { _sql, _ := _database.Sqlite.DB(); _sql.Close() }()
 
@@ -85,6 +85,42 @@ func TestSqlite_setupDatabase(t *testing.T) {
 
 		if err != nil {
 			t.Errorf("setupDatabase returned err: %v", err)
+		}
+	}
+}
+
+func TestSqlite_createTables(t *testing.T) {
+	// setup types
+
+	// setup the test database client
+	_database, err := NewTest()
+	if err != nil {
+		t.Errorf("unable to create new sqlite test database: %v", err)
+	}
+	defer func() { _sql, _ := _database.Sqlite.DB(); _sql.Close() }()
+
+	tests := []struct {
+		failure bool
+	}{
+		{
+			failure: false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := createTables(_database)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("createTables should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("createTables returned err: %v", err)
 		}
 	}
 }

--- a/database/sqlite/step_test.go
+++ b/database/sqlite/step_test.go
@@ -5,28 +5,11 @@
 package sqlite
 
 import (
-	"log"
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/server/database/sqlite/ddl"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
-
-func init() {
-	// setup the test database client
-	_database, err := NewTest()
-	if err != nil {
-		log.Fatalf("unable to create new sqlite test database: %v", err)
-	}
-
-	// create the step table
-	err = _database.Sqlite.Exec(ddl.CreateStepTable).Error
-	if err != nil {
-		log.Fatalf("unable to create %s table: %v", constants.TableStep, err)
-	}
-}
 
 func TestSqlite_Client_GetStep(t *testing.T) {
 	// setup types

--- a/database/sqlite/user_test.go
+++ b/database/sqlite/user_test.go
@@ -5,28 +5,11 @@
 package sqlite
 
 import (
-	"log"
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/server/database/sqlite/ddl"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
-
-func init() {
-	// setup the test database client
-	_database, err := NewTest()
-	if err != nil {
-		log.Fatalf("unable to create new sqlite test database: %v", err)
-	}
-
-	// create the user table
-	err = _database.Sqlite.Exec(ddl.CreateUserTable).Error
-	if err != nil {
-		log.Fatalf("unable to create %s table: %v", constants.TableUser, err)
-	}
-}
 
 func TestSqlite_Client_GetUser(t *testing.T) {
 	// setup types

--- a/database/sqlite/worker_test.go
+++ b/database/sqlite/worker_test.go
@@ -5,29 +5,11 @@
 package sqlite
 
 import (
-	"log"
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/server/database/sqlite/ddl"
-
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
-
-func init() {
-	// setup the test database client
-	_database, err := NewTest()
-	if err != nil {
-		log.Fatalf("unable to create new sqlite test database: %v", err)
-	}
-
-	// create the worker table
-	err = _database.Sqlite.Exec(ddl.CreateWorkerTable).Error
-	if err != nil {
-		log.Fatalf("unable to create %s table: %v", constants.TableWorker, err)
-	}
-}
 
 func TestSqlite_Client_GetWorker(t *testing.T) {
 	// setup types


### PR DESCRIPTION
Leftover work for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-vela/server/pull/342

Dependent on https://github.com/go-vela/server/pull/405

This adds a `createTables()` helper function to the `github.com/go-vela/server/database/sqlite` client:

https://github.com/go-vela/server/blob/92f49dc0141a376023b0384c175539d55a8f6ba6/database/sqlite/sqlite.go#L156-L216

This function will be used to create the data tables in the database.

This previously was a private, helper function in the old database client which I've slightly modified:

https://github.com/go-vela/server/blob/b7742462653923b5e1c263e8f8f6695e15c81964/database/client.go#L191-L249

This change also allows us to remove the `init()` functions in the test files responsible for creating Sqlite data tables.