### PR TITLE
enhance: setting version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,8 @@ ifndef GITHUB_TAG
 	GITHUB_TAG = $(shell git describe --tag --abbrev=0)
 endif
 
-# check if a go version is already set
-ifndef GOLANG_VERSION
-	# capture the current go version we build the application from
-	GOLANG_VERSION = $(shell go version | awk '{ print $$3 }')
-endif
-
 # create a list of linker flags for building the golang application
-LD_FLAGS = -X github.com/go-vela/server/version.Commit=${GITHUB_SHA} -X github.com/go-vela/server/version.Date=${BUILD_DATE} -X github.com/go-vela/server/version.Go=${GOLANG_VERSION} -X github.com/go-vela/server/version.Tag=${GITHUB_TAG}
+LD_FLAGS = -X github.com/go-vela/server/version.Commit=${GITHUB_SHA} -X github.com/go-vela/server/version.Date=${BUILD_DATE} -X github.com/go-vela/server/version.Tag=${GITHUB_TAG}
 
 # The `clean` target is intended to clean the workspace
 # and prepare the local changes for submission.

--- a/version/version.go
+++ b/version/version.go
@@ -9,8 +9,8 @@ import (
 	"runtime"
 
 	"github.com/Masterminds/semver/v3"
-
 	"github.com/go-vela/types/version"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -32,6 +32,14 @@ var (
 
 // New creates a new version object for Vela that is used throughout the application.
 func New() *version.Version {
+	// check if a semantic tag was provided
+	if len(Tag) == 0 {
+		logrus.Warningf("no semantic tag provided - defaulting to v0.0.0")
+
+		// set a fallback default for the tag
+		Tag = "v0.0.0"
+	}
+
 	v, err := semver.NewVersion(Tag)
 	if err != nil {
 		fmt.Println(fmt.Errorf("unable to parse semantic version for %s: %v", Tag, err))

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	// Date represents the build date information for the package.
 	Date string
 	// Go represents the golang version information for the package.
-	Go string
+	Go = runtime.Version()
 	// OS represents the operating system information for the package.
 	OS = runtime.GOOS
 	// Tag represents the git tag information for the package.


### PR DESCRIPTION
This change slightly modifies two pieces from the version output.

This first part is updating the version output to use a fallback value for the semantic tag of `v0.0.0`.

This should prevent the possibility of a panic happening if the tag info isn't captured properly:

https://github.com/go-vela/server/blob/aff96b30eefd6d9425758088f97e42be1fd80243/Makefile#L17-L21

The second part is using Go's `runtime.Version()` function to capture the version of `go` the app is built with:

https://pkg.go.dev/runtime#Version

Since we're relying on that function from the `runtime` library, we no longer need to capture that info in the `Makefile`.

Previously, we used to run the `go version` command and parse the value from the output:

https://github.com/go-vela/server/blob/aff96b30eefd6d9425758088f97e42be1fd80243/Makefile#L23-L27