### PR TITLE
fix(api/secret): get rid of whitespace check for secret updating

### DIFF
--- a/api/secret.go
+++ b/api/secret.go
@@ -609,16 +609,6 @@ func UpdateSecret(c *gin.Context) {
 		return
 	}
 
-	// reject secrets with solely whitespace characters as its value
-	trimmed := strings.TrimSpace(input.GetValue())
-	if len(trimmed) == 0 {
-		retErr := fmt.Errorf("secret value must contain non-whitespace characters")
-
-		util.HandleError(c, http.StatusBadRequest, retErr)
-
-		return
-	}
-
 	// update secret fields if provided
 	input.SetName(s)
 	input.SetOrg(o)


### PR DESCRIPTION
When trying to update a secret to handle more events, I received a `400` because I wanted to keep the value of the secret the same. In other words, we already handle whitespace updates by simply keeping the original secret value — we don't need this check; in fact, it's just a bug if we leave it.