### PR TITLE
fix: GET on /api/v1/user/source/repos returns the full repo struct

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -396,12 +396,16 @@ func GetUserSourceRepos(c *gin.Context) {
 		org := srepo.Org
 		name := srepo.Name
 		active := false
-
 		// library struct to omit optional fields
 		repo := library.Repo{
-			Org:    org,
-			Name:   name,
-			Active: &active,
+			Org:      org,
+			Name:     name,
+			FullName: srepo.FullName,
+			Link:     srepo.Link,
+			Clone:    srepo.Clone,
+			Branch:   srepo.Branch,
+			Private:  srepo.Private,
+			Active:   &active,
 		}
 		output[srepo.GetOrg()] = append(output[srepo.GetOrg()], repo)
 	}
@@ -442,6 +446,16 @@ func GetUserSourceRepos(c *gin.Context) {
 					if orgRepos[i].GetName() == dbRepo.GetName() {
 						active := dbRepo.GetActive()
 						(&orgRepos[i]).Active = &active
+						(&orgRepos[i]).ID = dbRepo.ID
+						(&orgRepos[i]).UserID = dbRepo.UserID
+						(&orgRepos[i]).Timeout = dbRepo.Timeout
+						(&orgRepos[i]).Visibility = dbRepo.Visibility
+						(&orgRepos[i]).Trusted = dbRepo.Trusted
+						(&orgRepos[i]).AllowPull = dbRepo.AllowPull
+						(&orgRepos[i]).AllowPush = dbRepo.AllowPush
+						(&orgRepos[i]).AllowDeploy = dbRepo.AllowDeploy
+						(&orgRepos[i]).AllowTag = dbRepo.AllowTag
+						(&orgRepos[i]).AllowComment = dbRepo.AllowComment
 					}
 				}
 			}


### PR DESCRIPTION
Fix for [#263](https://github.com/go-vela/community/issues/263): The GET on /api/v1/user/source/repos returns the full repo struct as mentioned in the [docs](https://go-vela.github.io/docs/reference/api/user/current/repos/#response) and this doesn't change how the UI displays the source repos page.