### PR TITLE
fix(api/repo): validation check for pipeline_type

### DIFF
--- a/api/repo.go
+++ b/api/repo.go
@@ -148,10 +148,11 @@ func CreateRepo(c *gin.Context) {
 		r.SetPipelineType(constants.PipelineTypeYAML)
 	} else {
 		// ensure the pipeline type matches one of the expected values
-		if input.GetPipelineType() != constants.PipelineTypeYAML ||
-			input.GetPipelineType() != constants.PipelineTypeGo ||
+		if input.GetPipelineType() != constants.PipelineTypeYAML &&
+			input.GetPipelineType() != constants.PipelineTypeGo &&
 			input.GetPipelineType() != constants.PipelineTypeStarlark {
-			retErr := fmt.Errorf("pipeline_type of %s is invalid", input.GetPipelineType())
+			// nolint: lll // ignore long line length due to error message
+			retErr := fmt.Errorf("unable to create new repo %s: invalid pipeline_type provided %s", r.GetFullName(), input.GetPipelineType())
 
 			util.HandleError(c, http.StatusBadRequest, retErr)
 


### PR DESCRIPTION
This fixes an issue that was discovered when attempting to create a repo using the `vela` CLI.

The error message that is returned looks like:

```sh
$ vela add repo --org foo --repo bar
time="2021-08-26T16:29:37Z" level=fatal msg="pipeline_type of yaml is invalid"
```

This error is presented because the [CLI has a default of `yaml` set](https://github.com/go-vela/cli/blob/v0.9.0/action/repo_add.go#L112-L118) for the `pipeline_type`:

```go
		&cli.StringFlag{
			EnvVars: []string{"VELA_PIPELINE_TYPE", "PIPELINE_TYPE"},
			Name:    "pipeline-type",
			Aliases: []string{"pt"},
			Usage:   "type of base pipeline for the compiler to render",
			Value:   constants.PipelineTypeYAML,
		},
```

But the validation check in the API for the server is using `||` (or) comparisons rather than `&&` (and) comparisons:

https://github.com/go-vela/server/blob/943f4e92426510ba9a6711bcd9da44951c37429c/api/repo.go#L149-L161

To elaborate in words, the comparison in its current state says:

> If the `pipeline_type` provided for a repo:
>
> * does not equal `yaml`
> * OR does not equal `go`
> * OR does not equal `starlark`
>
> Than, the server will return the `pipeline_type of <type> is invalid` error.

To fix this comparison, we'll update it to be the following in words:

> If the `pipeline_type` provided for a repo:
>
> * does not equal `yaml`
> * AND does not equal `go`
> * AND does not equal `starlark`
>
> Than, the server will return the `pipeline_type of <type> is invalid` error.