### PR TITLE
initial work for signature api and build checking in webhook

### DIFF
--- a/api/build.go
+++ b/api/build.go
@@ -213,7 +213,7 @@ func CreateBuild(c *gin.Context) {
 	}
 
 	// send API call to capture the pipeline configuration file
-	config, err := scm.FromContext(c).ConfigBackoff(u, r, input.GetCommit())
+	config, _, err := scm.FromContext(c).ConfigBackoff(u, r, input.GetCommit())
 	if err != nil {
 		// nolint: lll // ignore long line length due to error message
 		retErr := fmt.Errorf("unable to get pipeline configuration for %s/%d: %w", r.GetFullName(), input.GetNumber(), err)
@@ -898,7 +898,7 @@ func RestartBuild(c *gin.Context) {
 	}
 
 	// send API call to capture the pipeline configuration file
-	config, err := scm.FromContext(c).ConfigBackoff(u, r, b.GetCommit())
+	config, _, err := scm.FromContext(c).ConfigBackoff(u, r, b.GetCommit())
 	if err != nil {
 		retErr := fmt.Errorf("unable to get pipeline configuration for %s: %w", entry, err)
 

--- a/api/repo.go
+++ b/api/repo.go
@@ -718,6 +718,11 @@ func UpdateRepo(c *gin.Context) {
 		r.SetAllowComment(input.GetAllowComment())
 	}
 
+	if input.Trusted != nil {
+		// update trusted if set
+		r.SetTrusted(input.GetTrusted())
+	}
+
 	// set default events if no events are enabled
 	if !r.GetAllowPull() && !r.GetAllowPush() &&
 		!r.GetAllowDeploy() && !r.GetAllowTag() &&

--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -41,8 +41,8 @@ type ModifyResponse struct {
 // Compile produces an executable pipeline from a yaml configuration.
 //
 // nolint: gocyclo,funlen // ignore function length due to comments
-func (c *client) Compile(v interface{}) (*pipeline.Build, error) {
-	p, err := c.Parse(v)
+func (c *client) Compile(cfg interface{}) (*pipeline.Build, error) {
+	p, err := c.Parse(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/router/pipeline.go
+++ b/router/pipeline.go
@@ -18,6 +18,7 @@ import (
 // GET  /api/v1/pipelines/:org/:repo/templates
 // POST /api/v1/pipelines/:org/:repo/expand
 // POST /api/v1/pipelines/:org/:repo/compile
+// POST /api/v1/pipelines/:org/:repo/sign
 // POST /api/v1/pipelines/:org/:repo/validate .
 func PipelineHandlers(base *gin.RouterGroup) {
 	// Pipelines endpoints
@@ -27,6 +28,7 @@ func PipelineHandlers(base *gin.RouterGroup) {
 		pipelines.GET("/templates", api.GetTemplates)
 		pipelines.POST("/expand", api.ExpandPipeline)
 		pipelines.POST("/validate", api.ValidatePipeline)
+		pipelines.POST("/sign", api.SignPipeline)
 		pipelines.POST("/compile", api.CompilePipeline)
 	} // end of pipelines endpoints
 }

--- a/scm/github/testdata/signature.json
+++ b/scm/github/testdata/signature.json
@@ -1,0 +1,18 @@
+{
+    "type": "file",
+    "encoding": "base64",
+    "size": 5362,
+    "name": ".vela.sig",
+    "path": ".vela.sig",
+    "content": "LS0tCnZlcnNpb246ICIxIgoKbWV0YWRhdGE6CiAgb3M6IGxpbnV4CgpzdGVwczoKICAtIG5hbWU6IGJ1aWxkCiAgICBpbWFnZTogb3BlbmpkazpsYXRlc3QKICAgIHB1bGw6IHRydWUKICAgIGVudmlyb25tZW50OgogICAgICBHUkFETEVfVVNFUl9IT01FOiAuZ3JhZGxlCiAgICAgIEdSQURMRV9PUFRTOiAtRG9yZy5ncmFkbGUuZGFlbW9uPWZhbHNlIC1Eb3JnLmdyYWRsZS53b3JrZXJzLm1heD0xIC1Eb3JnLmdyYWRsZS5wYXJhbGxlbD1mYWxzZQogICAgY29tbWFuZHM6CiAgICAgIC0gLi9ncmFkbGV3IGJ1aWxkIGRpc3RUYXIK",
+    "sha": "3d21ec53a331a6f037a91c368710b99387d012c1",
+    "url": "https://api.github.com/repos/octokit/octokit.rb/contents/.vela.sig",
+    "git_url": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+    "html_url": "https://github.com/octokit/octokit.rb/blob/master/.vela.sig",
+    "download_url": "https://raw.githubusercontent.com/octokit/octokit.rb/master/.vela.sig",
+    "_links": {
+      "git": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+      "self": "https://api.github.com/repos/octokit/octokit.rb/contents/.vela.sig",
+      "html": "https://github.com/octokit/octokit.rb/blob/master/.vela.sig"
+    }
+  }

--- a/scm/service.go
+++ b/scm/service.go
@@ -87,11 +87,11 @@ type Service interface {
 
 	// Config defines a function that captures
 	// the pipeline configuration from a repo.
-	Config(*library.User, *library.Repo, string) ([]byte, error)
+	Config(*library.User, *library.Repo, string) ([]byte, []byte, error)
 	// ConfigBackoff is a truncated constant backoff wrapper for Config.
 	// Retry again in five seconds if Config fails to retrieve yaml/yml file.
 	// Will return an error after five failed attempts.
-	ConfigBackoff(*library.User, *library.Repo, string) ([]byte, error)
+	ConfigBackoff(*library.User, *library.Repo, string) ([]byte, []byte, error)
 	// Disable defines a function that deactivates
 	// a repo by destroying the webhook.
 	Disable(*library.User, string, string) error


### PR DESCRIPTION
This is very much a draft but I was hoping it could provide some more detail on how the pipeline signing might work server-side. For example purposes, I made `Trusted` the field in question, put the signature in a separate file `.vela.sig`, and use the entire contents of the `.vela.yml` file as the key for the signature.

A few things I'm missing: expanded pipeline since templates could get manipulated, SHA checksum of `.vela.yml` file, and obviously the accompanying CLI changes. I mainly wanted to put this out here as a draft as a supplement to the [proposal](https://github.com/go-vela/community/pull/461)