### PR TITLE
chore: deprecate unused api endpoints

### DIFF
--- a/api/log.go
+++ b/api/log.go
@@ -88,6 +88,7 @@ func GetBuildLogs(c *gin.Context) {
 // Create the logs for a service
 //
 // ---
+// deprecated: true
 // produces:
 // - application/json
 // parameters:
@@ -253,6 +254,7 @@ func GetServiceLog(c *gin.Context) {
 // Update the logs for a service
 //
 // ---
+// deprecated: true
 // produces:
 // - application/json
 // parameters:
@@ -431,6 +433,7 @@ func DeleteServiceLog(c *gin.Context) {
 // Create the logs for a step
 //
 // ---
+// deprecated: true
 // produces:
 // - application/json
 // parameters:
@@ -597,6 +600,7 @@ func GetStepLog(c *gin.Context) {
 // Update the logs for a step
 //
 // ---
+// deprecated: true
 // produces:
 // - application/json
 // parameters:


### PR DESCRIPTION
deprecates api endpoints that are no longer used after https://github.com/go-vela/pkg-executor/pull/177

https://goswagger.io/use/spec/route.html

![Screen Shot 2021-10-06 at 4 35 56 PM](https://user-images.githubusercontent.com/16466829/136287461-f279cd77-8be5-4832-913e-3bf91cf01727.png)
