### PR TITLE
fix(deps): address vulnerable jwt-go library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,13 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/aws/aws-sdk-go v1.40.16
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/gin-gonic/gin v1.7.3
 	github.com/go-playground/assert/v2 v2.0.1
 	github.com/go-vela/compiler v0.8.2-0.20210728151243-38af4aebce57
 	github.com/go-vela/pkg-queue v0.8.1
 	github.com/go-vela/types v0.8.3-0.20210726122150-0eaf6091307b
+	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-github/v37 v37.0.0
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -250,6 +250,8 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v4 v4.0.0 h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=
+github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/router/middleware/token/token.go
+++ b/router/middleware/token/token.go
@@ -17,8 +17,8 @@ import (
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 
-	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/dgrijalva/jwt-go/request"
+	jwt "github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v4/request"
 	"github.com/sirupsen/logrus"
 )
 

--- a/router/middleware/token/token_test.go
+++ b/router/middleware/token/token_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 )
 
 func TestToken_Compose(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/go-vela/community/issues/352

This updates the library the server uses to handle [JWT](https://jwt.io/) token processing.

Currently, we're using `github.com/dgrijalva/jwt-go`.

After this change, we'll be using `github.com/golang-jwt/jwt`.

This resolves the known vulnerability in the old JWT library reported by Dependabot:

https://github.com/go-vela/server/security/dependabot/go.mod/github.com%2Fdgrijalva%2Fjwt-go/open

> **CVE-2020-26160** - `high severity`
>
> **Vulnerable versions**: `<= 3.2.0`
>
> **Patched version**: `No fix`
>
> [jwt-go](https://github.com/dgrijalva/jwt-go) allows attackers to bypass intended access restrictions in situations with []string{} for m["aud"] (which is allowed by the specification). Because the type assertion fails, "" is the value of aud. This is a security problem if the JWT token is presented to a service that lacks its own audience check. There is no patch available and users of jwt-go are advised to migrate to [golang-jwt](https://github.com/golang-jwt/jwt) at version 3.2.1

