### PR TITLE
fix(database): sort org build list by started timestamp

### DIFF
--- a/database/postgres/build_list.go
+++ b/database/postgres/build_list.go
@@ -71,7 +71,7 @@ func (c *client) GetOrgBuildList(org string, filters map[string]string, page, pe
 		Select("builds.*").
 		Joins("JOIN repos ON builds.repo_id = repos.id and repos.org = ?", org).
 		Where(filters).
-		Order("number DESC").
+		Order("started DESC").
 		Limit(perPage).
 		Offset(offset).
 		Scan(b).Error

--- a/database/postgres/build_list_test.go
+++ b/database/postgres/build_list_test.go
@@ -118,7 +118,7 @@ func TestPostgres_Client_GetOrgBuildList(t *testing.T) {
 		AddRow(2, 1, 2, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0)
 
 	// ensure the mock expects the query
-	_mock.ExpectQuery("SELECT builds.* FROM \"builds\" JOIN repos ON builds.repo_id = repos.id and repos.org = $1 ORDER BY number DESC LIMIT 10").WillReturnRows(_rows)
+	_mock.ExpectQuery("SELECT builds.* FROM \"builds\" JOIN repos ON builds.repo_id = repos.id and repos.org = $1 ORDER BY started DESC LIMIT 10").WillReturnRows(_rows)
 
 	// setup tests
 	tests := []struct {
@@ -186,7 +186,7 @@ func TestPostgres_Client_GetOrgBuildList_NonAdmin(t *testing.T) {
 	).AddRow(1, 1, 1, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0)
 
 	// ensure the mock expects the query
-	_mock.ExpectQuery("SELECT builds.* FROM \"builds\" JOIN repos ON builds.repo_id = repos.id and repos.org = $1 WHERE \"visibility\" = $2 ORDER BY number DESC LIMIT 10").WillReturnRows(_rows)
+	_mock.ExpectQuery("SELECT builds.* FROM \"builds\" JOIN repos ON builds.repo_id = repos.id and repos.org = $1 WHERE \"visibility\" = $2 ORDER BY started DESC LIMIT 10").WillReturnRows(_rows)
 
 	// setup tests
 	tests := []struct {
@@ -256,7 +256,7 @@ func TestPostgres_Client_GetOrgBuildListByEvent(t *testing.T) {
 		AddRow(2, 1, 2, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0)
 
 	// ensure the mock expects the query
-	_mock.ExpectQuery("SELECT builds.* FROM \"builds\" JOIN repos ON builds.repo_id = repos.id and repos.org = $1 WHERE \"event\" = $2 ORDER BY number DESC LIMIT 10").WillReturnRows(_rows)
+	_mock.ExpectQuery("SELECT builds.* FROM \"builds\" JOIN repos ON builds.repo_id = repos.id and repos.org = $1 WHERE \"event\" = $2 ORDER BY started DESC LIMIT 10").WillReturnRows(_rows)
 
 	// setup tests
 	tests := []struct {

--- a/database/sqlite/build_list.go
+++ b/database/sqlite/build_list.go
@@ -71,7 +71,7 @@ func (c *client) GetOrgBuildList(org string, filters map[string]string, page int
 		Select("builds.*").
 		Joins("JOIN repos ON builds.repo_id = repos.id AND repos.org = ?", org).
 		Where(filters).
-		Order("number DESC").
+		Order("started DESC").
 		Limit(perPage).
 		Offset(offset).
 		Scan(b).Error

--- a/database/sqlite/build_list_test.go
+++ b/database/sqlite/build_list_test.go
@@ -132,7 +132,7 @@ func TestSqlite_Client_GetOrgBuildList(t *testing.T) {
 	}{
 		{
 			failure: false,
-			want:    []*library.Build{_buildTwo, _buildOne},
+			want:    []*library.Build{_buildOne, _buildTwo},
 		},
 	}
 	filters := map[string]string{}


### PR DESCRIPTION
Fixes https://github.com/go-vela/community/issues/354

This will sort the list of `builds` returned for a specific `org` by the `build.started` timestamp.

Currently, we're sorting the list of `builds` for a specific `org` by `build.number`.

The problem this causes is the `builds` for some `repos` may not appear because they have a smaller `build.number`.

## Example

Let's say we have two `repos` in an `org` named `test`:

* `test/foo`
* `test/bar`

And let's say `test/foo` has ran 200 `builds` while `test/bar` has only ran 100 `builds`.

If you attempt to capture a list of builds for `test`, you'll only see the builds for `test/foo`.

This happens because the `builds` for `test/foo` all have a higher `build.number` field than the `builds` for `test/bar`.