### PR TITLE
fix(database): updating secrets with empty fields

### DIFF
--- a/database/postgres/secret.go
+++ b/database/postgres/secret.go
@@ -138,7 +138,7 @@ func (c *client) UpdateSecret(s *library.Secret) error {
 	// send query to the database
 	return c.Postgres.
 		Table(constants.TableSecret).
-		Save(secret).Error
+		Save(secret.Nullify()).Error
 }
 
 // DeleteSecret deletes a secret by unique ID from the database.

--- a/database/postgres/secret_test.go
+++ b/database/postgres/secret_test.go
@@ -294,7 +294,7 @@ func TestPostgres_Client_UpdateSecret(t *testing.T) {
 
 	// ensure the mock expects the query
 	_mock.ExpectExec(`UPDATE "secrets" SET "org"=$1,"repo"=$2,"team"=$3,"name"=$4,"value"=$5,"type"=$6,"images"=$7,"events"=$8,"allow_command"=$9 WHERE "id" = $10`).
-		WithArgs("foo", "bar", "", "baz", AnyArgument{}, "repo", "{}", "{}", false, 1).
+		WithArgs("foo", "bar", nil, "baz", AnyArgument{}, "repo", "{}", "{}", false, 1).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	// setup tests

--- a/database/sqlite/secret.go
+++ b/database/sqlite/secret.go
@@ -138,7 +138,7 @@ func (c *client) UpdateSecret(s *library.Secret) error {
 	// send query to the database
 	return c.Sqlite.
 		Table(constants.TableSecret).
-		Save(secret).Error
+		Save(secret.Nullify()).Error
 }
 
 // DeleteSecret deletes a secret by unique ID from the database.


### PR DESCRIPTION
Related to https://github.com/go-vela/types/pull/166

Based off of https://github.com/go-vela/server/pull/428

Currently, there is a bug when attempting to update `secrets` in Vela.

If you attempt to update a `repo` or `shared` secret, you may experience errors from the database like:

```
Status 500 (unable to update secret <secret> for native service: ERROR: duplicate key value violates unique constraint "secrets_type_org_team_name_key" (SQLSTATE 23505))
```

OR

```
Status 500 (unable to update secret <secret> for native service: ERROR: duplicate key value violates unique constraint "secrets_type_org_repo_name_key" (SQLSTATE 23505))
```

This only happens when you attempt to update a secret that has the same `name` and is in the same `org`.

An example to replicate the behavior for `repo` secrets:

```
$ vela update secret --secret.engine native --secret.type repo --org MyOrg --repo repo1 --name foo --value bar

$ vela update secret --secret.engine native --secret.type repo --org MyOrg --repo repo2 --name foo --value bar
```

> NOTE: The `org` and `name` fields are the same above, but the `repo` is different.