### PR TITLE
backport(secret/vault): update strategy to refresh token

### DIFF
--- a/secret/vault/refresh.go
+++ b/secret/vault/refresh.go
@@ -8,24 +8,27 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
-	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 // initialize obtains the vault token from the given auth method
 //
 // docs: https://www.vaultproject.io/docs/auth
 func (c *client) initialize() error {
-	// declare variables to be utilize within the switch
-	var token string
-	var ttl time.Duration
+	logrus.Trace("initializing token for vault")
+
+	// declare variables to be utilized within the switch
+	var (
+		token string
+		ttl   time.Duration
+	)
 
 	switch c.config.AuthMethod {
 	case "aws":
-		// create session for aws
+		// create session for AWS
 		sess, err := session.NewSessionWithOptions(session.Options{
 			Config: aws.Config{
 				CredentialsChainVerboseErrors: aws.Bool(true),
@@ -36,13 +39,13 @@ func (c *client) initialize() error {
 			return errors.Wrap(err, "failed to create aws session for vault")
 		}
 
-		// generate sts client for later api calls
+		// generate sts client for future API calls
 		c.AWS.StsClient = sts.New(sess)
 
 		// obtain token from vault
 		token, ttl, err = c.getAwsToken()
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to get AWS token from vault")
 		}
 	}
 
@@ -61,7 +64,7 @@ func (c *client) getAwsToken() (string, time.Duration, error) {
 		return "", 0, err
 	}
 
-	logrus.Trace("getting token from vault")
+	logrus.Trace("getting AWS token from vault")
 	secret, err := c.Vault.Logical().Write("auth/aws/login", headers)
 	if err != nil {
 		return "", 0, err
@@ -77,7 +80,7 @@ func (c *client) getAwsToken() (string, time.Duration, error) {
 // generateAwsAuthHeader will generate the necessary data
 // to send to the Vault server for generating a token.
 func (c *client) generateAwsAuthHeader() (map[string]interface{}, error) {
-	logrus.Trace("generating auth headers for vault")
+	logrus.Trace("generating AWS auth headers for vault")
 	req, _ := c.AWS.StsClient.GetCallerIdentityRequest(&sts.GetCallerIdentityInput{})
 
 	// sign the request
@@ -113,18 +116,15 @@ func (c *client) generateAwsAuthHeader() (map[string]interface{}, error) {
 	return loginData, nil
 }
 
-// refreshToken will refresh the given token if possible or generate a new one entirely.
+// refreshToken will refresh the token used for Vault.
 func (c *client) refreshToken() {
 	for {
+		logrus.Tracef("sleeping for configured vault token duration %v", c.config.TokenDuration)
+		// sleep for the configured token duration before refreshing the token
 		time.Sleep(c.config.TokenDuration)
-		// token refresh may fail since the allowable refresh
-		// timeframe varies depending on the auth method
-		_, err := c.Vault.Auth().Token().RenewSelf(int(c.TTL / time.Second))
-		// fall back to obtaining a new token if the refresh fails
-		if err != nil {
-			err = c.initialize()
-		}
 
+		// reinitialize the client to refresh the token
+		err := c.initialize()
 		if err != nil {
 			logrus.Errorf("failed to refresh vault token: %s", err)
 		} else {


### PR DESCRIPTION
Related to https://github.com/go-vela/community/issues/473

This is a backport of https://github.com/go-vela/server/pull/570 into the `v0.11.x` codebase.

To create the backport, a new `v0.11.1` branch was created from the `v0.11.0` release for Vela.

Then, I created a new `backport/fix/secret/vault` branch based off the `v0.11.1` branch to add the functionality needed.

Once the functionality is accepted and merged, a new `v0.11.1` release will be cut from the `v0.11.1` branch. 