### PR TITLE
fix(sqlite): add workaround for gorm record not found

### DIFF
--- a/database/sqlite/build.go
+++ b/database/sqlite/build.go
@@ -18,6 +18,8 @@ import (
 )
 
 // GetBuild gets a build by number and repo ID from the database.
+//
+// nolint: dupl // ignore false positive of duplicate code
 func (c *client) GetBuild(number int, r *library.Repo) (*library.Build, error) {
 	logrus.Tracef("getting build %s/%d from the database", r.GetFullName(), number)
 
@@ -25,12 +27,17 @@ func (c *client) GetBuild(number int, r *library.Repo) (*library.Build, error) {
 	b := new(database.Build)
 
 	// send query to the database and store result in variable
-	err := c.Sqlite.
+	result := c.Sqlite.
 		Table(constants.TableBuild).
 		Raw(dml.SelectRepoBuild, r.GetID(), number).
-		Scan(b).Error
+		Scan(b)
 
-	return b.ToLibrary(), err
+	// check if the query returned a record not found error or no rows were returned
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	return b.ToLibrary(), result.Error
 }
 
 // GetLastBuild gets the last build by repo ID from the database.
@@ -41,17 +48,18 @@ func (c *client) GetLastBuild(r *library.Repo) (*library.Build, error) {
 	b := new(database.Build)
 
 	// send query to the database and store result in variable
-	err := c.Sqlite.
+	result := c.Sqlite.
 		Table(constants.TableBuild).
 		Raw(dml.SelectLastRepoBuild, r.GetID()).
-		Scan(b).Error
+		Scan(b)
 
-	// the record will not exist if it's a new repo
-	if errors.Is(err, gorm.ErrRecordNotFound) {
+	// check if the query returned a record not found error or no rows were returned
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+		// the record will not exist if it's a new repo
 		return nil, nil
 	}
 
-	return b.ToLibrary(), err
+	return b.ToLibrary(), result.Error
 }
 
 // GetLastBuildByBranch gets the last build by repo ID and branch from the database.
@@ -63,17 +71,18 @@ func (c *client) GetLastBuildByBranch(r *library.Repo, branch string) (*library.
 	b := new(database.Build)
 
 	// send query to the database and store result in variable
-	err := c.Sqlite.
+	result := c.Sqlite.
 		Table(constants.TableBuild).
 		Raw(dml.SelectLastRepoBuildByBranch, r.GetID(), branch).
-		Scan(b).Error
+		Scan(b)
 
-	// the record will not exist if it's a new repo
-	if errors.Is(err, gorm.ErrRecordNotFound) {
+	// check if the query returned a record not found error or no rows were returned
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+		// the record will not exist if it's a new repo
 		return nil, nil
 	}
 
-	return b.ToLibrary(), err
+	return b.ToLibrary(), result.Error
 }
 
 // GetPendingAndRunningBuilds returns the list of pending
@@ -85,10 +94,15 @@ func (c *client) GetPendingAndRunningBuilds(after string) ([]*library.BuildQueue
 	b := new([]database.BuildQueue)
 
 	// send query to the database and store result in variable
-	err := c.Sqlite.
+	result := c.Sqlite.
 		Table(constants.TableBuild).
 		Raw(dml.SelectPendingAndRunningBuilds, after).
-		Scan(b).Error
+		Scan(b)
+
+	// check if the query returned a record not found error or no rows were returned
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+		return nil, gorm.ErrRecordNotFound
+	}
 
 	// variable we want to return
 	builds := []*library.BuildQueue{}
@@ -102,7 +116,7 @@ func (c *client) GetPendingAndRunningBuilds(after string) ([]*library.BuildQueue
 		builds = append(builds, tmp.ToLibrary())
 	}
 
-	return builds, err
+	return builds, result.Error
 }
 
 // CreateBuild creates a new build in the database.

--- a/database/sqlite/build_test.go
+++ b/database/sqlite/build_test.go
@@ -44,20 +44,26 @@ func TestSqlite_Client_GetBuild(t *testing.T) {
 			failure: false,
 			want:    _build,
 		},
