### PR TITLE
feat(database): support skipping creation of tables and indexes

### DIFF
--- a/cmd/vela-server/database.go
+++ b/cmd/vela-server/database.go
@@ -25,6 +25,7 @@ func setupDatabase(c *cli.Context) (database.Service, error) {
 		ConnectionIdle:   c.Int("database.connection.idle"),
 		ConnectionOpen:   c.Int("database.connection.open"),
 		EncryptionKey:    c.String("database.encryption.key"),
+		SkipCreation:     c.Bool("database.skip_creation"),
 	}
 
 	// setup the database

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -25,6 +25,7 @@ func TestDatabase_New(t *testing.T) {
 				ConnectionIdle:   5,
 				ConnectionOpen:   20,
 				EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
+				SkipCreation:     false,
 			},
 		},
 		{
@@ -37,6 +38,7 @@ func TestDatabase_New(t *testing.T) {
 				ConnectionIdle:   5,
 				ConnectionOpen:   20,
 				EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
+				SkipCreation:     false,
 			},
 		},
 		{
@@ -49,6 +51,7 @@ func TestDatabase_New(t *testing.T) {
 				ConnectionIdle:   5,
 				ConnectionOpen:   20,
 				EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
+				SkipCreation:     false,
 			},
 		},
 		{
@@ -61,6 +64,7 @@ func TestDatabase_New(t *testing.T) {
 				ConnectionIdle:   5,
 				ConnectionOpen:   20,
 				EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
+				SkipCreation:     false,
 			},
 		},
 	}

--- a/database/flags.go
+++ b/database/flags.go
@@ -84,4 +84,10 @@ var Flags = []cli.Flag{
 		Name:     "database.encryption.key",
 		Usage:    "AES-256 key for encrypting and decrypting values in the database",
 	},
+	&cli.BoolFlag{
+		EnvVars:  []string{"VELA_DATABASE_SKIP_CREATION", "DATABASE_SKIP_CREATION"},
+		FilePath: "/vela/database/skip_creation",
+		Name:     "database.skip_creation",
+		Usage:    "enables skipping the creation of objects in the database",
+	},
 }

--- a/database/flags.go
+++ b/database/flags.go
@@ -88,6 +88,6 @@ var Flags = []cli.Flag{
 		EnvVars:  []string{"VELA_DATABASE_SKIP_CREATION", "DATABASE_SKIP_CREATION"},
 		FilePath: "/vela/database/skip_creation",
 		Name:     "database.skip_creation",
-		Usage:    "enables skipping the creation of objects in the database",
+		Usage:    "enables skipping the creation of tables and indexes in the database",
 	},
 }

