### PR TITLE
fix(database): sort by created instead of started

### DIFF
--- a/database/postgres/build_list.go
+++ b/database/postgres/build_list.go
@@ -71,7 +71,7 @@ func (c *client) GetOrgBuildList(org string, filters map[string]string, page, pe
 		Select("builds.*").
 		Joins("JOIN repos ON builds.repo_id = repos.id and repos.org = ?", org).
 		Where(filters).
-		Order("started DESC").
+		Order("created DESC").
 		Limit(perPage).
 		Offset(offset).
 		Scan(b).Error

--- a/database/postgres/build_list_test.go
+++ b/database/postgres/build_list_test.go
@@ -118,7 +118,7 @@ func TestPostgres_Client_GetOrgBuildList(t *testing.T) {
 		AddRow(2, 1, 2, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0)
 
 	// ensure the mock expects the query
-	_mock.ExpectQuery("SELECT builds.* FROM \"builds\" JOIN repos ON builds.repo_id = repos.id and repos.org = $1 ORDER BY started DESC LIMIT 10").WillReturnRows(_rows)
+	_mock.ExpectQuery("SELECT builds.* FROM \"builds\" JOIN repos ON builds.repo_id = repos.id and repos.org = $1 ORDER BY created DESC LIMIT 10").WillReturnRows(_rows)
 
 	// setup tests
 	tests := []struct {
@@ -186,7 +186,7 @@ func TestPostgres_Client_GetOrgBuildList_NonAdmin(t *testing.T) {
 	).AddRow(1, 1, 1, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0)
 
 	// ensure the mock expects the query
-	_mock.ExpectQuery("SELECT builds.* FROM \"builds\" JOIN repos ON builds.repo_id = repos.id and repos.org = $1 WHERE \"visibility\" = $2 ORDER BY started DESC LIMIT 10").WillReturnRows(_rows)
+	_mock.ExpectQuery("SELECT builds.* FROM \"builds\" JOIN repos ON builds.repo_id = repos.id and repos.org = $1 WHERE \"visibility\" = $2 ORDER BY created DESC LIMIT 10").WillReturnRows(_rows)
 
 	// setup tests
 	tests := []struct {
@@ -256,7 +256,7 @@ func TestPostgres_Client_GetOrgBuildListByEvent(t *testing.T) {
 		AddRow(2, 1, 2, 0, "", "", "", 0, 0, 0, 0, "", nil, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0)
 
 	// ensure the mock expects the query
-	_mock.ExpectQuery("SELECT builds.* FROM \"builds\" JOIN repos ON builds.repo_id = repos.id and repos.org = $1 WHERE \"event\" = $2 ORDER BY started DESC LIMIT 10").WillReturnRows(_rows)
+	_mock.ExpectQuery("SELECT builds.* FROM \"builds\" JOIN repos ON builds.repo_id = repos.id and repos.org = $1 WHERE \"event\" = $2 ORDER BY created DESC LIMIT 10").WillReturnRows(_rows)
 
 	// setup tests
 	tests := []struct {

--- a/database/sqlite/build_list.go
+++ b/database/sqlite/build_list.go
@@ -71,7 +71,7 @@ func (c *client) GetOrgBuildList(org string, filters map[string]string, page int
 		Select("builds.*").
 		Joins("JOIN repos ON builds.repo_id = repos.id AND repos.org = ?", org).
 		Where(filters).
-		Order("started DESC").
+		Order("created DESC").
 		Limit(perPage).
 		Offset(offset).
 		Scan(b).Error


### PR DESCRIPTION
modification of https://github.com/go-vela/server/pull/464 that utilizes `created` instead of `started` for the sorting.

intent is to prevent items jumping in the list since it's more likely for `started` to be `0` (top of the list) and then updated, whereas `created` is typically set when added to the db.