### PR TITLE
refactor!: switch to using database.New()

### DIFF
--- a/cmd/vela-server/database.go
+++ b/cmd/vela-server/database.go
@@ -5,12 +5,7 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/go-vela/server/database"
-	"github.com/go-vela/server/database/postgres"
-	"github.com/go-vela/server/database/sqlite"
-	"github.com/go-vela/types/constants"
 
 	"github.com/sirupsen/logrus"
 
@@ -21,46 +16,19 @@ import (
 func setupDatabase(c *cli.Context) (database.Service, error) {
 	logrus.Debug("Creating database client from CLI configuration")
 
-	switch c.String("database.driver") {
-	case constants.DriverPostgres, "postgresql":
-		return setupPostgres(c)
-	case constants.DriverSqlite, "sqlite":
-		return setupSqlite(c)
-	default:
-		return nil, fmt.Errorf("invalid database driver: %s", c.String("database.driver"))
+	// database configuration
+	_setup := &database.Setup{
+		Driver:           c.String("database.driver"),
+		Address:          c.String("database.addr"),
+		CompressionLevel: c.Int("database.compression.level"),
+		ConnectionLife:   c.Duration("database.connection.life"),
+		ConnectionIdle:   c.Int("database.connection.idle"),
+		ConnectionOpen:   c.Int("database.connection.open"),
+		EncryptionKey:    c.String("database.encryption.key"),
 	}
-}
 
-// helper function to setup the Postgres database from the CLI arguments.
-func setupPostgres(c *cli.Context) (database.Service, error) {
-	logrus.Tracef("Creating %s database client from CLI configuration", constants.DriverPostgres)
-
-	// create new Postgres database service
+	// setup the database
 	//
-	// https://pkg.go.dev/github.com/go-vela/server/database/postgres?tab=doc#New
-	return postgres.New(
-		postgres.WithAddress(c.String("database.config")),
-		postgres.WithCompressionLevel(c.Int("database.compression.level")),
-		postgres.WithConnectionLife(c.Duration("database.connection.life")),
-		postgres.WithConnectionIdle(c.Int("database.connection.idle")),
-		postgres.WithConnectionOpen(c.Int("database.connection.open")),
-		postgres.WithEncryptionKey(c.String("database.encryption.key")),
-	)
-}
-
-// helper function to setup the Sqlite database from the CLI arguments.
-func setupSqlite(c *cli.Context) (database.Service, error) {
-	logrus.Tracef("Creating %s database client from CLI configuration", constants.DriverSqlite)
-
-	// create new Sqlite database service
-	//
-	// https://pkg.go.dev/github.com/go-vela/server/database/sqlite?tab=doc#New
-	return sqlite.New(
-		sqlite.WithAddress(c.String("database.config")),
-		sqlite.WithCompressionLevel(c.Int("database.compression.level")),
-		sqlite.WithConnectionLife(c.Duration("database.connection.life")),
-		sqlite.WithConnectionIdle(c.Int("database.connection.idle")),
-		sqlite.WithConnectionOpen(c.Int("database.connection.open")),
-		sqlite.WithEncryptionKey(c.String("database.encryption.key")),
-	)
+	// https://pkg.go.dev/github.com/go-vela/server/database?tab=doc#New
+	return database.New(_setup)
 }

--- a/cmd/vela-server/main.go
+++ b/cmd/vela-server/main.go
@@ -9,10 +9,10 @@ import (
 	"time"
 
 	"github.com/go-vela/pkg-queue/queue"
+	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/secret"
 	"github.com/go-vela/server/source"
 	"github.com/go-vela/server/version"
-	"github.com/go-vela/types/constants"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
@@ -116,50 +116,6 @@ func main() {
 			Usage:   "github token, used by compiler, for pulling registry templates",
 		},
 
-		// Database Flags
-
-		&cli.StringFlag{
-			EnvVars: []string{"VELA_DATABASE_DRIVER", "DATABASE_DRIVER"},
-			Name:    "database.driver",
-			Usage:   "sets the driver to be used for the database",
-			Value:   "sqlite3",
-		},
-		&cli.StringFlag{
-			EnvVars: []string{"VELA_DATABASE_CONFIG", "DATABASE_CONFIG"},
-			Name:    "database.config",
-			Usage:   "sets the configuration string to be used for the database",
-			Value:   "vela.sqlite",
-		},
-		&cli.IntFlag{
-			EnvVars: []string{"VELA_DATABASE_CONNECTION_OPEN", "DATABASE_CONNECTION_OPEN"},
-			Name:    "database.connection.open",
-			Usage:   "sets the number of open connections to the database",
-			Value:   0,
-		},
-		&cli.IntFlag{
-			EnvVars: []string{"VELA_DATABASE_CONNECTION_IDLE", "DATABASE_CONNECTION_IDLE"},
-			Name:    "database.connection.idle",
-			Usage:   "sets the number of idle connections to the database",
-			Value:   2,
-		},
-		&cli.DurationFlag{
-			EnvVars: []string{"VELA_DATABASE_CONNECTION_LIFE", "DATABASE_CONNECTION_LIFE"},
-			Name:    "database.connection.life",
-			Usage:   "sets the amount of time a connection may be reused for the database",
-			Value:   30 * time.Minute,
-		},
-		&cli.IntFlag{
-			EnvVars: []string{"VELA_DATABASE_COMPRESSION_LEVEL", "DATABASE_COMPRESSION_LEVEL"},
-			Name:    "database.compression.level",
-			Usage:   "sets the level of compression for logs stored in the database",
-			Value:   constants.CompressionThree,
-		},
-		&cli.StringFlag{
-			EnvVars: []string{"VELA_DATABASE_ENCRYPTION_KEY", "DATABASE_ENCRYPTION_KEY"},
-			Name:    "database.encryption.key",
-			Usage:   "AES-256 key for encrypting and decrypting values",
-		},
-
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_MODIFICATION_ADDR", "MODIFICATION_ADDR"},
 			Name:    "modification-addr",
@@ -193,6 +149,10 @@ func main() {
 			Value:   5 * time.Minute,
 		},
 	}
+
+	// Database Flags
+
+	app.Flags = append(app.Flags, database.Flags...)
 
 	// Queue Flags
 

--- a/cmd/vela-server/metadata.go
+++ b/cmd/vela-server/metadata.go
@@ -55,7 +55,7 @@ func setupMetadata(c *cli.Context) (*types.Metadata, error) {
 func metadataDatabase(c *cli.Context) (*types.Database, error) {
 	logrus.Trace("Creating database metadata from CLI configuration")
 
-	u, err := url.Parse(c.String("database.config"))
+	u, err := url.Parse(c.String("database.addr"))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/vela-server/validate.go
+++ b/cmd/vela-server/validate.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-vela/types/constants"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
@@ -24,24 +23,6 @@ func validate(c *cli.Context) error {
 
 	// validate compiler configuration
 	err = validateCompiler(c)
-	if err != nil {
-		return err
-	}
-
-	// validate database configuration
-	err = validateDatabase(c)
-	if err != nil {
-		return err
-	}
-
-	// validate secret configuration
-	err = validateSecret(c)
-	if err != nil {
-		return err
-	}
-
-	// validate source configuration
-	err = validateSource(c)
 	if err != nil {
 		return err
 	}
@@ -107,111 +88,6 @@ func validateCompiler(c *cli.Context) error {
 
 		if len(c.String("github-token")) == 0 {
 			return fmt.Errorf("github-token (VELA_COMPILER_GITHUB_TOKEN or COMPILER_GITHUB_TOKEN) flag not specified")
-		}
-	}
-
-	return nil
-}
-
-// helper function to validate the database CLI configuration.
-func validateDatabase(c *cli.Context) error {
-	logrus.Trace("Validating database CLI configuration")
-
-	if len(c.String("database.driver")) == 0 {
-		return fmt.Errorf("database.driver (VELA_DATABASE_DRIVER or DATABASE_DRIVER) flag not specified")
-	}
-
-	if len(c.String("database.config")) == 0 {
-		return fmt.Errorf("database.config (VELA_DATABASE_CONFIG or DATABASE_CONFIG) flag not specified")
-	}
-
-	switch c.Int("database.compression.level") {
-	case constants.CompressionNegOne:
-		fallthrough
-	case constants.CompressionZero:
-		fallthrough
-	case constants.CompressionOne:
-		fallthrough
-	case constants.CompressionTwo:
-		fallthrough
-	case constants.CompressionThree:
-		fallthrough
-	case constants.CompressionFour:
-		fallthrough
-	case constants.CompressionFive:
-		fallthrough
-	case constants.CompressionSix:
-		fallthrough
-	case constants.CompressionSeven:
-		fallthrough
-	case constants.CompressionEight:
-		fallthrough
-	case constants.CompressionNine:
-		break
-	default:
-		// nolint:lll // ignoring line length due to error message
-		return fmt.Errorf("database compression level of '%d' is unsupported", c.Int("database.compression.level"))
-	}
-
-	// enforce AES-256, so check explicitly for 32 bytes on the key
-	//
-	// nolint: gomnd // ignore magic number
-	if len(c.String("database.encryption.key")) != 32 {
-		// nolint: lll // ignore long line length due to long error message
-		return fmt.Errorf("database.encryption.key (VELA_DATABASE_ENCRYPTION_KEY or DATABASE_ENCRYPTION_KEY) invalid length specified: %d", len(c.String("database.encryption.key")))
-	}
-
-	return nil
-}
-
-// helper function to validate the secret CLI configuration.
-//
-// nolint:lll // ignoring line length check to avoid breaking up error messages
-func validateSecret(c *cli.Context) error {
-	logrus.Trace("Validating secret CLI configuration")
-
-	if c.Bool("vault-driver") {
-		if len(c.String("vault-addr")) == 0 {
-			return fmt.Errorf("vault-addr (VELA_SECRET_VAULT_ADDR or SECRET_VAULT_ADDR) flag not specified")
-		}
-
-		if len(c.String("vault-token")) == 0 && len(c.String("vault-auth-method")) == 0 {
-			return fmt.Errorf("vault-token (VELA_SECRET_VAULT_TOKEN or SECRET_VAULT_TOKEN) or vault-auth-method (VELA_SECRET_VAULT_AUTH_METHOD or SECRET_VAULT_AUTH_METHOD) flag not specified")
-		}
-
-		if len(c.String("vault-token")) == 0 {
-			switch c.String("vault-auth-method") {
-			case "aws":
-			default:
-				return fmt.Errorf("vault auth method of '%s' is unsupported", c.String("vault-auth-method"))
-			}
-
-			if c.String("vault-auth-method") == "aws" {
-				if len(c.String("vault-aws-role")) == 0 {
-					return fmt.Errorf("vault-aws-role (VELA_SECRET_VAULT_AWS_ROLE or SECRET_VAULT_AWS_ROLE) flag not specified")
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-// helper function to validate the source CLI configuration.
-func validateSource(c *cli.Context) error {
-	logrus.Trace("Validating source CLI configuration")
-
-	if len(c.String("source-driver")) > 0 {
-		if len(c.String("source-url")) == 0 {
-			return fmt.Errorf("source-url (VELA_SOURCE_URL or SOURCE_URL) flag not specified")
-		}
-
-		if len(c.String("source-client")) == 0 {
-			return fmt.Errorf("source-client (VELA_SOURCE_CLIENT or SOURCE_CLIENT) flag not specified")
-		}
-
-		if len(c.String("source-secret")) == 0 {
-			return fmt.Errorf("source-secret (VELA_SOURCE_SECRET or SOURCE_SECRET) flag not specified")
 		}
 	}
 

--- a/database/flags.go
+++ b/database/flags.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package database
+
+import (
+	"time"
+
+	"github.com/go-vela/types/constants"
+	"github.com/urfave/cli/v2"
+)
+
+// Flags represents all supported command line
+// interface (CLI) flags for the database.
+//
+// https://pkg.go.dev/github.com/urfave/cli?tab=doc#Flag
+var Flags = []cli.Flag{
+
+	// Logger Flags
+
+	&cli.StringFlag{
+		EnvVars: []string{"VELA_DATABASE_LOG_FORMAT", "DATABASE_LOG_FORMAT", "VELA_LOG_FORMAT"},
+		Name:    "database.log.format",
+		Usage:   "format of logs to output",
+		Value:   "json",
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"VELA_DATABASE_LOG_LEVEL", "DATABASE_LOG_LEVEL", "VELA_LOG_LEVEL"},
+		Name:    "database.log.level",
+		Usage:   "level of logs to output",
+		Value:   "info",
+	},
+
+	// Database Flags
+
+	&cli.StringFlag{
+		EnvVars: []string{"VELA_DATABASE_DRIVER", "DATABASE_DRIVER"},
+		Name:    "database.driver",
+		Usage:   "driver to be used for the database system",
+		Value:   "sqlite3",
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"VELA_DATABASE_ADDR", "DATABASE_ADDR"},
+		Name:    "database.addr",
+		Usage:   "fully qualified url (<scheme>://<host>) for the database",
+		Value:   "vela.sqlite",
+	},
+	&cli.IntFlag{
+		EnvVars: []string{"VELA_DATABASE_CONNECTION_OPEN", "DATABASE_CONNECTION_OPEN"},
+		Name:    "database.connection.open",
+		Usage:   "maximum number of open connections to the database",
+		Value:   0,
+	},
+	&cli.IntFlag{
+		EnvVars: []string{"VELA_DATABASE_CONNECTION_IDLE", "DATABASE_CONNECTION_IDLE"},
+		Name:    "database.connection.idle",
+		Usage:   "maximum number of idle connections to the database",
+		Value:   2,
+	},
+	&cli.DurationFlag{
+		EnvVars: []string{"VELA_DATABASE_CONNECTION_LIFE", "DATABASE_CONNECTION_LIFE"},
+		Name:    "database.connection.life",
+		Usage:   "duration of time a connection may be reused for the database",
+		Value:   30 * time.Minute,
+	},
+	&cli.IntFlag{
+		EnvVars: []string{"VELA_DATABASE_COMPRESSION_LEVEL", "DATABASE_COMPRESSION_LEVEL"},
+		Name:    "database.compression.level",
+		Usage:   "level of compression for logs stored in the database",
+		Value:   constants.CompressionThree,
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"VELA_DATABASE_ENCRYPTION_KEY", "DATABASE_ENCRYPTION_KEY"},
+		Name:    "database.encryption.key",
+		Usage:   "AES-256 key for encrypting and decrypting values in the database",
+	},
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,10 @@ services:
     networks:
       - vela
     environment:
+      DATABASE_DRIVER: postgres
+      DATABASE_ADDR: 'postgres://vela:zB7mrKDTZqNeNTD8z47yG4DHywspAh@postgres:5432/vela?sslmode=disable'
+      DATABASE_COMPRESSION_LEVEL: 3
+      DATABASE_ENCRYPTION_KEY: 'C639A572E14D5075C526FDDD43E4ECF6'
       QUEUE_DRIVER: redis
       QUEUE_ADDR: 'redis://redis:6379'
       QUEUE_ROUTES: 'docker,local,docker:local'
@@ -32,9 +36,6 @@ services:
       SECRET_VAULT_TOKEN: vela
       VELA_ADDR: 'http://localhost:8080'
       VELA_WEBUI_ADDR: 'http://localhost:8888'
-      VELA_DATABASE_DRIVER: postgres
-      VELA_DATABASE_CONFIG: 'postgres://vela:zB7mrKDTZqNeNTD8z47yG4DHywspAh@postgres:5432/vela?sslmode=disable'
-      VELA_DATABASE_ENCRYPTION_KEY: 'C639A572E14D5075C526FDDD43E4ECF6'
       VELA_LOG_LEVEL: trace
       VELA_SECRET: 'zB7mrKDTZqNeNTD8z47yG4DHywspAh'
       VELA_REFRESH_TOKEN_DURATION: 90m


### PR DESCRIPTION
Leftover work from https://github.com/go-vela/community/issues/248

Related to https://github.com/go-vela/server/pull/398, https://github.com/go-vela/server/pull/411 and https://github.com/go-vela/server/pull/416.

This updates the codebase to now utilize the `database.New()` function call and `database.Setup{}` type:

https://github.com/go-vela/server/blob/01a3e68116b41e9f3268cda868b37ebefd9d3bb4/cmd/vela-server/database.go#L15-L34

Along with this change, moved the flags for the `database` package into the `database.Flags{}` type:

https://github.com/go-vela/server/blob/01a3e68116b41e9f3268cda868b37ebefd9d3bb4/database/flags.go#L14-L78

> NOTE: The following flags are modified with this change:
> 
> * `database.config` -> `database.addr`