### PR TITLE
feat: output version info to stdout

### DIFF
--- a/cmd/vela-server/main.go
+++ b/cmd/vela-server/main.go
@@ -183,7 +183,8 @@ func main() {
 	// set logrus to log in JSON format
 	logrus.SetFormatter(&logrus.JSONFormatter{})
 
-	if err := app.Run(os.Args); err != nil {
+	err = app.Run(os.Args)
+	if err != nil {
 		logrus.Fatal(err)
 	}
 }

--- a/cmd/vela-server/main.go
+++ b/cmd/vela-server/main.go
@@ -5,6 +5,8 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"time"
 
@@ -19,10 +21,22 @@ import (
 
 // nolint: funlen // ignore function length due to flags
 func main() {
+	// capture application version information
+	v := version.New()
+
+	// serialize the version information as pretty JSON
+	bytes, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	// output the version information to stdout
+	fmt.Fprintf(os.Stdout, "%s\n", string(bytes))
+
 	app := cli.NewApp()
 	app.Name = "vela-server"
 	app.Action = server
-	app.Version = version.New().Semantic()
+	app.Version = v.Semantic()
 
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{


### PR DESCRIPTION
This updates the `github.com/go-vela/server` app to output the version information to stdout on startup:

```sh
$ docker logs server
{
  "canonical": "v0.8.2",
  "major": 0,
  "minor": 8,
  "patch": 2,
  "metadata": {
    "architecture": "amd64",
    "build_date": "2021-06-15T08:57:00Z",
    "compiler": "gc",
    "git_commit": "7ed708324825cc05e596306093a2855da47330c7",
    "go_version": "go1.16.5",
    "operating_system": "linux"
  }
}
<more logs>
```