+		{
+			failure: true,
+			want:    nil,
+		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		// defer cleanup of the builds table
-		defer _database.Sqlite.Exec("delete from builds;")
-
-		// create the build in the database
-		err := _database.CreateBuild(test.want)
-		if err != nil {
-			t.Errorf("unable to create test build: %v", err)
+		if test.want != nil {
+			// create the build in the database
+			err := _database.CreateBuild(test.want)
+			if err != nil {
+				t.Errorf("unable to create test build: %v", err)
+			}
 		}
 
 		got, err := _database.GetBuild(1, _repo)
+
+		// cleanup the builds table
+		_ = _database.Sqlite.Exec("DELETE FROM builds;")
 
 		if test.failure {
 			if err == nil {
@@ -110,20 +116,26 @@ func TestSqlite_Client_GetLastBuild(t *testing.T) {
 			failure: false,
 			want:    _build,
 		},
+		{
+			failure: false,
+			want:    nil,
+		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		// defer cleanup of the builds table
-		defer _database.Sqlite.Exec("delete from builds;")
-
-		// create the build in the database
-		err := _database.CreateBuild(test.want)
-		if err != nil {
-			t.Errorf("unable to create test build: %v", err)
+		if test.want != nil {
+			// create the build in the database
+			err := _database.CreateBuild(test.want)
+			if err != nil {
+				t.Errorf("unable to create test build: %v", err)
+			}
 		}
 
 		got, err := _database.GetLastBuild(_repo)
+
+		// cleanup the builds table
+		_ = _database.Sqlite.Exec("DELETE FROM builds;")
 
 		if test.failure {
 			if err == nil {
@@ -177,20 +189,26 @@ func TestSqlite_Client_GetLastBuildByBranch(t *testing.T) {
 			failure: false,
 			want:    _build,
 		},
+		{
+			failure: false,
+			want:    nil,
+		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		// defer cleanup of the builds table
-		defer _database.Sqlite.Exec("delete from builds;")
-
-		// create the build in the database
-		err := _database.CreateBuild(test.want)
-		if err != nil {
-			t.Errorf("unable to create test build: %v", err)
+		if test.want != nil {
+			// create the build in the database
+			err := _database.CreateBuild(test.want)
+			if err != nil {
+				t.Errorf("unable to create test build: %v", err)
+			}
 		}
 
 		got, err := _database.GetLastBuildByBranch(_repo, "master")
+
+		// cleanup the builds table
+		_ = _database.Sqlite.Exec("DELETE FROM builds;")
 
 		if test.failure {
 			if err == nil {
@@ -265,34 +283,39 @@ func TestSqlite_Client_GetPendingAndRunningBuilds(t *testing.T) {
 			failure: false,
 			want:    []*library.BuildQueue{_queueOne, _queueTwo},
 		},
+		{
+			failure: true,
+			want:    nil,
+		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		// defer cleanup of the repos table
-		defer _database.Sqlite.Exec("delete from repos;")
-
 		// create the repo in the database
 		err := _database.CreateRepo(_repo)
 		if err != nil {
 			t.Errorf("unable to create test repo: %v", err)
 		}
 
-		// defer cleanup of the builds table
-		defer _database.Sqlite.Exec("delete from builds;")
+		if test.want != nil {
+			// create the builds in the database
+			err = _database.CreateBuild(_buildOne)
+			if err != nil {
+				t.Errorf("unable to create test build: %v", err)
+			}
 
-		// create the builds in the database
-		err = _database.CreateBuild(_buildOne)
-		if err != nil {
-			t.Errorf("unable to create test build: %v", err)
-		}
-
-		err = _database.CreateBuild(_buildTwo)
-		if err != nil {
-			t.Errorf("unable to create test build: %v", err)
+			err = _database.CreateBuild(_buildTwo)
+			if err != nil {
+				t.Errorf("unable to create test build: %v", err)
+			}
 		}
 
 		got, err := _database.GetPendingAndRunningBuilds("0")
+
+		// cleanup the repos table
+		_ = _database.Sqlite.Exec("DELETE FROM repos;")
+		// cleanup the builds table
+		_ = _database.Sqlite.Exec("DELETE FROM builds;")
 
 		if test.failure {
 			if err == nil {

--- a/database/sqlite/hook.go
+++ b/database/sqlite/hook.go
@@ -18,6 +18,8 @@ import (
 )
 
 // GetHook gets a hook by number and repo ID from the database.
+//
+// nolint: dupl // ignore false positive of duplicate code
 func (c *client) GetHook(number int, r *library.Repo) (*library.Hook, error) {
 	logrus.Tracef("getting hook %s/%d from the database", r.GetFullName(), number)
 
@@ -25,12 +27,17 @@ func (c *client) GetHook(number int, r *library.Repo) (*library.Hook, error) {
 	h := new(database.Hook)
 
 	// send query to the database and store result in variable
-	err := c.Sqlite.
+	result := c.Sqlite.
 		Table(constants.TableHook).
 		Raw(dml.SelectRepoHook, r.GetID(), number).
-		Scan(h).Error
+		Scan(h)
 
-	return h.ToLibrary(), err
+	// check if the query returned a record not found error or no rows were returned
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	return h.ToLibrary(), result.Error
 }
 
 // GetLastHook gets the last hook by repo ID from the database.
@@ -41,17 +48,18 @@ func (c *client) GetLastHook(r *library.Repo) (*library.Hook, error) {
 	h := new(database.Hook)
 
 	// send query to the database and store result in variable
-	err := c.Sqlite.
+	result := c.Sqlite.
 		Table(constants.TableHook).
 		Raw(dml.SelectLastRepoHook, r.GetID()).
-		Scan(h).Error
+		Scan(h)
 
-	// the record will not exist if it's a new repo
-	if errors.Is(err, gorm.ErrRecordNotFound) {
+	// check if the query returned a record not found error or no rows were returned
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+		// the record will not exist if it's a new repo
 		return nil, nil
 	}
 
-	return h.ToLibrary(), err
+	return h.ToLibrary(), result.Error
 }
 
 // CreateHook creates a new hook in the database.

--- a/database/sqlite/hook_test.go
+++ b/database/sqlite/hook_test.go
@@ -43,20 +43,26 @@ func TestSqlite_Client_GetHook(t *testing.T) {
 			failure: false,
 			want:    _hook,
 		},
+		{
+			failure: true,
+			want:    nil,
+		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		// defer cleanup of the hooks table
-		defer _database.Sqlite.Exec("delete from hooks;")
-
-		// create the hook in the database
-		err := _database.CreateHook(test.want)
-		if err != nil {
-			t.Errorf("unable to create test hook: %v", err)
+		if test.want != nil {
+			// create the hook in the database
+			err := _database.CreateHook(test.want)
+			if err != nil {
+				t.Errorf("unable to create test hook: %v", err)
+			}
 		}
 
 		got, err := _database.GetHook(1, _repo)
+
+		// cleanup the hooks table
+		_ = _database.Sqlite.Exec("DELETE FROM hooks;")
 
 		if test.failure {
 			if err == nil {
@@ -108,20 +114,26 @@ func TestSqlite_Client_GetLastHook(t *testing.T) {
 			failure: false,
 			want:    _hook,
 		},
+		{
+			failure: false,
+			want:    nil,
+		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		// defer cleanup of the hooks table
-		defer _database.Sqlite.Exec("delete from hooks;")
-
-		// create the hook in the database
-		err := _database.CreateHook(test.want)
-		if err != nil {
-			t.Errorf("unable to create test hook: %v", err)
+		if test.want != nil {
+			// create the hook in the database
+			err := _database.CreateHook(test.want)
+			if err != nil {
+				t.Errorf("unable to create test hook: %v", err)
+			}
 		}
 
 		got, err := _database.GetLastHook(_repo)
+
+		// cleanup the hooks table
+		_ = _database.Sqlite.Exec("DELETE FROM hooks;")
 
 		if test.failure {
 			if err == nil {

--- a/database/sqlite/log_test.go
+++ b/database/sqlite/log_test.go
@@ -103,20 +103,26 @@ func TestSqlite_Client_GetStepLog(t *testing.T) {
 			failure: false,
 			want:    _log,
 		},
+		{
+			failure: true,
+			want:    nil,
+		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		// defer cleanup of the logs table
-		defer _database.Sqlite.Exec("delete from logs;")
-
-		// create the log in the database
-		err := _database.CreateLog(test.want)
-		if err != nil {
-			t.Errorf("unable to create test log: %v", err)
+		if test.want != nil {
+			// create the log in the database
+			err := _database.CreateLog(test.want)
+			if err != nil {
+				t.Errorf("unable to create test log: %v", err)
+			}
 		}
 
 		got, err := _database.GetStepLog(1)
+
+		// cleanup the logs table
+		_ = _database.Sqlite.Exec("DELETE FROM logs;")
 
 		if test.failure {
 			if err == nil {
@@ -161,20 +167,26 @@ func TestSqlite_Client_GetServiceLog(t *testing.T) {
 			failure: false,
 			want:    _log,
 		},
+		{
+			failure: true,
+			want:    nil,
+		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		// defer cleanup of the logs table
-		defer _database.Sqlite.Exec("delete from logs;")
-
-		// create the log in the database
-		err := _database.CreateLog(test.want)
-		if err != nil {
-			t.Errorf("unable to create test log: %v", err)
+		if test.want != nil {
+			// create the log in the database
+			err := _database.CreateLog(test.want)
+			if err != nil {
+				t.Errorf("unable to create test log: %v", err)
+			}
 		}
 
 		got, err := _database.GetServiceLog(1)
+
+		// cleanup the logs table
+		_ = _database.Sqlite.Exec("DELETE FROM logs;")
 
 		if test.failure {
 			if err == nil {

--- a/database/sqlite/secret_test.go
+++ b/database/sqlite/secret_test.go
@@ -37,20 +37,26 @@ func TestSqlite_Client_GetSecret_Org(t *testing.T) {
 			failure: false,
 			want:    _secret,
 		},
+		{
+			failure: true,
+			want:    nil,
+		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		// defer cleanup of the secrets table
-		defer _database.Sqlite.Exec("delete from secrets;")
-
-		// create the secret in the database
-		err := _database.CreateSecret(test.want)
-		if err != nil {
-			t.Errorf("unable to create test secret: %v", err)
+		if test.want != nil {
+			// create the secret in the database
+			err := _database.CreateSecret(test.want)
+			if err != nil {
+				t.Errorf("unable to create test secret: %v", err)
+			}
 		}
 
 		got, err := _database.GetSecret("org", "foo", "*", "bar")
+
+		// cleanup the secrets table
+		_ = _database.Sqlite.Exec("DELETE FROM secrets;")
 
 		if test.failure {
 			if err == nil {
@@ -96,20 +102,26 @@ func TestSqlite_Client_GetSecret_Repo(t *testing.T) {
 			failure: false,
 			want:    _secret,
 		},
+		{
+			failure: true,
+			want:    nil,
+		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		// defer cleanup of the secrets table
-		defer _database.Sqlite.Exec("delete from secrets;")
-
-		// create the secret in the database
-		err := _database.CreateSecret(test.want)
-		if err != nil {
-			t.Errorf("unable to create test secret: %v", err)
+		if test.want != nil {
+			// create the secret in the database
+			err := _database.CreateSecret(test.want)
+			if err != nil {
+				t.Errorf("unable to create test secret: %v", err)
+			}
 		}
 
 		got, err := _database.GetSecret("repo", "foo", "bar", "baz")
+
+		// cleanup the secrets table
+		_ = _database.Sqlite.Exec("DELETE FROM secrets;")
 
 		if test.failure {
 			if err == nil {
@@ -155,20 +167,26 @@ func TestSqlite_Client_GetSecret_Shared(t *testing.T) {
 			failure: false,
 			want:    _secret,
 		},
+		{
+			failure: true,
+			want:    nil,
+		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		// defer cleanup of the secrets table
-		defer _database.Sqlite.Exec("delete from secrets;")
-
-		// create the secret in the database
-		err := _database.CreateSecret(test.want)
-		if err != nil {
-			t.Errorf("unable to create test secret: %v", err)
+		if test.want != nil {
+			// create the secret in the database
+			err := _database.CreateSecret(test.want)
+			if err != nil {
+				t.Errorf("unable to create test secret: %v", err)
+			}
 		}
 
 		got, err := _database.GetSecret("shared", "foo", "bar", "baz")
+
+		// cleanup the secrets table
+		_ = _database.Sqlite.Exec("DELETE FROM secrets;")
 
 		if test.failure {
 			if err == nil {

--- a/database/sqlite/service_test.go
+++ b/database/sqlite/service_test.go
@@ -42,20 +42,26 @@ func TestSqlite_Client_GetService(t *testing.T) {
 			failure: false,
 			want:    _service,
 		},
+		{
+			failure: true,
+			want:    nil,
+		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		// defer cleanup of the services table
-		defer _database.Sqlite.Exec("delete from services;")
-
-		// create the service in the database
-		err := _database.CreateService(test.want)
-		if err != nil {
-			t.Errorf("unable to create test service: %v", err)
+		if test.want != nil {
+			// create the service in the database
+			err := _database.CreateService(test.want)
+			if err != nil {
+				t.Errorf("unable to create test service: %v", err)
+			}
 		}
 
 		got, err := _database.GetService(1, _build)
+
+		// cleanup the services table
+		_ = _database.Sqlite.Exec("DELETE FROM services;")
 
 		if test.failure {
 			if err == nil {

--- a/database/sqlite/step.go
+++ b/database/sqlite/step.go
@@ -5,10 +5,13 @@
 package sqlite
 
 import (
+	"errors"
+
 	"github.com/go-vela/server/database/sqlite/dml"
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
+	"gorm.io/gorm"
 
 	"github.com/sirupsen/logrus"
 )
@@ -21,12 +24,17 @@ func (c *client) GetStep(number int, b *library.Build) (*library.Step, error) {
 	s := new(database.Step)
 
 	// send query to the database and store result in variable
-	err := c.Sqlite.
+	result := c.Sqlite.
 		Table(constants.TableStep).
 		Raw(dml.SelectBuildStep, b.GetID(), number).
-		Scan(s).Error
+		Scan(s)
 
-	return s.ToLibrary(), err
+	// check if the query returned a record not found error or no rows were returned
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	return s.ToLibrary(), result.Error
 }
 
 // CreateStep creates a new step in the database.

--- a/database/sqlite/step_test.go
+++ b/database/sqlite/step_test.go
@@ -42,20 +42,26 @@ func TestSqlite_Client_GetStep(t *testing.T) {
 			failure: false,
 			want:    _step,
 		},
+		{
+			failure: true,
+			want:    nil,
+		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		// defer cleanup of the steps table
-		defer _database.Sqlite.Exec("delete from steps;")
-
-		// create the step in the database
-		err := _database.CreateStep(test.want)
-		if err != nil {
-			t.Errorf("unable to create test step: %v", err)
+		if test.want != nil {
+			// create the step in the database
+			err := _database.CreateStep(test.want)
+			if err != nil {
+				t.Errorf("unable to create test step: %v", err)
+			}
 		}
 
 		got, err := _database.GetStep(1, _build)
+
+		// cleanup the steps table
+		_ = _database.Sqlite.Exec("DELETE FROM steps;")
 
 		if test.failure {
 			if err == nil {

--- a/database/sqlite/user_test.go
+++ b/database/sqlite/user_test.go
@@ -35,20 +35,26 @@ func TestSqlite_Client_GetUser(t *testing.T) {
 			failure: false,
 			want:    _user,
 		},
+		{
+			failure: true,
+			want:    nil,
+		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		// defer cleanup of the users table
-		defer _database.Sqlite.Exec("delete from users;")
-
-		// create the user in the database
-		err := _database.CreateUser(test.want)
-		if err != nil {
-			t.Errorf("unable to create test user: %v", err)
+		if test.want != nil {
+			// create the user in the database
+			err := _database.CreateUser(test.want)
+			if err != nil {
+				t.Errorf("unable to create test user: %v", err)
+			}
 		}
 
 		got, err := _database.GetUser(1)
+
+		// cleanup the users table
+		_ = _database.Sqlite.Exec("DELETE FROM users;")
 
 		if test.failure {
 			if err == nil {

--- a/database/sqlite/worker.go
+++ b/database/sqlite/worker.go
@@ -5,10 +5,13 @@
 package sqlite
 
 import (
+	"errors"
+
 	"github.com/go-vela/server/database/sqlite/dml"
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
+	"gorm.io/gorm"
 
 	"github.com/sirupsen/logrus"
 )
@@ -21,12 +24,17 @@ func (c *client) GetWorker(hostname string) (*library.Worker, error) {
 	w := new(database.Worker)
 
 	// send query to the database and store result in variable
-	err := c.Sqlite.
+	result := c.Sqlite.
 		Table(constants.TableWorker).
 		Raw(dml.SelectWorker, hostname).
-		Scan(w).Error
+		Scan(w)
 
-	return w.ToLibrary(), err
+	// check if the query returned a record not found error or no rows were returned
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	return w.ToLibrary(), result.Error
 }
 
 // GetWorker gets a worker by address from the database.
@@ -37,12 +45,17 @@ func (c *client) GetWorkerByAddress(address string) (*library.Worker, error) {
 	w := new(database.Worker)
 
 	// send query to the database and store result in variable
-	err := c.Sqlite.
+	result := c.Sqlite.
 		Table(constants.TableWorker).
 		Raw(dml.SelectWorkerByAddress, address).
-		Scan(w).Error
+		Scan(w)
 
-	return w.ToLibrary(), err
+	// check if the query returned a record not found error or no rows were returned
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	return w.ToLibrary(), result.Error
 }
 
 // CreateWorker creates a new worker in the database.

--- a/database/sqlite/worker_test.go
+++ b/database/sqlite/worker_test.go
@@ -35,20 +35,26 @@ func TestSqlite_Client_GetWorker(t *testing.T) {
 			failure: false,
 			want:    _worker,
 		},
+		{
+			failure: true,
+			want:    nil,
+		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		// defer cleanup of the workers table
-		defer _database.Sqlite.Exec("delete from workers;")
-
-		// create the worker in the database
-		err := _database.CreateWorker(test.want)
-		if err != nil {
-			t.Errorf("unable to create test worker: %v", err)
+		if test.want != nil {
+			// create the worker in the database
+			err := _database.CreateWorker(test.want)
+			if err != nil {
+				t.Errorf("unable to create test worker: %v", err)
+			}
 		}
 
 		got, err := _database.GetWorker("worker_0")
+
+		// cleanup the workers table
+		_ = _database.Sqlite.Exec("DELETE FROM workers;")
 
 		if test.failure {
 			if err == nil {
@@ -92,20 +98,26 @@ func TestSqlite_Client_GetWorkerByAddress(t *testing.T) {
 			failure: false,
 			want:    _worker,
 		},
+		{
+			failure: true,
+			want:    nil,
+		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		// defer cleanup of the workers table
-		defer _database.Sqlite.Exec("delete from workers;")
-
-		// create the worker in the database
-		err := _database.CreateWorker(test.want)
-		if err != nil {
-			t.Errorf("unable to create test worker: %v", err)
+		if test.want != nil {
+			// create the worker in the database
+			err := _database.CreateWorker(test.want)
+			if err != nil {
+				t.Errorf("unable to create test worker: %v", err)
+			}
 		}
 
 		got, err := _database.GetWorkerByAddress("localhost")
+
+		// cleanup the workers table
+		_ = _database.Sqlite.Exec("DELETE FROM workers;")
 
 		if test.failure {
 			if err == nil {


### PR DESCRIPTION
Leftover work for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-gorm/gorm/issues/4416

**This is a workaround to a problem found in an upstream library.**

This updates the `go-vela/server/database/sqlite` client to specifically check for the rows returned from queries:

https://github.com/go-vela/server/blob/c7e995a6546ba08f2c977428cd79a8a3ed726a32/database/sqlite/build.go#L35-L38

You'll note that we are explicitly checking the `RowsAffected` field is equal to `0` from the result returned by GORM.

This is required due to what initially appears to be a bug in GORM (See above [go-gorm/gorm](https://github.com/go-gorm/gorm) issue for more details).

GORM no longer returns `record not found` when a query is ran against the database and no rows are returned.