### PR TITLE
enhance(source): allow admin to customize oauth scopes

### DIFF
--- a/cmd/vela-server/source.go
+++ b/cmd/vela-server/source.go
@@ -25,6 +25,7 @@ func setupSource(c *cli.Context) (source.Service, error) {
 		ServerAddress: c.String("server-addr"),
 		StatusContext: c.String("source.context"),
 		WebUIAddress:  c.String("webui-addr"),
+		Scopes:        c.StringSlice("source.scopes"),
 	}
 
 	// setup the source

--- a/source/flags.go
+++ b/source/flags.go
@@ -60,4 +60,10 @@ var Flags = []cli.Flag{
 		Usage:   "context for commit status in version control system",
 		Value:   "continuous-integration/vela",
 	},
+	&cli.StringSliceFlag{
+		EnvVars: []string{"VELA_SOURCE_SCOPES", "SOURCE_SCOPES"},
+		Name:    "source.scopes",
+		Usage:   "OAuth scopes to be used for the version control system",
+		Value:   cli.NewStringSlice("repo", "repo:status", "user:email", "read:user", "read:org"),
+	},
 }

--- a/source/github/github.go
+++ b/source/github/github.go
@@ -41,6 +41,8 @@ type config struct {
 	StatusContext string
 	// specifies the Vela web UI address to use for the GitHub client
 	WebUIAddress string
+	// specifies the OAuth scopes to use for the GitHub client
+	Scopes []string
 }
 
 type client struct {
@@ -74,7 +76,7 @@ func New(opts ...ClientOpt) (*client, error) {
 	c.OAuth = &oauth2.Config{
 		ClientID:     c.config.ClientID,
 		ClientSecret: c.config.ClientSecret,
-		Scopes:       []string{"repo", "repo:status", "user:email", "read:user", "read:org"},
+		Scopes:       c.config.Scopes,
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  fmt.Sprintf("%s/login/oauth/authorize", c.config.Address),
 			TokenURL: fmt.Sprintf("%s/login/oauth/access_token", c.config.Address),

--- a/source/github/github.go
+++ b/source/github/github.go
@@ -83,11 +83,16 @@ func New(opts ...ClientOpt) (*client, error) {
 		},
 	}
 
+	var githubScopes []github.Scope
+	for _, scope := range c.config.Scopes {
+		githubScopes = append(githubScopes, github.Scope(scope))
+	}
+
 	// create the GitHub authorization object
 	c.AuthReq = &github.AuthorizationRequest{
 		ClientID:     &c.config.ClientID,
 		ClientSecret: &c.config.ClientSecret,
-		Scopes:       []github.Scope{"repo", "repo:status", "user:email", "read:user", "read:org"},
+		Scopes:       githubScopes,
 	}
 
 	return c, nil

--- a/source/github/github_test.go
+++ b/source/github/github_test.go
@@ -41,6 +41,7 @@ func TestGithub_New(t *testing.T) {
 			WithServerAddress("https://vela-server.example.com"),
 			WithStatusContext("continuous-integration/vela"),
 			WithWebUIAddress("https://vela.example.com"),
+			WithScopes([]string{"repo", "repo:status", "user:email", "read:user", "read:org"}),
 		)
 
 		if test.failure {

--- a/source/github/opts.go
+++ b/source/github/opts.go
@@ -116,3 +116,20 @@ func WithWebUIAddress(address string) ClientOpt {
 		return nil
 	}
 }
+
+// WithScopes sets the GitHub OAuth scopes in the source client.
+func WithScopes(scopes []string) ClientOpt {
+	logrus.Trace("configuring oauth scopes in github source client")
+
+	return func(c *client) error {
+		// check if the scopes provided is empty
+		if len(scopes) == 0 {
+			return fmt.Errorf("no GitHub OAuth scopes provided")
+		}
+
+		// set the scopes in the github client
+		c.config.Scopes = scopes
+
+		return nil
+	}
+}

--- a/source/github/opts_test.go
+++ b/source/github/opts_test.go
@@ -244,3 +244,46 @@ func TestGithub_ClientOpt_WithWebUIAddress(t *testing.T) {
 		}
 	}
 }
