### PR TITLE
fix(api-spec): ensure api spec validates

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,6 +16,10 @@ jobs:
     - name: clone
       uses: actions/checkout@v2
 
+    - name: tags
+      run: |
+        git fetch --tags
+
     - name: validate
       run: |
         # Check that go mod tidy produces a zero diff; clean up any changes afterwards.
@@ -26,3 +30,8 @@ jobs:
         go fmt ./... && git diff --exit-code; code=$?; git checkout -- .; (exit $code)
         # Check that go fix ./... produces a zero diff; clean up any changes afterwards.
         go fix ./... && git diff --exit-code; code=$?; git checkout -- .; (exit $code)
+
+    - name: validate spec
+      run: |
+        make spec-install
+        make spec

--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,16 @@ spec-gen:
 	@swagger generate spec -m -o ${SPEC_FILE}
 	@echo "### ${SPEC_FILE} created successfully"
 
+# The `spec-validate` target is intended to validate
+# an api-spec using go-swagger (https://goswagger.io)
+#
+# Usage: `make spec-validate`
+.PHONY: spec-validate
+spec-validate:
+	@echo
+	@echo "### Validating api spec using go-swagger"
+	@swagger validate ${SPEC_FILE}
+
 # The `spec-version-update` target is intended to update
 # the api-spec version in the generated api-spec
 # using the latest git tag.
@@ -301,9 +311,9 @@ spec-version-update:
 	@echo "### Updating api-spec version"
 	@jq '.info.version = "$(subst v,,${GITHUB_TAG})"' ${SPEC_FILE} | sponge ${SPEC_FILE}
 
-# The `spec` target will call spec-gen and
-# spec-version-update to create an api-spec.
+# The `spec` target will call spec-gen, spec-version-update
+# and spec-validate to create and validate an api-spec.
 #
 # Usage: `make spec`
 .PHONY: spec
-spec: spec-gen spec-version-update
+spec: spec-gen spec-version-update spec-validate

--- a/api/authenticate.go
+++ b/api/authenticate.go
@@ -13,13 +13,13 @@ import (
 	"github.com/go-vela/server/router/middleware/token"
 	"github.com/go-vela/server/source"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types"
-	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/types"
 	"github.com/go-vela/types/library"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
 )
 
 // swagger:operation GET /authenticate authenticate GetAuthenticate
@@ -188,25 +188,42 @@ func Authenticate(c *gin.Context) {
 	c.JSON(http.StatusOK, library.Login{Token: &at})
 }
 
-// swagger:operation GET /authenticate/{type}/{port} authenticate GetAuthenticateType
+// swagger:operation GET /authenticate/web authenticate GetAuthenticateTypeWeb
 //
 // Authentication entrypoint that builds the right post-auth
-// redirect URL and redirects to /authenticate after
+// redirect URL for web authentication requests
+// and redirects to /authenticate after
+//
+// ---
+// produces:
+// - application/json
+// parameters:
+// - in: query
+//   name: code
+//   description: the code received after identity confirmation
+//   type: string
+// - in: query
+//   name: state
+//   description: a random string
+//   type: string
+// responses:
+//   '307':
+//     description: Redirected for authentication
+
+// swagger:operation GET /authenticate/cli/{port} authenticate GetAuthenticateTypeCLI
+//
+// Authentication entrypoint that builds the right post-auth
+// redirect URL for CLI authentication requests
+// and redirects to /authenticate after
 //
 // ---
 // produces:
 // - application/json
 // parameters:
 // - in: path
-//   name: type
-//   description: the type of auth request
-//   type: string
-//   enum:
-//     - web
-//     - cli
-// - in: path
 //   name: port
-//   description: the port number (if type is 'cli')
+//   required: true
+//   description: the port number
 //   type: integer
 // - in: query
 //   name: code

--- a/api/badge.go
+++ b/api/badge.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/repo"
+
 	"github.com/go-vela/types/constants"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 )
 
 // swagger:operation GET /badge/{org}/{repo}/status.svg base GetBadge

--- a/api/build.go
+++ b/api/build.go
@@ -13,15 +13,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-vela/server/router/middleware/user"
-
 	"github.com/go-vela/server/compiler"
