### PR TITLE
fix(database): creating secrets with empty fields

### DIFF
--- a/database/postgres/secret.go
+++ b/database/postgres/secret.go
@@ -111,7 +111,7 @@ func (c *client) CreateSecret(s *library.Secret) error {
 	// send query to the database
 	return c.Postgres.
 		Table(constants.TableSecret).
-		Create(secret).Error
+		Create(secret.Nullify()).Error
 }
 
 // UpdateSecret updates a secret in the database.

--- a/database/postgres/secret_test.go
+++ b/database/postgres/secret_test.go
@@ -245,7 +245,7 @@ func TestPostgres_Client_CreateSecret(t *testing.T) {
 
 	// ensure the mock expects the query
 	_mock.ExpectQuery(`INSERT INTO "secrets" ("org","repo","team","name","value","type","images","events","allow_command","id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) RETURNING "id"`).
-		WithArgs("foo", "bar", "", "baz", AnyArgument{}, "repo", "{}", "{}", false, 1).
+		WithArgs("foo", "bar", nil, "baz", AnyArgument{}, "repo", "{}", "{}", false, 1).
 		WillReturnRows(_rows)
 
 	// setup tests

--- a/database/sqlite/secret.go
+++ b/database/sqlite/secret.go
@@ -111,7 +111,7 @@ func (c *client) CreateSecret(s *library.Secret) error {
 	// send query to the database
 	return c.Sqlite.
 		Table(constants.TableSecret).
-		Create(secret).Error
+		Create(secret.Nullify()).Error
 }
 
 // UpdateSecret updates a secret in the database.


### PR DESCRIPTION
Related to https://github.com/go-vela/types/pull/166

Currently, there is a bug when attempting to create `secrets` in Vela.

If you attempt to create a `repo` or `shared` secret, you may experience errors from the database like:

```
Status 500 (unable to create secret <secret> for native service: ERROR: duplicate key value violates unique constraint "secrets_type_org_team_name_key" (SQLSTATE 23505))
```

OR

```
Status 500 (unable to create secret <secret> for native service: ERROR: duplicate key value violates unique constraint "secrets_type_org_repo_name_key" (SQLSTATE 23505))
```

This only happens when you attempt to create a secret that has the same `name` and is in the same `org`.

An example to replicate the behavior for `repo` secrets:

```
$ vela add secret --secret.engine native --secret.type repo --org MyOrg --repo repo1 --name foo --value bar

$ vela add secret --secret.engine native --secret.type repo --org MyOrg --repo repo2 --name foo --value bar
```

> NOTE: The `org` and `name` fields are the same above, but the `repo` is different.