### PR TITLE
fix(api): assume more results exist if list not empty

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -423,7 +423,7 @@ func GetUserSourceRepos(c *gin.Context) {
 			// add repos to list of database org repos
 			dbRepos = append(dbRepos, dbReposPart...)
 
-			// assume another page exists if under 100 results are returned
+			// assume no more pages exist if under 100 results are returned
 			//
 			// nolint: gomnd // ignore magic number
 			if len(dbReposPart) < 100 {

--- a/api/user.go
+++ b/api/user.go
@@ -423,13 +423,13 @@ func GetUserSourceRepos(c *gin.Context) {
 			// add repos to list of database org repos
 			dbRepos = append(dbRepos, dbReposPart...)
 
-			// assume another page exists if any results are returned
+			// assume another page exists if under 100 results are returned
 			//
 			// nolint: gomnd // ignore magic number
-			if len(dbReposPart) >= 1 {
-				page++
-			} else {
+			if len(dbReposPart) < 100 {
 				page = 0
+			} else {
+				page++
 			}
 		}
 

--- a/api/user.go
+++ b/api/user.go
@@ -423,10 +423,10 @@ func GetUserSourceRepos(c *gin.Context) {
 			// add repos to list of database org repos
 			dbRepos = append(dbRepos, dbReposPart...)
 
-			// making an assumption that 50 means there is another page
+			// assume another page exists if any results are returned
 			//
 			// nolint: gomnd // ignore magic number
-			if len(dbReposPart) == 50 {
+			if len(dbReposPart) >= 1 {
 				page++
 			} else {
 				page = 0


### PR DESCRIPTION
This resolves the issue where the `/api/v1/user/source/repos` endpoint was incorrectly returning `active: false` for some repositories when the given user had >= 100 repos returned by the aforementioned endpoint.