### PR TITLE
enhance(build): set canceled commit status in source system

### DIFF
--- a/api/build.go
+++ b/api/build.go
@@ -896,6 +896,7 @@ func UpdateBuild(c *gin.Context) {
 	// check if the build is in a "final" state
 	if b.GetStatus() == constants.StatusSuccess ||
 		b.GetStatus() == constants.StatusFailure ||
+		b.GetStatus() == constants.StatusCanceled ||
 		b.GetStatus() == constants.StatusKilled ||
 		b.GetStatus() == constants.StatusError {
 		// send API call to capture the repo owner

--- a/source/github/repo.go
+++ b/source/github/repo.go
@@ -205,13 +205,16 @@ func (c *client) Status(u *library.User, b *library.Build, org, name string) err
 	switch b.GetStatus() {
 	case constants.StatusRunning, constants.StatusPending:
 		state = "pending"
-		description = "the build is pending"
+		description = fmt.Sprintf("the build is %s", b.GetStatus())
 	case constants.StatusSuccess:
 		state = "success"
 		description = "the build was successful"
 	case constants.StatusFailure:
 		state = "failure"
 		description = "the build has failed"
+	case constants.StatusCanceled:
+		state = "failure"
+		description = "the build was canceled"
 	case constants.StatusKilled:
 		state = "failure"
 		description = "the build was killed"


### PR DESCRIPTION
This updates the `PUT /api/v1/repos/:org/:repo/builds/:build` endpoint in Vela.

Currently, if a build is `canceled`, we don't actually update the commit `status` in the source system like other statuses.

This is controlled through the `github.com/go-vela/api/UpdateBuild()` function:

https://github.com/go-vela/server/blob/35c522e3d72e7781abde74056303eb09a63beb86/api/build.go#L896-L913

And the `github.com/go-vela/server/source.Status()` function doesn't account for the `canceled` status either:

https://github.com/go-vela/server/blob/35c522e3d72e7781abde74056303eb09a63beb86/source/github/repo.go#L203-L221

This augments these functions for the API endpoint to account for the `canceled` status when setting it for the commit.