### PR TITLE
enhance: allow user to query build via commit hash

### DIFF
--- a/api/build.go
+++ b/api/build.go
@@ -417,6 +417,8 @@ func GetBuilds(c *gin.Context) {
 	event := c.Query("event")
 	// capture the status type parameter
 	status := c.Query("status")
+	// capture the commit hash parameter
+	commit := c.Query("commit")
 
 	// check if branch filter was provided
 	if len(branch) > 0 {
@@ -455,6 +457,12 @@ func GetBuilds(c *gin.Context) {
 
 		// add status to filters map
 		filters["status"] = status
+	}
+
+	// check if commit hash filter was provided
+	if len(commit) > 0 {
+		// add commit to filters map
+		filters["commit"] = commit
 	}
 
 	// capture page query parameter if present


### PR DESCRIPTION
For implementing [124](https://github.com/go-vela/community/issues/124).
Added request parameter `commit` that allows the user to query builds based on the commit hash. 
A `GET` request on `/api/v1/repos/:org/:repo/builds?commit=40charactersOfTheCommitHash` returns the list of builds for that particular commit.