### PR TITLE
fix(secrets): actually set updated_at and updated_by fields

### DIFF
--- a/secret/native/update.go
+++ b/secret/native/update.go
@@ -62,5 +62,9 @@ func (c *client) Update(sType, org, name string, s *library.Secret) error {
 		sec.SetAllowCommand(s.GetAllowCommand())
 	}
 
+	if len(s.GetUpdatedBy()) > 0 {
+		sec.SetUpdatedBy(s.GetUpdatedBy())
+	}
+
 	return c.Database.UpdateSecret(sec)
 }

--- a/secret/native/update.go
+++ b/secret/native/update.go
@@ -62,9 +62,11 @@ func (c *client) Update(sType, org, name string, s *library.Secret) error {
 		sec.SetAllowCommand(s.GetAllowCommand())
 	}
 
-	if len(s.GetUpdatedBy()) > 0 {
-		sec.SetUpdatedBy(s.GetUpdatedBy())
-	}
+	// update updated_at if set
+	sec.SetUpdatedAt(s.GetUpdatedAt())
+
+	// update updated_by if set
+	sec.SetUpdatedBy(s.GetUpdatedBy())
 
 	return c.Database.UpdateSecret(sec)
 }

--- a/secret/native/update_test.go
+++ b/secret/native/update_test.go
@@ -15,6 +15,22 @@ import (
 
 func TestNative_Update(t *testing.T) {
 	// setup types
+	original := new(library.Secret)
+	original.SetID(1)
+	original.SetOrg("foo")
+	original.SetRepo("bar")
+	original.SetTeam("")
+	original.SetName("baz")
+	original.SetValue("secretValue")
+	original.SetType("repo")
+	original.SetImages([]string{"foo", "baz"})
+	original.SetEvents([]string{"foob", "bar"})
+	original.SetAllowCommand(true)
+	original.SetCreatedAt(1)
+	original.SetCreatedBy("user")
+	original.SetUpdatedAt(1)
+	original.SetUpdatedBy("user")
+
 	want := new(library.Secret)
 	want.SetID(1)
 	want.SetOrg("foo")
@@ -40,7 +56,7 @@ func TestNative_Update(t *testing.T) {
 		_sql.Close()
 	}()
 
-	_ = db.CreateSecret(want)
+	_ = db.CreateSecret(original)
 
 	// run test
 	s, err := New(


### PR DESCRIPTION
Actually setting the metadata fields when a secret is updated. I also made the existing test actually test for an update so this hopefully won't happen in the future. 