### PR TITLE
fix(api/repo): fix path for GetOrgRepos in swagger spec

### DIFF
--- a/api/repo.go
+++ b/api/repo.go
@@ -393,7 +393,7 @@ func GetRepos(c *gin.Context) {
 	c.JSON(http.StatusOK, r)
 }
 
-// swagger:operation GET /api/v1/{org} repos GetOrgRepos
+// swagger:operation GET /api/v1/repos/{org} repos GetOrgRepos
 //
 // Get all repos for the provided org in the configured backend
 //


### PR DESCRIPTION
Adding `repos` to path for the swagger spec