### PR TITLE
fix(api/secrets): reject secrets with only whitespace characters

### DIFF
--- a/api/secret.go
+++ b/api/secret.go
@@ -81,6 +81,8 @@ import (
 
 // CreateSecret represents the API handler to
 // create a secret in the configured backend.
+//
+// nolint: funlen // ignore funlen linter
 func CreateSecret(c *gin.Context) {
 	// capture middleware values
 	u := user.Retrieve(c)
@@ -123,6 +125,16 @@ func CreateSecret(c *gin.Context) {
 	err := c.Bind(input)
 	if err != nil {
 		retErr := fmt.Errorf("unable to decode JSON for secret %s for %s service: %w", entry, e, err)
+
+		util.HandleError(c, http.StatusBadRequest, retErr)
+
+		return
+	}
+
+	// reject secrets with solely whitespace characters as its value
+	trimmed := strings.TrimSpace(input.GetValue())
+	if len(trimmed) == 0 {
+		retErr := fmt.Errorf("secret value must contain non-whitespace characters")
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
 
@@ -544,6 +556,8 @@ func GetSecret(c *gin.Context) {
 //       "$ref": "#/definitions/Error"
 
 // UpdateSecret updates a secret for the provided secrets service.
+//
+// nolint: funlen // ignore funlen linter
 func UpdateSecret(c *gin.Context) {
 	// capture middleware values
 	u := user.Retrieve(c)
@@ -589,6 +603,16 @@ func UpdateSecret(c *gin.Context) {
 	err := c.Bind(input)
 	if err != nil {
 		retErr := fmt.Errorf("unable to decode JSON for secret %s for %s service: %v", entry, e, err)
+
+		util.HandleError(c, http.StatusBadRequest, retErr)
+
+		return
+	}
+
+	// reject secrets with solely whitespace characters as its value
+	trimmed := strings.TrimSpace(input.GetValue())
+	if len(trimmed) == 0 {
+		retErr := fmt.Errorf("secret value must contain non-whitespace characters")
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
 


### PR DESCRIPTION
Backport for patch release `v0.12.1`. Somewhat related to https://github.com/go-vela/worker/pull/274. 

Already merged PR for this change: https://github.com/go-vela/server/pull/588