### PR TITLE
fix(postgres): add workaround for gorm record not found

### DIFF
--- a/database/postgres/build_test.go
+++ b/database/postgres/build_test.go
@@ -50,8 +50,10 @@ func TestPostgres_Client_GetBuild(t *testing.T) {
 		[]string{"id", "repo_id", "number", "parent", "event", "status", "error", "enqueued", "created", "started", "finished", "deploy", "deploy_payload", "clone", "source", "title", "message", "commit", "sender", "author", "email", "link", "branch", "ref", "base_ref", "head_ref", "host", "runtime", "distribution", "timestamp"},
 	).AddRow(1, 1, 1, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0)
 
-	// ensure the mock expects the query
+	// ensure the mock expects the query for test case 1
 	_mock.ExpectQuery(_query.SQL.String()).WillReturnRows(_rows)
+	// ensure the mock expects the error for test case 2
+	_mock.ExpectQuery(_query.SQL.String()).WillReturnError(gorm.ErrRecordNotFound)
 
 	// setup tests
 	tests := []struct {
@@ -61,6 +63,10 @@ func TestPostgres_Client_GetBuild(t *testing.T) {
 		{
 			failure: false,
 			want:    _build,
+		},
+		{
+			failure: true,
+			want:    nil,
 		},
 	}
 
@@ -120,8 +126,10 @@ func TestPostgres_Client_GetLastBuild(t *testing.T) {
 		[]string{"id", "repo_id", "number", "parent", "event", "status", "error", "enqueued", "created", "started", "finished", "deploy", "deploy_payload", "clone", "source", "title", "message", "commit", "sender", "author", "email", "link", "branch", "ref", "base_ref", "head_ref", "host", "runtime", "distribution", "timestamp"},
 	).AddRow(1, 1, 1, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0)
 
-	// ensure the mock expects the query
+	// ensure the mock expects the query for test case 1
 	_mock.ExpectQuery(_query.SQL.String()).WillReturnRows(_rows)
+	// ensure the mock expects the error for test case 2
+	_mock.ExpectQuery(_query.SQL.String()).WillReturnError(gorm.ErrRecordNotFound)
 
 	// setup tests
 	tests := []struct {
@@ -131,6 +139,10 @@ func TestPostgres_Client_GetLastBuild(t *testing.T) {
 		{
 			failure: false,
 			want:    _build,
+		},
+		{
+			failure: false,
+			want:    nil,
 		},
 	}
 
@@ -190,8 +202,10 @@ func TestPostgres_Client_GetLastBuildByBranch(t *testing.T) {
 		[]string{"id", "repo_id", "number", "parent", "event", "status", "error", "enqueued", "created", "started", "finished", "deploy", "deploy_payload", "clone", "source", "title", "message", "commit", "sender", "author", "email", "link", "branch", "ref", "base_ref", "head_ref", "host", "runtime", "distribution", "timestamp"},
 	).AddRow(1, 1, 1, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0)
 
-	// ensure the mock expects the query
+	// ensure the mock expects the query for test case 1
 	_mock.ExpectQuery(_query.SQL.String()).WillReturnRows(_rows)
+	// ensure the mock expects the error for test case 2
+	_mock.ExpectQuery(_query.SQL.String()).WillReturnError(gorm.ErrRecordNotFound)
 
 	// setup tests
 	tests := []struct {
@@ -201,6 +215,10 @@ func TestPostgres_Client_GetLastBuildByBranch(t *testing.T) {
 		{
 			failure: false,
 			want:    _build,
+		},
+		{
+			failure: false,
+			want:    nil,
 		},
 	}
 
@@ -254,11 +272,12 @@ func TestPostgres_Client_GetPendingAndRunningBuilds(t *testing.T) {
 
 	// create expected return in mock
 	_rows := sqlmock.NewRows([]string{"created", "full_name", "number", "status"}).
-		AddRow(0, "", 1, "").
-		AddRow(0, "", 2, "")
+		AddRow(0, "", 1, "").AddRow(0, "", 2, "")
 
-	// ensure the mock expects the query
+	// ensure the mock expects the query for test case 1
 	_mock.ExpectQuery(_query.SQL.String()).WillReturnRows(_rows)
+	// ensure the mock expects the error for test case 2
+	_mock.ExpectQuery(_query.SQL.String()).WillReturnError(gorm.ErrRecordNotFound)
 
 	// setup tests
 	tests := []struct {
@@ -268,6 +287,10 @@ func TestPostgres_Client_GetPendingAndRunningBuilds(t *testing.T) {
 		{
 			failure: false,
 			want:    []*library.BuildQueue{_buildOne, _buildTwo},
+		},
+		{
+			failure: true,
+			want:    nil,
 		},
 	}
 

--- a/database/postgres/hook_test.go
+++ b/database/postgres/hook_test.go
@@ -49,8 +49,10 @@ func TestPostgres_Client_GetHook(t *testing.T) {
 		[]string{"id", "repo_id", "build_id", "number", "source_id", "created", "host", "event", "branch", "error", "status", "link"},
 	).AddRow(1, 1, 1, 1, "c8da1302-07d6-11ea-882f-4893bca275b8", 0, "", "", "", "", "", "")
 
-	// ensure the mock expects the query
+	// ensure the mock expects the query for test case 1
 	_mock.ExpectQuery(_query.SQL.String()).WillReturnRows(_rows)
+	// ensure the mock expects the error for test case 2
+	_mock.ExpectQuery(_query.SQL.String()).WillReturnError(gorm.ErrRecordNotFound)
 
 	// setup tests
 	tests := []struct {
@@ -60,6 +62,10 @@ func TestPostgres_Client_GetHook(t *testing.T) {
 		{
 			failure: false,
 			want:    _hook,
+		},
+		{
+			failure: true,
+			want:    nil,
 		},
 	}
 
@@ -118,8 +124,10 @@ func TestPostgres_Client_GetLastHook(t *testing.T) {
 		[]string{"id", "repo_id", "build_id", "number", "source_id", "created", "host", "event", "branch", "error", "status", "link"},
 	).AddRow(1, 1, 1, 1, "c8da1302-07d6-11ea-882f-4893bca275b8", 0, "", "", "", "", "", "")
 
-	// ensure the mock expects the query
+	// ensure the mock expects the query for test case 1
 	_mock.ExpectQuery(_query.SQL.String()).WillReturnRows(_rows)
+	// ensure the mock expects the error for test case 2
+	_mock.ExpectQuery(_query.SQL.String()).WillReturnError(gorm.ErrRecordNotFound)
 
 	// setup tests
 	tests := []struct {
@@ -129,6 +137,10 @@ func TestPostgres_Client_GetLastHook(t *testing.T) {
 		{
 			failure: false,
 			want:    _hook,
+		},
+		{
+			failure: false,
+			want:    nil,
 		},
 	}
 

--- a/database/postgres/log.go
+++ b/database/postgres/log.go
@@ -5,12 +5,14 @@
 package postgres
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/go-vela/server/database/postgres/dml"
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
+	"gorm.io/gorm"
 
 	"github.com/sirupsen/logrus"
 )
@@ -66,18 +68,20 @@ func (c *client) GetStepLog(id int64) (*library.Log, error) {
 	l := new(database.Log)
 
 	// send query to the database and store result in variable
-	err := c.Postgres.
+	result := c.Postgres.
 		Table(constants.TableLog).
 		Raw(dml.SelectStepLog, id).
-		Scan(l).Error
-	if err != nil {
-		return l.ToLibrary(), err
+		Scan(l)
+
+	// check if the query returned a record not found error or no rows were returned
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+		return nil, gorm.ErrRecordNotFound
 	}
 
 	// decompress log data for the step
 	//
 	// https://pkg.go.dev/github.com/go-vela/types/database#Log.Decompress
-	err = l.Decompress()
+	err := l.Decompress()
 	if err != nil {
 		// ensures that the change is backwards compatible
 		// by logging the error instead of returning it
@@ -85,11 +89,11 @@ func (c *client) GetStepLog(id int64) (*library.Log, error) {
 		logrus.Errorf("unable to decompress logs for step %d: %v", id, err)
 
 		// return the uncompressed log
-		return l.ToLibrary(), nil
+		return l.ToLibrary(), result.Error
 	}
 
 	// return the decompressed log
-	return l.ToLibrary(), nil
+	return l.ToLibrary(), result.Error
 }
 
 // GetServiceLog gets a log by unique ID from the database.
@@ -102,18 +106,20 @@ func (c *client) GetServiceLog(id int64) (*library.Log, error) {
 	l := new(database.Log)
 
 	// send query to the database and store result in variable
-	err := c.Postgres.
+	result := c.Postgres.
 		Table(constants.TableLog).
 		Raw(dml.SelectServiceLog, id).
-		Scan(l).Error
-	if err != nil {
-		return l.ToLibrary(), err
+		Scan(l)
+
+	// check if the query returned a record not found error or no rows were returned
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+		return nil, gorm.ErrRecordNotFound
 	}
 
 	// decompress log data for the service
 	//
 	// https://pkg.go.dev/github.com/go-vela/types/database#Log.Decompress
-	err = l.Decompress()
+	err := l.Decompress()
 	if err != nil {
 		// ensures that the change is backwards compatible
 		// by logging the error instead of returning it
@@ -121,11 +127,11 @@ func (c *client) GetServiceLog(id int64) (*library.Log, error) {
 		logrus.Errorf("unable to decompress logs for service %d: %v", id, err)
 
 		// return the uncompressed log
-		return l.ToLibrary(), nil
+		return l.ToLibrary(), result.Error
 	}
 
 	// return the decompressed log
-	return l.ToLibrary(), nil
+	return l.ToLibrary(), result.Error
 }
 
 // CreateLog creates a new log in the database.

--- a/database/postgres/log_test.go
+++ b/database/postgres/log_test.go
@@ -111,8 +111,10 @@ func TestPostgres_Client_GetStepLog(t *testing.T) {
 		[]string{"id", "build_id", "repo_id", "service_id", "step_id", "data"},
 	).AddRow(1, 1, 1, 0, 1, []byte{})
 
-	// ensure the mock expects the query
+	// ensure the mock expects the query for test case 1
 	_mock.ExpectQuery(_query.SQL.String()).WillReturnRows(_rows)
+	// ensure the mock expects the error for test case 2
+	_mock.ExpectQuery(_query.SQL.String()).WillReturnError(gorm.ErrRecordNotFound)
 
 	// setup tests
 	tests := []struct {
@@ -122,6 +124,10 @@ func TestPostgres_Client_GetStepLog(t *testing.T) {
 		{
 			failure: false,
 			want:    _log,
+		},
+		{
+			failure: true,
+			want:    nil,
 		},
 	}
 
@@ -173,8 +179,10 @@ func TestPostgres_Client_GetServiceLog(t *testing.T) {
 		[]string{"id", "build_id", "repo_id", "service_id", "step_id", "data"},
 	).AddRow(1, 1, 1, 1, 0, []byte{})
 
-	// ensure the mock expects the query
+	// ensure the mock expects the query for test case 1
 	_mock.ExpectQuery(_query.SQL.String()).WillReturnRows(_rows)
+	// ensure the mock expects the error for test case 2
+	_mock.ExpectQuery(_query.SQL.String()).WillReturnError(gorm.ErrRecordNotFound)
 
 	// setup tests
 	tests := []struct {
@@ -184,6 +192,10 @@ func TestPostgres_Client_GetServiceLog(t *testing.T) {
 		{
 			failure: false,
 			want:    _log,
+		},
+		{
+			failure: true,
+			want:    nil,
 		},
 	}
 

--- a/database/postgres/repo.go
+++ b/database/postgres/repo.go
@@ -5,12 +5,14 @@
 package postgres
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/go-vela/server/database/postgres/dml"
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
+	"gorm.io/gorm"
 
 	"github.com/sirupsen/logrus"
 )
@@ -23,18 +25,20 @@ func (c *client) GetRepo(org, name string) (*library.Repo, error) {
 	r := new(database.Repo)
 
 	// send query to the database and store result in variable
-	err := c.Postgres.
+	result := c.Postgres.
 		Table(constants.TableRepo).
 		Raw(dml.SelectRepo, org, name).
-		Scan(r).Error
-	if err != nil {
-		return nil, err
+		Scan(r)
+
+	// check if the query returned a record not found error or no rows were returned
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+		return nil, gorm.ErrRecordNotFound
 	}
 
 	// decrypt the fields for the repo
 	//
 	// https://pkg.go.dev/github.com/go-vela/types/database#Repo.Decrypt
-	err = r.Decrypt(c.config.EncryptionKey)
+	err := r.Decrypt(c.config.EncryptionKey)
 	if err != nil {
 		// ensures that the change is backwards compatible
 		// by logging the error instead of returning it
@@ -42,11 +46,11 @@ func (c *client) GetRepo(org, name string) (*library.Repo, error) {
 		logrus.Errorf("unable to decrypt repo %s/%s: %v", org, name, err)
 
 		// return the unencrypted repo
-		return r.ToLibrary(), nil
+		return r.ToLibrary(), result.Error
 	}
 
 	// return the decrypted repo
-	return r.ToLibrary(), nil
+	return r.ToLibrary(), result.Error
 }
 
 // CreateRepo creates a new repo in the database.

--- a/database/postgres/repo_test.go
+++ b/database/postgres/repo_test.go
@@ -44,8 +44,10 @@ func TestPostgres_Client_GetRepo(t *testing.T) {
 		[]string{"id", "user_id", "hash", "org", "name", "full_name", "link", "clone", "branch", "timeout", "counter", "visibility", "private", "trusted", "active", "allow_pull", "allow_push", "allow_deploy", "allow_tag", "allow_comment"},
 	).AddRow(1, 1, "baz", "foo", "bar", "foo/bar", "", "", "", 0, 0, "public", false, false, false, false, false, false, false, false)
 
-	// ensure the mock expects the query
+	// ensure the mock expects the query for test case 1
 	_mock.ExpectQuery(_query.SQL.String()).WillReturnRows(_rows)
+	// ensure the mock expects the error for test case 2
+	_mock.ExpectQuery(_query.SQL.String()).WillReturnError(gorm.ErrRecordNotFound)
 
 	// setup tests
 	tests := []struct {
@@ -55,6 +57,10 @@ func TestPostgres_Client_GetRepo(t *testing.T) {
 		{
 			failure: false,
 			want:    _repo,
+		},
+		{
+			failure: true,
+			want:    nil,
 		},
 	}
 

--- a/database/postgres/secret.go
+++ b/database/postgres/secret.go
@@ -5,12 +5,14 @@
 package postgres
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/go-vela/server/database/postgres/dml"
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
+	"gorm.io/gorm"
 
 	"github.com/sirupsen/logrus"
 )
@@ -27,20 +29,41 @@ func (c *client) GetSecret(t, o, n, secretName string) (*library.Secret, error) 
 	// send query to the database and store result in variable
 	switch t {
 	case constants.SecretOrg:
-		err = c.Postgres.
+		result := c.Postgres.
 			Table(constants.TableSecret).
 			Raw(dml.SelectOrgSecret, o, secretName).
-			Scan(s).Error
+			Scan(s)
+
+		// check if the query returned a record not found error or no rows were returned
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+			return nil, gorm.ErrRecordNotFound
+		}
+
+		err = result.Error
 	case constants.SecretRepo:
-		err = c.Postgres.
+		result := c.Postgres.
 			Table(constants.TableSecret).
 			Raw(dml.SelectRepoSecret, o, n, secretName).
-			Scan(s).Error
+			Scan(s)
+
+		// check if the query returned a record not found error or no rows were returned
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+			return nil, gorm.ErrRecordNotFound
+		}
+
+		err = result.Error
 	case constants.SecretShared:
-		err = c.Postgres.
+		result := c.Postgres.
 			Table(constants.TableSecret).
 			Raw(dml.SelectSharedSecret, o, n, secretName).
-			Scan(s).Error
+			Scan(s)
+
+		// check if the query returned a record not found error or no rows were returned
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+			return nil, gorm.ErrRecordNotFound
+		}
+
+		err = result.Error
 	}
 	if err != nil {
 		return nil, err

--- a/database/postgres/secret_test.go
+++ b/database/postgres/secret_test.go
@@ -43,8 +43,10 @@ func TestPostgres_Client_GetSecret_Org(t *testing.T) {
 		[]string{"id", "type", "org", "repo", "team", "name", "value", "images", "events", "allow_command"},
 	).AddRow(1, "org", "foo", "*", "", "bar", "baz", "{}", "{}", false)
 
-	// ensure the mock expects the query
+	// ensure the mock expects the query for test case 1
 	_mock.ExpectQuery(_query.SQL.String()).WillReturnRows(_rows)
+	// ensure the mock expects the error for test case 2
+	_mock.ExpectQuery(_query.SQL.String()).WillReturnError(gorm.ErrRecordNotFound)
 
 	// setup tests
 	tests := []struct {
@@ -53,8 +55,11 @@ func TestPostgres_Client_GetSecret_Org(t *testing.T) {
 	}{
 		{
 			failure: false,
-
-			want: _secret,
+			want:    _secret,
+		},
+		{
+			failure: true,
+			want:    nil,
 		},
 	}
 
@@ -107,8 +112,10 @@ func TestPostgres_Client_GetSecret_Repo(t *testing.T) {
 		[]string{"id", "type", "org", "repo", "team", "name", "value", "images", "events", "allow_command"},
 	).AddRow(1, "repo", "foo", "bar", "", "baz", "foob", "{}", "{}", false)
 
-	// ensure the mock expects the query
+	// ensure the mock expects the query for test case 1
 	_mock.ExpectQuery(_query.SQL.String()).WillReturnRows(_rows)
+	// ensure the mock expects the error for test case 2
+	_mock.ExpectQuery(_query.SQL.String()).WillReturnError(gorm.ErrRecordNotFound)
 
 	// setup tests
 	tests := []struct {
@@ -117,8 +124,11 @@ func TestPostgres_Client_GetSecret_Repo(t *testing.T) {
 	}{
 		{
 			failure: false,
-
-			want: _secret,
+			want:    _secret,
+		},
+		{
+			failure: true,
+			want:    nil,
 		},
 	}
 
@@ -171,8 +181,10 @@ func TestPostgres_Client_GetSecret_Shared(t *testing.T) {
 		[]string{"id", "type", "org", "repo", "team", "name", "value", "images", "events", "allow_command"},
 	).AddRow(1, "shared", "foo", "", "bar", "baz", "foob", "{}", "{}", false)
 
-	// ensure the mock expects the query
+	// ensure the mock expects the query for test case 1
 	_mock.ExpectQuery(_query.SQL.String()).WillReturnRows(_rows)
+	// ensure the mock expects the error for test case 2
+	_mock.ExpectQuery(_query.SQL.String()).WillReturnError(gorm.ErrRecordNotFound)
 
 	// setup tests
 	tests := []struct {
@@ -181,8 +193,11 @@ func TestPostgres_Client_GetSecret_Shared(t *testing.T) {
 	}{
 		{
 			failure: false,
-
-			want: _secret,
+			want:    _secret,
+		},
+		{
+			failure: true,
+			want:    nil,
 		},
 	}
 

--- a/database/postgres/service.go
+++ b/database/postgres/service.go
@@ -5,10 +5,13 @@
 package postgres
 
 import (
+	"errors"
+
 	"github.com/go-vela/server/database/postgres/dml"
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
+	"gorm.io/gorm"
 
 	"github.com/sirupsen/logrus"
 )
@@ -21,12 +24,17 @@ func (c *client) GetService(number int, b *library.Build) (*library.Service, err
 	s := new(database.Service)
 
 	// send query to the database and store result in variable
-	err := c.Postgres.
+	result := c.Postgres.
 		Table(constants.TableService).
 		Raw(dml.SelectBuildService, b.GetID(), number).
-		Scan(s).Error
+		Scan(s)
 
-	return s.ToLibrary(), err
+	// check if the query returned a record not found error or no rows were returned
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	return s.ToLibrary(), result.Error
 }
 
 // CreateService creates a new service in the database.

--- a/database/postgres/service_test.go
+++ b/database/postgres/service_test.go
@@ -48,8 +48,10 @@ func TestPostgres_Client_GetService(t *testing.T) {
 		[]string{"id", "repo_id", "build_id", "number", "name", "image", "status", "error", "exit_code", "created", "started", "finished", "host", "runtime", "distribution"},
 	).AddRow(1, 1, 1, 1, "foo", "bar", "", "", 0, 0, 0, 0, "", "", "")
 
-	// ensure the mock expects the query
+	// ensure the mock expects the query for test case 1
 	_mock.ExpectQuery(_query.SQL.String()).WillReturnRows(_rows)
+	// ensure the mock expects the error for test case 2
+	_mock.ExpectQuery(_query.SQL.String()).WillReturnError(gorm.ErrRecordNotFound)
 
 	// setup tests
 	tests := []struct {
@@ -59,6 +61,10 @@ func TestPostgres_Client_GetService(t *testing.T) {
 		{
 			failure: false,
 			want:    _service,
+		},
+		{
+			failure: true,
+			want:    nil,
 		},
 	}
 

--- a/database/postgres/step_test.go
+++ b/database/postgres/step_test.go
@@ -48,8 +48,10 @@ func TestPostgres_Client_GetStep(t *testing.T) {
 		[]string{"id", "repo_id", "build_id", "number", "name", "image", "stage", "status", "error", "exit_code", "created", "started", "finished", "host", "runtime", "distribution"},
 	).AddRow(1, 1, 1, 1, "foo", "bar", "", "", "", 0, 0, 0, 0, "", "", "")
 
-	// ensure the mock expects the query
+	// ensure the mock expects the query for test case 1
 	_mock.ExpectQuery(_query.SQL.String()).WillReturnRows(_rows)
+	// ensure the mock expects the error for test case 2
+	_mock.ExpectQuery(_query.SQL.String()).WillReturnError(gorm.ErrRecordNotFound)
 
 	// setup tests
 	tests := []struct {
@@ -59,6 +61,10 @@ func TestPostgres_Client_GetStep(t *testing.T) {
 		{
 			failure: false,
 			want:    _step,
+		},
+		{
+			failure: true,
+			want:    nil,
 		},
 	}
 

--- a/database/postgres/user.go
+++ b/database/postgres/user.go
@@ -5,12 +5,14 @@
 package postgres
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/go-vela/server/database/postgres/dml"
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
+	"gorm.io/gorm"
 
 	"github.com/sirupsen/logrus"
 )
@@ -25,18 +27,20 @@ func (c *client) GetUser(id int64) (*library.User, error) {
 	u := new(database.User)
 
 	// send query to the database and store result in variable
-	err := c.Postgres.
+	result := c.Postgres.
 		Table(constants.TableUser).
 		Raw(dml.SelectUser, id).
-		Scan(u).Error
-	if err != nil {
-		return nil, err
+		Scan(u)
+
+	// check if the query returned a record not found error or no rows were returned
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+		return nil, gorm.ErrRecordNotFound
 	}
 
 	// decrypt the fields for the user
 	//
 	// https://pkg.go.dev/github.com/go-vela/types/database#User.Decrypt
-	err = u.Decrypt(c.config.EncryptionKey)
+	err := u.Decrypt(c.config.EncryptionKey)
 	if err != nil {
 		// ensures that the change is backwards compatible
 		// by logging the error instead of returning it
@@ -44,11 +48,11 @@ func (c *client) GetUser(id int64) (*library.User, error) {
 		logrus.Errorf("unable to decrypt user %d: %v", id, err)
 
 		// return the unencrypted user
-		return u.ToLibrary(), nil
+		return u.ToLibrary(), result.Error
 	}
 
 	// return the decrypted user
-	return u.ToLibrary(), nil
+	return u.ToLibrary(), result.Error
 }
 
 // GetUserName gets a user by name from the database.
@@ -61,18 +65,20 @@ func (c *client) GetUserName(name string) (*library.User, error) {
 	u := new(database.User)
 
 	// send query to the database and store result in variable
-	err := c.Postgres.
+	result := c.Postgres.
 		Table(constants.TableUser).
 		Raw(dml.SelectUserName, name).
-		Scan(u).Error
-	if err != nil {
-		return nil, err
+		Scan(u)
+
+	// check if the query returned a record not found error or no rows were returned
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+		return nil, gorm.ErrRecordNotFound
 	}
 
 	// decrypt the fields for the user
 	//
 	// https://pkg.go.dev/github.com/go-vela/types/database#User.Decrypt
-	err = u.Decrypt(c.config.EncryptionKey)
+	err := u.Decrypt(c.config.EncryptionKey)
 	if err != nil {
 		// ensures that the change is backwards compatible
 		// by logging the error instead of returning it
@@ -80,11 +86,11 @@ func (c *client) GetUserName(name string) (*library.User, error) {
 		logrus.Errorf("unable to decrypt user %s: %v", name, err)
 
 		// return the unencrypted user
-		return u.ToLibrary(), nil
+		return u.ToLibrary(), result.Error
 	}
 
 	// return the decrypted user
-	return u.ToLibrary(), nil
+	return u.ToLibrary(), result.Error
 }
 
 // CreateUser creates a new user in the database.

--- a/database/postgres/user_test.go
+++ b/database/postgres/user_test.go
@@ -41,8 +41,10 @@ func TestPostgres_Client_GetUser(t *testing.T) {
 		[]string{"id", "name", "refresh_token", "token", "hash", "favorites", "active", "admin"},
 	).AddRow(1, "foo", "", "bar", "baz", "{}", false, false)
 
-	// ensure the mock expects the query
+	// ensure the mock expects the query for test case 1
 	_mock.ExpectQuery(_query.SQL.String()).WillReturnRows(_rows)
+	// ensure the mock expects the error for test case 2
+	_mock.ExpectQuery(_query.SQL.String()).WillReturnError(gorm.ErrRecordNotFound)
 
 	// setup tests
 	tests := []struct {
@@ -52,6 +54,10 @@ func TestPostgres_Client_GetUser(t *testing.T) {
 		{
 			failure: false,
 			want:    _user,
+		},
+		{
+			failure: true,
+			want:    nil,
 		},
 	}
 

--- a/database/postgres/worker_test.go
+++ b/database/postgres/worker_test.go
@@ -40,8 +40,10 @@ func TestPostgres_Client_GetWorker(t *testing.T) {
 		[]string{"id", "hostname", "address", "routes", "active", "last_checked_in", "build_limit"},
 	).AddRow(1, "worker_0", "localhost", "{}", true, 0, 0)
 
-	// ensure the mock expects the query
+	// ensure the mock expects the query for test case 1
 	_mock.ExpectQuery(_query.SQL.String()).WillReturnRows(_rows)
+	// ensure the mock expects the error for test case 2
+	_mock.ExpectQuery(_query.SQL.String()).WillReturnError(gorm.ErrRecordNotFound)
 
 	// setup tests
 	tests := []struct {
@@ -51,6 +53,10 @@ func TestPostgres_Client_GetWorker(t *testing.T) {
 		{
 			failure: false,
 			want:    _worker,
+		},
+		{
+			failure: true,
+			want:    nil,
 		},
 	}
 
@@ -101,8 +107,10 @@ func TestPostgres_Client_GetWorkerByAddress(t *testing.T) {
 		[]string{"id", "hostname", "address", "routes", "active", "last_checked_in", "build_limit"},
 	).AddRow(1, "worker_0", "localhost", "{}", true, 0, 0)
 
-	// ensure the mock expects the query
+	// ensure the mock expects the query for test case 1
 	_mock.ExpectQuery(_query.SQL.String()).WillReturnRows(_rows)
+	// ensure the mock expects the error for test case 2
+	_mock.ExpectQuery(_query.SQL.String()).WillReturnError(gorm.ErrRecordNotFound)
 
 	// setup tests
 	tests := []struct {
@@ -112,6 +120,10 @@ func TestPostgres_Client_GetWorkerByAddress(t *testing.T) {
 		{
 			failure: false,
 			want:    _worker,
+		},
+		{
+			failure: true,
+			want:    nil,
 		},
 	}
 


### PR DESCRIPTION
Leftover work for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-gorm/gorm/issues/4416

**This is a workaround to a problem found in an upstream library.**

This updates the `go-vela/server/database/postgres` client to specifically check for the rows returned from queries:

https://github.com/go-vela/server/blob/95e6969b501087ab414fca37f8a60ff1faed9736/database/postgres/build.go#L35-L38

You'll note that we are explicitly checking the `RowsAffected` field is equal to `0` from the result returned by GORM.

This is required due to what initially appears to be a bug in GORM (See above [go-gorm/gorm](https://github.com/go-gorm/gorm) issue for more details).

GORM no longer returns `record not found` when a query is ran against the database and no rows are returned.