### PR TITLE
feat: add database.Driver() function

### DIFF
--- a/database/postgres/driver.go
+++ b/database/postgres/driver.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import "github.com/go-vela/types/constants"
+
+// Driver outputs the configured database driver.
+func (c *client) Driver() string {
+	return constants.DriverPostgres
+}

--- a/database/postgres/driver_test.go
+++ b/database/postgres/driver_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-vela/types/constants"
+)
+
+func TestPostgres_Client_Driver(t *testing.T) {
+	// setup types
+	want := constants.DriverPostgres
+
+	// setup the test database client
+	_database, _, err := NewTest()
+	if err != nil {
+		t.Errorf("unable to create new postgres test database: %v", err)
+	}
+	defer func() { _sql, _ := _database.Postgres.DB(); _sql.Close() }()
+
+	// run test
+	got := _database.Driver()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Driver is %v, want %v", got, want)
+	}
+}

--- a/database/service.go
+++ b/database/service.go
@@ -11,6 +11,12 @@ import (
 // Service represents the interface for Vela integrating
 // with the different supported Database backends.
 type Service interface {
+	// Database Interface Functions
+
+	// Driver defines a function that outputs
+	// the configured database driver.
+	Driver() string
+
 	// Build Database Interface Functions
 
 	// GetBuild defines a function that

--- a/database/sqlite/driver.go
+++ b/database/sqlite/driver.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package sqlite
+
+import "github.com/go-vela/types/constants"
+
+// Driver outputs the configured database driver.
+func (c *client) Driver() string {
+	return constants.DriverSqlite
+}

--- a/database/sqlite/driver_test.go
+++ b/database/sqlite/driver_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package sqlite
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-vela/types/constants"
+)
+
+func TestSqlite_Client_Driver(t *testing.T) {
+	// setup types
+	want := constants.DriverSqlite
+
+	// setup the test database client
+	_database, err := NewTest()
+	if err != nil {
+		t.Errorf("unable to create new sqlite test database: %v", err)
+	}
+	defer func() { _sql, _ := _database.Sqlite.DB(); _sql.Close() }()
+
+	// run test
+	got := _database.Driver()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Driver is %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
This adds a `Driver()` function to the `go-vela/server/database.Service` interface:

https://github.com/go-vela/server/blob/9de2c808716b56d21b8c27fdb0877a1e09523bb6/database/service.go#L16-L18

And then we implement this function for each supported `database` service:

https://github.com/go-vela/server/blob/9de2c808716b56d21b8c27fdb0877a1e09523bb6/database/postgres/driver.go#L9-L12

https://github.com/go-vela/server/blob/9de2c808716b56d21b8c27fdb0877a1e09523bb6/database/sqlite/driver.go#L9-L12