### PR TITLE
fix: correct build number on restart

### DIFF
--- a/api/build.go
+++ b/api/build.go
@@ -755,6 +755,12 @@ func RestartBuild(c *gin.Context) {
 		return
 	}
 
+	// update the build numbers based off repo counter
+	inc := r.GetCounter() + 1
+
+	r.SetCounter(inc)
+	b.SetNumber(inc)
+
 	// update fields in build object
 	b.SetID(0)
 	b.SetNumber(r.GetCounter())
@@ -826,12 +832,6 @@ func RestartBuild(c *gin.Context) {
 
 		return
 	}
-
-	// update the build numbers based off repo counter
-	inc := r.GetCounter() + 1
-
-	r.SetCounter(inc)
-	b.SetNumber(inc)
 
 	// parse and compile the pipeline configuration file
 	p, err := compiler.FromContext(c).

--- a/api/build.go
+++ b/api/build.go
@@ -763,7 +763,6 @@ func RestartBuild(c *gin.Context) {
 
 	// update fields in build object
 	b.SetID(0)
-	b.SetNumber(r.GetCounter())
 	b.SetParent(lastBuild.GetNumber())
 	b.SetCreated(time.Now().UTC().Unix())
 	b.SetEnqueued(0)


### PR DESCRIPTION
on restart we incremented the build counter ***after*** setting the link property which is utilized in the UI, resulting in the link pointing to the previous build.

this PR moves the build increment logic up to be called before we set the link for the build within the handler for the restart endpoint.

in my testing, this solved the issue for the below:

fixes: https://github.com/go-vela/community/issues/353
fixes: https://github.com/go-vela/community/issues/322