### PR TITLE
refactor(database)!: switch to use sqlite.New()

### DIFF
--- a/cmd/vela-server/database.go
+++ b/cmd/vela-server/database.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/database/postgres"
+	"github.com/go-vela/server/database/sqlite"
 	"github.com/go-vela/types/constants"
 
 	"github.com/sirupsen/logrus"
@@ -50,5 +51,16 @@ func setupPostgres(c *cli.Context) (database.Service, error) {
 // helper function to setup the Sqlite database from the CLI arguments.
 func setupSqlite(c *cli.Context) (database.Service, error) {
 	logrus.Tracef("Creating %s database client from CLI configuration", constants.DriverSqlite)
-	return database.New(c)
+
+	// create new Sqlite database service
+	//
+	// https://pkg.go.dev/github.com/go-vela/server/database/sqlite?tab=doc#New
+	return sqlite.New(
+		sqlite.WithAddress(c.String("database.config")),
+		sqlite.WithCompressionLevel(c.Int("database.compression.level")),
+		sqlite.WithConnectionLife(c.Duration("database.connection.life")),
+		sqlite.WithConnectionIdle(c.Int("database.connection.idle")),
+		sqlite.WithConnectionOpen(c.Int("database.connection.open")),
+		sqlite.WithEncryptionKey(c.String("database.encryption.key")),
+	)
 }


### PR DESCRIPTION
Leftover work for https://github.com/go-vela/community/issues/248

Related to https://github.com/go-vela/server/pull/342

This updates the codebase to now utilize the `github.com/go-vela/server/database/sqlite.New()` function:

https://github.com/go-vela/server/blob/157109c980447bbca2b5f13cdeb8786bfa363849/cmd/vela-server/database.go#L51-L66