### PR TITLE
fix: capturing empty build queue

### DIFF
--- a/database/postgres/build.go
+++ b/database/postgres/build.go
@@ -99,11 +99,6 @@ func (c *client) GetPendingAndRunningBuilds(after string) ([]*library.BuildQueue
 		Raw(dml.SelectPendingAndRunningBuilds, after).
 		Scan(b)
 
-	// check if the query returned a record not found error or no rows were returned
-	if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
-		return nil, gorm.ErrRecordNotFound
-	}
-
 	// variable we want to return
 	builds := []*library.BuildQueue{}
 

--- a/database/sqlite/build.go
+++ b/database/sqlite/build.go
@@ -99,11 +99,6 @@ func (c *client) GetPendingAndRunningBuilds(after string) ([]*library.BuildQueue
 		Raw(dml.SelectPendingAndRunningBuilds, after).
 		Scan(b)
 
-	// check if the query returned a record not found error or no rows were returned
-	if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {
-		return nil, gorm.ErrRecordNotFound
-	}
-
 	// variable we want to return
 	builds := []*library.BuildQueue{}
 

--- a/database/sqlite/build_test.go
+++ b/database/sqlite/build_test.go
@@ -284,8 +284,8 @@ func TestSqlite_Client_GetPendingAndRunningBuilds(t *testing.T) {
 			want:    []*library.BuildQueue{_queueOne, _queueTwo},
 		},
 		{
-			failure: true,
-			want:    nil,
+			failure: false,
+			want:    []*library.BuildQueue{},
 		},
 	}
 
@@ -297,7 +297,7 @@ func TestSqlite_Client_GetPendingAndRunningBuilds(t *testing.T) {
 			t.Errorf("unable to create test repo: %v", err)
 		}
 
-		if test.want != nil {
+		if len(test.want) > 0 {
 			// create the builds in the database
 			err = _database.CreateBuild(_buildOne)
 			if err != nil {


### PR DESCRIPTION
This resolves an issue with the `/api/v1/admin/builds/queue` endpoint.

Currently, a problem exists with the above endpoint if no `pending` or `running` builds exist in the database.

if you send a `GET` request to the above URL in that scenario, you'll receive a `500 Internal Server Error` code.

Along with this HTTP status code, you'll receive the following error message:

```
{"error": "unable to capture all running and pending builds: record not found"}
```

The reason for this behavior is due to how the [GetPendingAndRunningBuilds()](https://github.com/go-vela/server/blob/13dcae99a55ff874c06fb7d97c9bdabe604dc288/api/admin/build.go#L98-L106) behaves in the `database` package.

When the function is called, we execute a query and perform a check to see if any results are returned:

https://github.com/go-vela/server/blob/13dcae99a55ff874c06fb7d97c9bdabe604dc288/database/postgres/build.go#L102-L105

https://github.com/go-vela/server/blob/13dcae99a55ff874c06fb7d97c9bdabe604dc288/database/sqlite/build.go#L102-L105

If no results are returned, the function will return an error stating no record could be found.

This change removes this check, preventing the error from being returned if no `pending` or `running` builds exist.

Instead, you'll now receive a `200 OK` HTTP status code with an empty list of builds.