### PR TITLE
fix(build)!: increase error limit to 1000

### DIFF
--- a/database/postgres/ddl/build.go
+++ b/database/postgres/ddl/build.go
@@ -17,7 +17,7 @@ builds (
 	parent         INTEGER,
 	event          VARCHAR(250),
 	status         VARCHAR(250),
-	error          VARCHAR(500),
+	error          VARCHAR(1000),
 	enqueued       INTEGER,
 	created        INTEGER,
 	started        INTEGER,


### PR DESCRIPTION
Related to [this change](https://github.com/go-vela/types/pull/231). 