+
+func TestGithub_ClientOpt_WithScopes(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		failure bool
+		scopes  []string
+		want    []string
+	}{
+		{
+			failure: false,
+			scopes:  []string{"repo", "repo:status", "user:email", "read:user", "read:org"},
+			want:    []string{"repo", "repo:status", "user:email", "read:user", "read:org"},
+		},
+		{
+			failure: true,
+			scopes:  []string{},
+			want:    []string{},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_service, err := New(
+			WithScopes(test.scopes),
+		)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("WithScopes should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("WithScopes returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(_service.config.Scopes, test.want) {
+			t.Errorf("WithScopes is %v, want %v", _service.config.Scopes, test.want)
+		}
+	}
+}

--- a/source/setup.go
+++ b/source/setup.go
@@ -106,7 +106,7 @@ func (s *Setup) Validate() error {
 	}
 
 	if len(s.Scopes) == 0 {
-		return fmt.Errorf("no scopes provided")
+		return fmt.Errorf("no source scopes provided")
 	}
 
 	// setup is valid

--- a/source/setup.go
+++ b/source/setup.go
@@ -34,6 +34,8 @@ type Setup struct {
 	StatusContext string
 	// specifies the Vela web UI address to use for the source client
 	WebUIAddress string
+	// specifies the OAuth scopes to use for the source client
+	Scopes []string
 }
 
 // Github creates and returns a Vela service capable of
@@ -51,6 +53,7 @@ func (s *Setup) Github() (Service, error) {
 		github.WithServerAddress(s.ServerAddress),
 		github.WithStatusContext(s.StatusContext),
 		github.WithWebUIAddress(s.WebUIAddress),
+		github.WithScopes(s.Scopes),
 	)
 }
 