-
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/queue"
 	"github.com/go-vela/server/router/middleware/build"
 	"github.com/go-vela/server/router/middleware/executors"
 	"github.com/go-vela/server/router/middleware/repo"
+	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/source"
 	"github.com/go-vela/server/util"
 
@@ -61,6 +59,10 @@ import (
 // security:
 //   - ApiKeyAuth: []
 // responses:
+//   '200':
+//     description: Request processed but build was skipped
+//     schema:
+//       type: string
 //   '201':
 //     description: Successfully created the build
 //     type: json
@@ -345,7 +347,7 @@ func skipEmptyBuild(p *pipeline.Build) string {
 //   - ApiKeyAuth: []
 // responses:
 //   '200':
-//     description: Successfully retrieved the build
+//     description: Successfully retrieved the builds
 //     schema:
 //       type: array
 //       items:
@@ -663,14 +665,14 @@ func GetOrgBuilds(c *gin.Context) {
 //   type: string
 // - in: path
 //   name: build
-//   description: Build number to restart
+//   description: Build number to retrieve
 //   required: true
 //   type: integer
 // security:
 //   - ApiKeyAuth: []
 // responses:
 //   '200':
-//     description: Successfully restarted the build
+//     description: Successfully retrieved the build
 //     type: json
 //     schema:
 //       "$ref": "#/definitions/Build"
@@ -715,6 +717,10 @@ func GetBuild(c *gin.Context) {
 // security:
 //   - ApiKeyAuth: []
 // responses:
+//   '200':
+//     description: Request processed but build was skipped
+//     schema:
+//       type: string
 //   '201':
 //     description: Successfully restarted the build
 //     schema:

--- a/api/deployment.go
+++ b/api/deployment.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 
 	"github.com/go-vela/server/database"
-
 	"github.com/go-vela/server/router/middleware/repo"
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/source"

--- a/api/login.go
+++ b/api/login.go
@@ -9,10 +9,10 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/go-vela/types"
+
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
-
-	"github.com/go-vela/types"
 )
 
 // swagger:operation GET /login authenticate GetLogin
@@ -24,9 +24,8 @@ import (
 // - in: query
 //   name: type
 //   description: the login type ("cli" or "web")
-//   schema:
-//     type: string
-//     enum:
+//   type: string
+//   enum:
 //     - web
 //     - cli
 // - in: query

--- a/api/logout.go
+++ b/api/logout.go
@@ -9,12 +9,14 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/gin-gonic/gin"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/util"
+
 	"github.com/go-vela/types"
 	"github.com/go-vela/types/constants"
+
+	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
 

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -8,8 +8,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/go-vela/server/database"
+
+	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -51,7 +52,7 @@ var (
 //
 // ---
 // produces:
-// - application/json
+// - text/plain
 // parameters:
 // responses:
 //   '200':

--- a/api/secret.go
+++ b/api/secret.go
@@ -10,10 +10,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-vela/server/source"
-
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/secret"
+	"github.com/go-vela/server/source"
 	"github.com/go-vela/server/util"
 
 	"github.com/go-vela/types/constants"

--- a/api/service.go
+++ b/api/service.go
@@ -177,7 +177,7 @@ func CreateService(c *gin.Context) {
 //     schema:
 //       "$ref": "#/definitions/Error"
 //   '500':
-//     description: Unable to restart the list of services
+//     description: Unable to retrieve the list of services
 //     schema:
 //       "$ref": "#/definitions/Error"
 

--- a/api/stream.go
+++ b/api/stream.go
@@ -57,6 +57,8 @@ const logUpdateInterval = 1 * time.Second
 //   name: body
 //   description: Payload containing logs
 //   required: true
+//   schema:
+//     type: string
 // security:
 //   - ApiKeyAuth: []
 // responses:
@@ -197,6 +199,8 @@ func PostServiceStream(c *gin.Context) {
 //   name: body
 //   description: Payload containing logs
 //   required: true
+//   schema:
+//     type: string
 // security:
 //   - ApiKeyAuth: []
 // responses:

--- a/api/token.go
+++ b/api/token.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	"github.com/go-vela/server/router/middleware/token"
 	"github.com/go-vela/server/util"
+
 	"github.com/go-vela/types/library"
+
+	"github.com/gin-gonic/gin"
 )
 
 // swagger:operation GET /token-refresh authenticate GetRefreshAccessToken
@@ -21,12 +23,8 @@ import (
 // ---
 // produces:
 // - application/json
-// parameters:
-// - in: cookie
-//   name: vela_refresh_token
-//   required: true
-//   schema:
-//     type: string
+// security:
+//   - CookieAuth: []
 // responses:
 //   '200':
 //     description: Successfully refreshed a token

--- a/api/version.go
+++ b/api/version.go
@@ -24,7 +24,7 @@ import (
 //   '200':
 //     description: Successfully retrieved the Vela API version
 //     schema:
-//       type: string
+//       "$ref": "#/definitions/Version"
 
 // Version represents the API handler to
 // report the version number for Vela.

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -20,11 +20,12 @@ import (
 	"github.com/go-vela/server/source"
 	"github.com/go-vela/server/util"
 
-	"github.com/gin-gonic/gin"
 	"github.com/go-vela/types"
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/pipeline"
+
+	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
 

--- a/api/worker.go
+++ b/api/worker.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/worker"
 	"github.com/go-vela/server/util"
+
 	"github.com/go-vela/types/library"
+
+	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
 
@@ -36,7 +38,7 @@ import (
 //   '201':
 //     description: Successfully created the worker
 //     schema:
-//       "$ref": "#/definitions/Worker"
+//       type: string
 //   '400':
 //     description: Unable to create the worker
 //     schema:

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/alicebob/miniredis/v2 v2.16.0
+	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.41.14
 	github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
@@ -16,7 +17,7 @@ require (
 	github.com/gin-gonic/gin v1.7.4
 	github.com/go-playground/assert/v2 v2.0.1
 	github.com/go-redis/redis/v8 v8.11.4
-	github.com/go-vela/types v0.11.0-rc1
+	github.com/go-vela/types v0.11.0-rc1.0.20211109203637-374249ce89c9
 	github.com/golang-jwt/jwt/v4 v4.1.0
 	github.com/gomodule/redigo v2.0.0+incompatible // indirect
 	github.com/google/go-cmp v0.5.6
@@ -31,6 +32,7 @@ require (
 	github.com/joho/godotenv v1.4.0
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
+	github.com/microcosm-cc/bluemonday v1.0.16 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/alicebob/miniredis/v2 v2.16.0
-	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.41.14
 	github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
@@ -32,7 +31,6 @@ require (
 	github.com/joho/godotenv v1.4.0
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
-	github.com/microcosm-cc/bluemonday v1.0.16 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -69,7 +69,6 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go v1.41.14 h1:zJnJ8Y964DjyRE55UVoMKgOG4w5i88LpN6xSpBX7z84=
 github.com/aws/aws-sdk-go v1.41.14/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
@@ -171,10 +170,6 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/go-vela/types v0.10.0 h1:C2RPVWAolm6TESb3JpKVdO2agtjG0ecnGuyrkEKNaS8=
-github.com/go-vela/types v0.10.0/go.mod h1:6taTlivaC0wDwDJVlc8sBaVZToyzkyDMtGUYIAfgA9M=
-github.com/go-vela/types v0.11.0-rc1 h1:1/wQA0NadOYpGKBuAwFisc4qIiw79wlU1qdiZClUfes=
-github.com/go-vela/types v0.11.0-rc1/go.mod h1:8Oml/G1ATFTJsKdsIsstUuHVLsUv7pl6+EiIyOaUqH0=
 github.com/go-vela/types v0.11.0-rc1.0.20211109203637-374249ce89c9 h1:jJvY5uUySoI3ui9vVfzj1dJIi4ikF1CO0b9ut+MbCpY=
 github.com/go-vela/types v0.11.0-rc1.0.20211109203637-374249ce89c9/go.mod h1:8Oml/G1ATFTJsKdsIsstUuHVLsUv7pl6+EiIyOaUqH0=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
@@ -441,7 +436,6 @@ github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJK
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/microcosm-cc/bluemonday v1.0.15/go.mod h1:ZLvAzeakRwrGnzQEvstVzVt3ZpqOF2+sdFr0Om+ce30=
 github.com/microcosm-cc/bluemonday v1.0.16 h1:kHmAq2t7WPWLjiGvzKa5o3HzSfahUKiOq7fAPUiMNIc=
 github.com/microcosm-cc/bluemonday v1.0.16/go.mod h1:Z0r70sCuXHig8YpBzCc5eGHAap2K7e/u082ZUpDRRqM=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,7 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go v1.41.14 h1:zJnJ8Y964DjyRE55UVoMKgOG4w5i88LpN6xSpBX7z84=
 github.com/aws/aws-sdk-go v1.41.14/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
@@ -170,8 +171,12 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-vela/types v0.10.0 h1:C2RPVWAolm6TESb3JpKVdO2agtjG0ecnGuyrkEKNaS8=
+github.com/go-vela/types v0.10.0/go.mod h1:6taTlivaC0wDwDJVlc8sBaVZToyzkyDMtGUYIAfgA9M=
 github.com/go-vela/types v0.11.0-rc1 h1:1/wQA0NadOYpGKBuAwFisc4qIiw79wlU1qdiZClUfes=
 github.com/go-vela/types v0.11.0-rc1/go.mod h1:8Oml/G1ATFTJsKdsIsstUuHVLsUv7pl6+EiIyOaUqH0=
+github.com/go-vela/types v0.11.0-rc1.0.20211109203637-374249ce89c9 h1:jJvY5uUySoI3ui9vVfzj1dJIi4ikF1CO0b9ut+MbCpY=
+github.com/go-vela/types v0.11.0-rc1.0.20211109203637-374249ce89c9/go.mod h1:8Oml/G1ATFTJsKdsIsstUuHVLsUv7pl6+EiIyOaUqH0=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -436,6 +441,7 @@ github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJK
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/microcosm-cc/bluemonday v1.0.15/go.mod h1:ZLvAzeakRwrGnzQEvstVzVt3ZpqOF2+sdFr0Om+ce30=
 github.com/microcosm-cc/bluemonday v1.0.16 h1:kHmAq2t7WPWLjiGvzKa5o3HzSfahUKiOq7fAPUiMNIc=
 github.com/microcosm-cc/bluemonday v1.0.16/go.mod h1:Z0r70sCuXHig8YpBzCc5eGHAap2K7e/u082ZUpDRRqM=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/router/router.go
+++ b/router/router.go
@@ -18,19 +18,26 @@
 //
 //     SecurityDefinitions:
 //       ApiKeyAuth:
+//         description: Bearer token
 //         type: apiKey
 //         in: header
 //         name: Authorization
+//       CookieAuth:
+//         description: Refresh token sent as cookie (swagger 2.0 doesn't support cookie)
+//         type: apiKey
+//         in: header
+//         name: vela_refresh_token
 //
 // swagger:meta
 package router
 
 import (
-	"github.com/gin-gonic/gin"
 	"github.com/go-vela/server/api"
 	"github.com/go-vela/server/router/middleware"
 	"github.com/go-vela/server/router/middleware/repo"
 	"github.com/go-vela/server/router/middleware/user"
+
+	"github.com/gin-gonic/gin"
 )
 
 const (

--- a/router/router.go
+++ b/router/router.go
@@ -23,7 +23,7 @@
 //         in: header
 //         name: Authorization
 //       CookieAuth:
-//         description: Refresh token sent as cookie (swagger 2.0 doesn't support cookie)
+//         description: Refresh token sent as cookie (swagger 2.0 doesn't support cookie auth)
 //         type: apiKey
 //         in: header
 //         name: vela_refresh_token


### PR DESCRIPTION
closes https://github.com/go-vela/community/issues/432
depends on https://github.com/go-vela/types/pull/208 (`/version` endpoint returns a Version object)

contains:
* various fixes to spec annotations (spelling, correctness, missing info, etc)
* adds spec validation to `validate` workflow in GitHub Actions
* consistent import sort in `/api` package

no code was changed, but theses edits should result in the automation producing a valid and more accurate API spec.

_note: `validate` workflow will fail due to new spec validation until the dependent PR is merged and `/types` import is updated_