### PR TITLE
enhance(database): validate compression level in setup

### DIFF
--- a/database/setup.go
+++ b/database/setup.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-vela/server/database/postgres"
 	"github.com/go-vela/server/database/sqlite"
+	"github.com/go-vela/types/constants"
 	"github.com/sirupsen/logrus"
 )
 
@@ -95,6 +96,35 @@ func (s *Setup) Validate() error {
 	// verify a database encryption key was provided
 	if len(s.EncryptionKey) == 0 {
 		return fmt.Errorf("no database encryption key provided")
+	}
+
+	// verify the database compression level is valid
+	switch s.CompressionLevel {
+	case constants.CompressionNegOne:
+		fallthrough
+	case constants.CompressionZero:
+		fallthrough
+	case constants.CompressionOne:
+		fallthrough
+	case constants.CompressionTwo:
+		fallthrough
+	case constants.CompressionThree:
+		fallthrough
+	case constants.CompressionFour:
+		fallthrough
+	case constants.CompressionFive:
+		fallthrough
+	case constants.CompressionSix:
+		fallthrough
+	case constants.CompressionSeven:
+		fallthrough
+	case constants.CompressionEight:
+		fallthrough
+	case constants.CompressionNine:
+		break
+	default:
+		// nolint:lll // ignoring line length due to error message
+		return fmt.Errorf("database compression level must be between %d and %d - provided level: %d", constants.CompressionNegOne, constants.CompressionNine, s.CompressionLevel)
 	}
 
 	// enforce AES-256 for the encryption key - explicitly check for 32 characters in the key

--- a/database/setup_test.go
+++ b/database/setup_test.go
@@ -130,6 +130,18 @@ func TestDatabase_Setup_Validate(t *testing.T) {
 			},
 		},
 		{
+			failure: false,
+			setup: &Setup{
+				Driver:           "postgres",
+				Address:          "postgres://foo:bar@localhost:5432/vela",
+				CompressionLevel: -1,
+				ConnectionLife:   10 * time.Second,
+				ConnectionIdle:   5,
+				ConnectionOpen:   20,
+				EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
+			},
+		},
+		{
 			failure: true,
 			setup: &Setup{
 				Driver:           "postgres",
@@ -187,6 +199,18 @@ func TestDatabase_Setup_Validate(t *testing.T) {
 				ConnectionIdle:   5,
 				ConnectionOpen:   20,
 				EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0",
+			},
+		},
+		{
+			failure: true,
+			setup: &Setup{
+				Driver:           "postgres",
+				Address:          "postgres://foo:bar@localhost:5432/vela",
+				CompressionLevel: 10,
+				ConnectionLife:   10 * time.Second,
+				ConnectionIdle:   5,
+				ConnectionOpen:   20,
+				EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
 			},
 		},
 	}


### PR DESCRIPTION
Leftover work for https://github.com/go-vela/community/issues/248

This ensures we validate the compression level field for logs stored in the database.

This is carried over from the previously used validation logic for database configuration:

https://github.com/go-vela/server/blob/64ac1023e85df61fe83d52d1eeda103869c21634/cmd/vela-server/validate.go#L116-L165