--- a/database/postgres/opts.go
+++ b/database/postgres/opts.go
@@ -101,7 +101,7 @@ func WithSkipCreation(skipCreation bool) ClientOpt {
 	logrus.Trace("configuring skip creating objects in postgres database client")
 
 	return func(c *client) error {
-		// set to skip creating objects in the postgres client
+		// set to skip creating tables and indexes in the postgres client
 		c.config.SkipCreation = skipCreation
 
 		return nil

--- a/database/postgres/opts.go
+++ b/database/postgres/opts.go
@@ -101,7 +101,7 @@ func WithSkipCreation(skipCreation bool) ClientOpt {
 	logrus.Trace("configuring skip creating objects in postgres database client")
 
 	return func(c *client) error {
-		// set the skip creating objects in the postgres client
+		// set to skip creating objects in the postgres client
 		c.config.SkipCreation = skipCreation
 
 		return nil

--- a/database/postgres/opts.go
+++ b/database/postgres/opts.go
@@ -95,3 +95,15 @@ func WithEncryptionKey(key string) ClientOpt {
 		return nil
 	}
 }
+
+// WithSkipCreation sets the Postgres skip creation logic in the database client.
+func WithSkipCreation(skipCreation bool) ClientOpt {
+	logrus.Trace("configuring skip creating objects in postgres database client")
+
+	return func(c *client) error {
+		// set the skip creating objects in the postgres client
+		c.config.SkipCreation = skipCreation
+
+		return nil
+	}
+}

--- a/database/postgres/opts_test.go
+++ b/database/postgres/opts_test.go
@@ -235,3 +235,37 @@ func TestPostgres_ClientOpt_WithEncryptionKey(t *testing.T) {
 		}
 	}
 }
+
+func TestPostgres_ClientOpt_WithSkipCreation(t *testing.T) {
+	// setup types
+	c := new(client)
+	c.config = new(config)
+
+	// setup tests
+	tests := []struct {
+		skipCreation bool
+		want         bool
+	}{
+		{
+			skipCreation: true,
+			want:         true,
+		},
+		{
+			skipCreation: false,
+			want:         false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := WithSkipCreation(test.skipCreation)(c)
+
+		if err != nil {
+			t.Errorf("WithSkipCreation returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(c.config.SkipCreation, test.want) {
+			t.Errorf("WithSkipCreation is %v, want %v", c.config.SkipCreation, test.want)
+		}
+	}
+}

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -31,7 +31,7 @@ type (
 		ConnectionOpen int
 		// specifies the encryption key to use for the Postgres client
 		EncryptionKey string
-		// specifies to skip creating objects for the Postgres client
+		// specifies to skip creating tables and indexes for the Postgres client
 		SkipCreation bool
 	}
 

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -31,6 +31,8 @@ type (
 		ConnectionOpen int
 		// specifies the encryption key to use for the Postgres client
 		EncryptionKey string
+		// specifies to skip creating objects for the Postgres client
+		SkipCreation bool
 	}
 
 	client struct {
@@ -94,6 +96,7 @@ func NewTest() (*client, sqlmock.Sqlmock, error) {
 		ConnectionIdle:   2,
 		ConnectionOpen:   0,
 		EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
+		SkipCreation:     false,
 	}
 	c.Postgres = new(gorm.DB)
 
@@ -151,16 +154,19 @@ func setupDatabase(c *client) error {
 		return err
 	}
 
-	// create the tables in the database
-	err = createTables(c)
-	if err != nil {
-		return err
-	}
+	// check if we should skip creating objects
+	if !c.config.SkipCreation {
+		// create the tables in the database
+		err = createTables(c)
+		if err != nil {
+			return err
+		}
 
-	// create the indexes in the database
-	err = createIndexes(c)
-	if err != nil {
-		return err
+		// create the indexes in the database
+		err = createIndexes(c)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -154,19 +154,23 @@ func setupDatabase(c *client) error {
 		return err
 	}
 
-	// check if we should skip creating objects
-	if !c.config.SkipCreation {
-		// create the tables in the database
-		err = createTables(c)
-		if err != nil {
-			return err
-		}
+	// check if we should skip creating database objects
+	if c.config.SkipCreation {
+		logrus.Warning("skipping creation of data tables and indexes in the postgres database")
 
-		// create the indexes in the database
-		err = createIndexes(c)
-		if err != nil {
-			return err
-		}
+		return nil
+	}
+
+	// create the tables in the database
+	err = createTables(c)
+	if err != nil {
+		return err
+	}
+
+	// create the indexes in the database
+	err = createIndexes(c)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -41,6 +41,7 @@ func TestPostgres_New(t *testing.T) {
 			WithConnectionIdle(5),
 			WithConnectionOpen(20),
 			WithEncryptionKey("A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW"),
+			WithSkipCreation(false),
 		)
 
 		if test.failure {

--- a/database/setup.go
+++ b/database/setup.go
@@ -35,7 +35,7 @@ type Setup struct {
 	ConnectionOpen int
 	// specifies the encryption key to use for the database client
 	EncryptionKey string
-	// specifies to skip creating objects to use for the database client
+	// specifies to skip creating tables and indexes for the database client
 	SkipCreation bool
 }
 

--- a/database/setup.go
+++ b/database/setup.go
@@ -35,6 +35,8 @@ type Setup struct {
 	ConnectionOpen int
 	// specifies the encryption key to use for the database client
 	EncryptionKey string
+	// specifies to skip creating objects to use for the database client
+	SkipCreation bool
 }
 
 // Postgres creates and returns a Vela service capable of
@@ -52,6 +54,7 @@ func (s *Setup) Postgres() (Service, error) {
 		postgres.WithConnectionIdle(s.ConnectionIdle),
 		postgres.WithConnectionOpen(s.ConnectionOpen),
 		postgres.WithEncryptionKey(s.EncryptionKey),
+		postgres.WithSkipCreation(s.SkipCreation),
 	)
 }
 
@@ -70,6 +73,7 @@ func (s *Setup) Sqlite() (Service, error) {
 		sqlite.WithConnectionIdle(s.ConnectionIdle),
 		sqlite.WithConnectionOpen(s.ConnectionOpen),
 		sqlite.WithEncryptionKey(s.EncryptionKey),
+		sqlite.WithSkipCreation(s.SkipCreation),
 	)
 }
 

--- a/database/setup_test.go
+++ b/database/setup_test.go
@@ -19,6 +19,7 @@ func TestDatabase_Setup_Postgres(t *testing.T) {
 		ConnectionIdle:   5,
 		ConnectionOpen:   20,
 		EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
+		SkipCreation:     false,
 	}
 
 	// setup tests
@@ -64,6 +65,7 @@ func TestDatabase_Setup_Sqlite(t *testing.T) {
 		ConnectionIdle:   5,
 		ConnectionOpen:   20,
 		EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
+		SkipCreation:     false,
 	}
 
 	// setup tests
@@ -115,6 +117,7 @@ func TestDatabase_Setup_Validate(t *testing.T) {
 				ConnectionIdle:   5,
 				ConnectionOpen:   20,
 				EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
+				SkipCreation:     false,
 			},
 		},
 		{
@@ -127,6 +130,7 @@ func TestDatabase_Setup_Validate(t *testing.T) {
 				ConnectionIdle:   5,
 				ConnectionOpen:   20,
 				EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
+				SkipCreation:     false,
 			},
 		},
 		{
@@ -139,6 +143,7 @@ func TestDatabase_Setup_Validate(t *testing.T) {
 				ConnectionIdle:   5,
 				ConnectionOpen:   20,
 				EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
+				SkipCreation:     false,
 			},
 		},
 		{
@@ -151,6 +156,7 @@ func TestDatabase_Setup_Validate(t *testing.T) {
 				ConnectionIdle:   5,
 				ConnectionOpen:   20,
 				EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
+				SkipCreation:     false,
 			},
 		},
 		{
@@ -163,6 +169,7 @@ func TestDatabase_Setup_Validate(t *testing.T) {
 				ConnectionIdle:   5,
 				ConnectionOpen:   20,
 				EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
+				SkipCreation:     false,
 			},
 		},
 		{
@@ -175,6 +182,7 @@ func TestDatabase_Setup_Validate(t *testing.T) {
 				ConnectionIdle:   5,
 				ConnectionOpen:   20,
 				EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
+				SkipCreation:     false,
 			},
 		},
 		{
@@ -187,6 +195,7 @@ func TestDatabase_Setup_Validate(t *testing.T) {
 				ConnectionIdle:   5,
 				ConnectionOpen:   20,
 				EncryptionKey:    "",
+				SkipCreation:     false,
 			},
 		},
 		{
@@ -199,6 +208,7 @@ func TestDatabase_Setup_Validate(t *testing.T) {
 				ConnectionIdle:   5,
 				ConnectionOpen:   20,
 				EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0",
+				SkipCreation:     false,
 			},
 		},
 		{
@@ -211,6 +221,7 @@ func TestDatabase_Setup_Validate(t *testing.T) {
 				ConnectionIdle:   5,
 				ConnectionOpen:   20,
 				EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
+				SkipCreation:     false,
 			},
 		},
 	}

--- a/database/sqlite/opts.go
+++ b/database/sqlite/opts.go
@@ -101,7 +101,7 @@ func WithSkipCreation(skipCreation bool) ClientOpt {
 	logrus.Trace("configuring skip creating objects in sqlite database client")
 
 	return func(c *client) error {
-		// set the skip creating objects in the sqlite client
+		// set to skip creating objects in the sqlite client
 		c.config.SkipCreation = skipCreation
 
 		return nil

--- a/database/sqlite/opts.go
+++ b/database/sqlite/opts.go
@@ -95,3 +95,15 @@ func WithEncryptionKey(key string) ClientOpt {
 		return nil
 	}
 }
+
+// WithSkipCreation sets the Sqlite skip creation logic in the database client.
+func WithSkipCreation(skipCreation bool) ClientOpt {
+	logrus.Trace("configuring skip creating objects in sqlite database client")
+
+	return func(c *client) error {
+		// set the skip creating objects in the sqlite client
+		c.config.SkipCreation = skipCreation
+
+		return nil
+	}
+}

--- a/database/sqlite/opts.go
+++ b/database/sqlite/opts.go
@@ -101,7 +101,7 @@ func WithSkipCreation(skipCreation bool) ClientOpt {
 	logrus.Trace("configuring skip creating objects in sqlite database client")
 
 	return func(c *client) error {
-		// set to skip creating objects in the sqlite client
+		// set to skip creating tables and indexes in the sqlite client
 		c.config.SkipCreation = skipCreation
 
 		return nil

--- a/database/sqlite/opts_test.go
+++ b/database/sqlite/opts_test.go
@@ -235,3 +235,37 @@ func TestSqlite_ClientOpt_WithEncryptionKey(t *testing.T) {
 		}
 	}
 }
+
+func TestSqlite_ClientOpt_WithSkipCreation(t *testing.T) {
+	// setup types
+	c := new(client)
+	c.config = new(config)
+
+	// setup tests
+	tests := []struct {
+		skipCreation bool
+		want         bool
+	}{
+		{
+			skipCreation: true,
+			want:         true,
+		},
+		{
+			skipCreation: false,
+			want:         false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := WithSkipCreation(test.skipCreation)(c)
+
+		if err != nil {
+			t.Errorf("WithSkipCreation returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(c.config.SkipCreation, test.want) {
+			t.Errorf("WithSkipCreation is %v, want %v", c.config.SkipCreation, test.want)
+		}
+	}
+}

--- a/database/sqlite/sqlite.go
+++ b/database/sqlite/sqlite.go
@@ -30,6 +30,8 @@ type (
 		ConnectionOpen int
 		// specifies the encryption key to use for the Sqlite client
 		EncryptionKey string
+		// specifies to skip creating objects for the Sqlite client
+		SkipCreation bool
 	}
 
 	client struct {
@@ -93,6 +95,7 @@ func NewTest() (*client, error) {
 		ConnectionIdle:   2,
 		ConnectionOpen:   0,
 		EncryptionKey:    "A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW",
+		SkipCreation:     false,
 	}
 	c.Sqlite = new(gorm.DB)
 
@@ -150,16 +153,19 @@ func setupDatabase(c *client) error {
 		return err
 	}
 
-	// create the tables in the database
-	err = createTables(c)
-	if err != nil {
-		return err
-	}
+	// check if we should skip creating objects
+	if !c.config.SkipCreation {
+		// create the tables in the database
+		err = createTables(c)
+		if err != nil {
+			return err
+		}
 
-	// create the indexes in the database
-	err = createIndexes(c)
-	if err != nil {
-		return err
+		// create the indexes in the database
+		err = createIndexes(c)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/database/sqlite/sqlite.go
+++ b/database/sqlite/sqlite.go
@@ -30,7 +30,7 @@ type (
 		ConnectionOpen int
 		// specifies the encryption key to use for the Sqlite client
 		EncryptionKey string
-		// specifies to skip creating objects for the Sqlite client
+		// specifies to skip creating tables and indexes for the Sqlite client
 		SkipCreation bool
 	}
 

--- a/database/sqlite/sqlite.go
+++ b/database/sqlite/sqlite.go
@@ -153,19 +153,23 @@ func setupDatabase(c *client) error {
 		return err
 	}
 
-	// check if we should skip creating objects
-	if !c.config.SkipCreation {
-		// create the tables in the database
-		err = createTables(c)
-		if err != nil {
-			return err
-		}
+	// check if we should skip creating database objects
+	if c.config.SkipCreation {
+		logrus.Warning("skipping creation of data tables and indexes in the sqlite database")
 
-		// create the indexes in the database
-		err = createIndexes(c)
-		if err != nil {
-			return err
-		}
+		return nil
+	}
+
+	// create the tables in the database
+	err = createTables(c)
+	if err != nil {
+		return err
+	}
+
+	// create the indexes in the database
+	err = createIndexes(c)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/database/sqlite/sqlite_test.go
+++ b/database/sqlite/sqlite_test.go
@@ -64,17 +64,35 @@ func TestSqlite_setupDatabase(t *testing.T) {
 	}
 	defer func() { _sql, _ := _database.Sqlite.DB(); _sql.Close() }()
 
+	// setup the skip test database client
+	_skipDatabase, err := NewTest()
+	if err != nil {
+		t.Errorf("unable to create new skip sqlite test database: %v", err)
+	}
+	defer func() { _sql, _ := _skipDatabase.Sqlite.DB(); _sql.Close() }()
+
+	err = WithSkipCreation(true)(_skipDatabase)
+	if err != nil {
+		t.Errorf("unable to set SkipCreation for sqlite test database: %v", err)
+	}
+
 	tests := []struct {
-		failure bool
+		failure  bool
+		database *client
 	}{
 		{
-			failure: false,
+			failure:  false,
+			database: _database,
+		},
+		{
+			failure:  false,
+			database: _skipDatabase,
 		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		err := setupDatabase(_database)
+		err := setupDatabase(test.database)
 
 		if test.failure {
 			if err == nil {

--- a/database/sqlite/sqlite_test.go
+++ b/database/sqlite/sqlite_test.go
@@ -37,6 +37,7 @@ func TestSqlite_New(t *testing.T) {
 			WithConnectionIdle(5),
 			WithConnectionOpen(20),
 			WithEncryptionKey("A1B2C3D4E5G6H7I8J9K0LMNOPQRSTUVW"),
+			WithSkipCreation(false),
 		)
 
 		if test.failure {


### PR DESCRIPTION
This adds a new `database.skip_creation` boolean flag to the `github.com/go-vela/server/database` package.

The intention of this flag is to enable skipping the creation of DDL objects (tables and indexes) in the database.

This flag can also be set via environment variables with:

* `VELA_DATABASE_SKIP_CREATION`
* `DATABASE_SKIP_CREATION`

This flag can also be set via a value in a file with the path `/vela/database/skip_creation`.

The use-case for this functionality is to enable Vela to support databases without admin access to that database.

This setup can happen when running Vela with a database that has extra security controls preventing DDL changes.

> NOTE: Most of the LOC found in this change are related to the tests added for this new flag.