### PR TITLE
chore: add required notice file for external lib

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-This file contains the open source licenses for the following open source components in go-vela/compiler
+This file contains the open source licenses for the following open source components in go-vela/server/compiler
 
 1. drone-cli (commit bed84a32ff0f565b4bd6176e1d87c9b33ec83ed0)
 https://github.com/drone/drone-cli


### PR DESCRIPTION
_PR includes the following:_

- copy over the notice file from the compiler. 