### PR TITLE
feat: add index on builds.created

### DIFF
--- a/database/postgres/ddl/build.go
+++ b/database/postgres/ddl/build.go
@@ -62,4 +62,13 @@ IF NOT EXISTS
 builds_status
 ON builds (status);
 `
+
+	// CreateBuildCreatedIndex represents a query to create an
+	// index on the builds table for the created column.
+	CreateBuildCreatedIndex = `
+CREATE INDEX CONCURRENTLY
+IF NOT EXISTS
+builds_created
+ON builds (created);
+`
 )

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -257,6 +257,12 @@ func createIndexes(c *client) error {
 		return fmt.Errorf("unable to create builds_status index for the %s table: %v", constants.TableBuild, err)
 	}
 
+	// create the builds_created index for the builds table
+	err = c.Postgres.Exec(ddl.CreateBuildCreatedIndex).Error
+	if err != nil {
+		return fmt.Errorf("unable to create builds_created index for the %s table: %v", constants.TableBuild, err)
+	}
+
 	// create the hooks_repo_id index for the hooks table
 	err = c.Postgres.Exec(ddl.CreateHookRepoIDIndex).Error
 	if err != nil {

--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -85,6 +85,7 @@ func TestPostgres_setupDatabase(t *testing.T) {
 	// ensure the mock expects the index queries
 	_mock.ExpectExec(ddl.CreateBuildRepoIDIndex).WillReturnResult(sqlmock.NewResult(1, 1))
 	_mock.ExpectExec(ddl.CreateBuildStatusIndex).WillReturnResult(sqlmock.NewResult(1, 1))
+	_mock.ExpectExec(ddl.CreateBuildCreatedIndex).WillReturnResult(sqlmock.NewResult(1, 1))
 	_mock.ExpectExec(ddl.CreateHookRepoIDIndex).WillReturnResult(sqlmock.NewResult(1, 1))
 	_mock.ExpectExec(ddl.CreateLogBuildIDIndex).WillReturnResult(sqlmock.NewResult(1, 1))
 	_mock.ExpectExec(ddl.CreateRepoOrgNameIndex).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -201,6 +202,7 @@ func TestPostgres_createIndexes(t *testing.T) {
 	// ensure the mock expects the index queries
 	_mock.ExpectExec(ddl.CreateBuildRepoIDIndex).WillReturnResult(sqlmock.NewResult(1, 1))
 	_mock.ExpectExec(ddl.CreateBuildStatusIndex).WillReturnResult(sqlmock.NewResult(1, 1))
+	_mock.ExpectExec(ddl.CreateBuildCreatedIndex).WillReturnResult(sqlmock.NewResult(1, 1))
 	_mock.ExpectExec(ddl.CreateHookRepoIDIndex).WillReturnResult(sqlmock.NewResult(1, 1))
 	_mock.ExpectExec(ddl.CreateLogBuildIDIndex).WillReturnResult(sqlmock.NewResult(1, 1))
 	_mock.ExpectExec(ddl.CreateRepoOrgNameIndex).WillReturnResult(sqlmock.NewResult(1, 1))

--- a/database/sqlite/ddl/build.go
+++ b/database/sqlite/ddl/build.go
@@ -62,4 +62,13 @@ IF NOT EXISTS
 builds_status
 ON builds (status);
 `
+
+	// CreateBuildCreatedIndex represents a query to create an
+	// index on the builds table for the created column.
+	CreateBuildCreatedIndex = `
+CREATE INDEX
+IF NOT EXISTS
+builds_created
+ON builds (created);
+`
 )

--- a/database/sqlite/sqlite.go
+++ b/database/sqlite/sqlite.go
@@ -256,6 +256,12 @@ func createIndexes(c *client) error {
 		return fmt.Errorf("unable to create builds_status index for the %s table: %v", constants.TableBuild, err)
 	}
 
+	// create the builds_created index for the builds table
+	err = c.Sqlite.Exec(ddl.CreateBuildCreatedIndex).Error
+	if err != nil {
+		return fmt.Errorf("unable to create builds_created index for the %s table: %v", constants.TableBuild, err)
+	}
+
 	// create the hooks_repo_id index for the hooks table
 	err = c.Sqlite.Exec(ddl.CreateHookRepoIDIndex).Error
 	if err != nil {


### PR DESCRIPTION
Used for reporting - e.g. `where created > $some_epoch` to quickly and cheaply limit querying recent build metrics.