@@ -100,6 +103,10 @@ func (s *Setup) Validate() error {
 	// verify a source status context secret was provided
 	if len(s.StatusContext) == 0 {
 		return fmt.Errorf("no source status context provided")
+	}
+
+	if len(s.Scopes) == 0 {
+		return fmt.Errorf("no scopes provided")
 	}
 
 	// setup is valid

--- a/source/setup_test.go
+++ b/source/setup_test.go
@@ -19,6 +19,7 @@ func TestSource_Setup_Github(t *testing.T) {
 		ServerAddress: "https://vela-server.example.com",
 		StatusContext: "continuous-integration/vela",
 		WebUIAddress:  "https://vela.example.com",
+		Scopes:        []string{"repo", "repo:status", "user:email", "read:user", "read:org"},
 	}
 
 	_github, err := _setup.Github()
@@ -105,6 +106,7 @@ func TestSource_Setup_Validate(t *testing.T) {
 				ServerAddress: "https://vela-server.example.com",
 				StatusContext: "continuous-integration/vela",
 				WebUIAddress:  "https://vela.example.com",
+				Scopes:        []string{"repo", "repo:status", "user:email", "read:user", "read:org"},
 			},
 		},
 		{
@@ -117,6 +119,7 @@ func TestSource_Setup_Validate(t *testing.T) {
 				ServerAddress: "https://vela-server.example.com",
 				StatusContext: "continuous-integration/vela",
 				WebUIAddress:  "https://vela.example.com",
+				Scopes:        []string{"repo", "repo:status", "user:email", "read:user", "read:org"},
 			},
 		},
 		{
@@ -129,6 +132,7 @@ func TestSource_Setup_Validate(t *testing.T) {
 				ServerAddress: "https://vela-server.example.com",
 				StatusContext: "continuous-integration/vela",
 				WebUIAddress:  "https://vela.example.com",
+				Scopes:        []string{"repo", "repo:status", "user:email", "read:user", "read:org"},
 			},
 		},
 		{
@@ -141,6 +145,7 @@ func TestSource_Setup_Validate(t *testing.T) {
 				ServerAddress: "https://vela-server.example.com",
 				StatusContext: "continuous-integration/vela",
 				WebUIAddress:  "https://vela.example.com",
+				Scopes:        []string{"repo", "repo:status", "user:email", "read:user", "read:org"},
 			},
 		},
 		{
@@ -153,6 +158,7 @@ func TestSource_Setup_Validate(t *testing.T) {
 				ServerAddress: "https://vela-server.example.com",
 				StatusContext: "continuous-integration/vela",
 				WebUIAddress:  "https://vela.example.com",
+				Scopes:        []string{"repo", "repo:status", "user:email", "read:user", "read:org"},
 			},
 		},
 		{
@@ -165,6 +171,7 @@ func TestSource_Setup_Validate(t *testing.T) {
 				ServerAddress: "https://vela-server.example.com",
 				StatusContext: "continuous-integration/vela",
 				WebUIAddress:  "https://vela.example.com",
+				Scopes:        []string{"repo", "repo:status", "user:email", "read:user", "read:org"},
 			},
 		},
 		{
@@ -177,6 +184,7 @@ func TestSource_Setup_Validate(t *testing.T) {
 				ServerAddress: "https://vela-server.example.com",
 				StatusContext: "continuous-integration/vela",
 				WebUIAddress:  "https://vela.example.com",
+				Scopes:        []string{"repo", "repo:status", "user:email", "read:user", "read:org"},
 			},
 		},
 		{
@@ -189,6 +197,7 @@ func TestSource_Setup_Validate(t *testing.T) {
 				ServerAddress: "https://vela-server.example.com",
 				StatusContext: "continuous-integration/vela",
 				WebUIAddress:  "https://vela.example.com",
+				Scopes:        []string{"repo", "repo:status", "user:email", "read:user", "read:org"},
 			},
 		},
 		{
@@ -201,6 +210,20 @@ func TestSource_Setup_Validate(t *testing.T) {
 				ServerAddress: "https://vela-server.example.com",
 				StatusContext: "",
 				WebUIAddress:  "https://vela.example.com",
+				Scopes:        []string{"repo", "repo:status", "user:email", "read:user", "read:org"},
+			},
+		},
+		{
+			failure: true,
+			setup: &Setup{
+				Driver:        "github",
+				Address:       "https://github.com",
+				ClientID:      "foo",
+				ClientSecret:  "bar",
+				ServerAddress: "https://vela-server.example.com",
+				StatusContext: "continuous-integration/vela",
+				WebUIAddress:  "https://vela.example.com",
+				Scopes:        []string{},
 			},
 		},
 	}

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -24,6 +24,7 @@ func TestSource_New(t *testing.T) {
 				ServerAddress: "https://vela-server.example.com",
 				StatusContext: "continuous-integration/vela",
 				WebUIAddress:  "https://vela.example.com",
+				Scopes:        []string{"repo", "repo:status", "user:email", "read:user", "read:org"},
 			},
 		},
 		{
@@ -36,6 +37,7 @@ func TestSource_New(t *testing.T) {
 				ServerAddress: "https://vela-server.example.com",
 				StatusContext: "continuous-integration/vela",
 				WebUIAddress:  "https://vela.example.com",
+				Scopes:        []string{"repo", "repo:status", "user:email", "read:user", "read:org"},
 			},
 		},
 		{
@@ -48,6 +50,7 @@ func TestSource_New(t *testing.T) {
 				ServerAddress: "https://vela-server.example.com",
 				StatusContext: "continuous-integration/vela",
 				WebUIAddress:  "https://vela.example.com",
+				Scopes:        []string{"repo", "repo:status", "user:email", "read:user", "read:org"},
 			},
 		},
 		{
@@ -60,6 +63,7 @@ func TestSource_New(t *testing.T) {
 				ServerAddress: "https://vela-server.example.com",
 				StatusContext: "continuous-integration/vela",
 				WebUIAddress:  "https://vela.example.com",
+				Scopes:        []string{"repo", "repo:status", "user:email", "read:user", "read:org"},
 			},
 		},
 	}


### PR DESCRIPTION
This change allows the Vela administrator to override the list of [OAuth scopes](https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps) by setting the `VELA_SOURCE_SCOPES` variable.

closes https://github.com/go-vela/community/issues/274