### PR TITLE
fix(api): listing empty deployments for repo

### DIFF
--- a/api/deployment.go
+++ b/api/deployment.go
@@ -211,7 +211,7 @@ func GetDeployments(c *gin.Context) {
 		return
 	}
 
-	var dWithBs []*library.Deployment
+	dWithBs := []*library.Deployment{}
 	for _, deployment := range d {
 		b, err := database.FromContext(c).GetDeploymentBuildList(*deployment.URL)
 		if err != nil {
@@ -221,11 +221,14 @@ func GetDeployments(c *gin.Context) {
 
 			return
 		}
-		var builds []library.Build
+
+		builds := []library.Build{}
 		for _, build := range b {
 			builds = append(builds, *build)
 		}
+
 		deployment.SetBuilds(builds)
+
 		dWithBs = append(dWithBs, deployment)
 	}
 


### PR DESCRIPTION
Based off of https://github.com/go-vela/server/pull/471

Related to https://github.com/go-vela/community/issues/364 

This issue was discovered in the latest RC:

https://github.com/go-vela/server/releases/tag/v0.10.0-rc2

When navigating to a repo in the Vela UI with no deployments, you'll see a TOAST error message:

![image](https://user-images.githubusercontent.com/10966923/137509314-4dbbee22-4cfb-40cc-ae52-0511b8f60d58.png)

Unfortunately, this error message will be displayed even when you are not on the `Deployments` tab in the UI.

If you navigate to the `Deployments` tab in the UI, you'll see an "infinite" spinning wheel with the TOAST error message:

![image](https://user-images.githubusercontent.com/10966923/137509539-c7ddc38e-429c-474d-b620-db7bbb940866.png)

The reason for this issue is due to us creating an empty slice of deployments as a variable `dWithBs`:

https://github.com/go-vela/server/blob/64f8df255456955126e763cf2e86f1dfac8cdc41/api/deployment.go#L214

However, we never actually initialize that variable which causes a `null` value to be returned by the server to the UI:

https://github.com/go-vela/server/blob/64f8df255456955126e763cf2e86f1dfac8cdc41/api/deployment.go#L241