### PR TITLE
enhance(router/pipeline): change expand, validate, and compile to MustRead

### DIFF
--- a/router/pipeline.go
+++ b/router/pipeline.go
@@ -40,7 +40,7 @@ func PipelineHandlers(base *gin.RouterGroup) {
 			_pipeline.GET("/templates", perm.MustRead(), pipeline.GetTemplates)
 			_pipeline.POST("/compile", perm.MustWrite(), pipeline.CompilePipeline)
 			_pipeline.POST("/expand", perm.MustRead(), pipeline.ExpandPipeline)
-			_pipeline.POST("/validate", perm.MustWrite(), pipeline.ValidatePipeline)
+			_pipeline.POST("/validate", perm.MustRead(), pipeline.ValidatePipeline)
 		} // end of pipeline endpoints
 	} // end of pipelines endpoints
 }

--- a/router/pipeline.go
+++ b/router/pipeline.go
@@ -39,7 +39,7 @@ func PipelineHandlers(base *gin.RouterGroup) {
 			_pipeline.DELETE("", perm.MustPlatformAdmin(), pipeline.DeletePipeline)
 			_pipeline.GET("/templates", perm.MustRead(), pipeline.GetTemplates)
 			_pipeline.POST("/compile", perm.MustWrite(), pipeline.CompilePipeline)
-			_pipeline.POST("/expand", perm.MustWrite(), pipeline.ExpandPipeline)
+			_pipeline.POST("/expand", perm.MustRead(), pipeline.ExpandPipeline)
 			_pipeline.POST("/validate", perm.MustWrite(), pipeline.ValidatePipeline)
 		} // end of pipeline endpoints
 	} // end of pipelines endpoints

--- a/router/pipeline.go
+++ b/router/pipeline.go
@@ -38,7 +38,7 @@ func PipelineHandlers(base *gin.RouterGroup) {
 			_pipeline.PUT("", perm.MustWrite(), pipeline.UpdatePipeline)
 			_pipeline.DELETE("", perm.MustPlatformAdmin(), pipeline.DeletePipeline)
 			_pipeline.GET("/templates", perm.MustRead(), pipeline.GetTemplates)
-			_pipeline.POST("/compile", perm.MustWrite(), pipeline.CompilePipeline)
+			_pipeline.POST("/compile", perm.MustRead(), pipeline.CompilePipeline)
 			_pipeline.POST("/expand", perm.MustRead(), pipeline.ExpandPipeline)
 			_pipeline.POST("/validate", perm.MustRead(), pipeline.ValidatePipeline)
 		} // end of pipeline endpoints


### PR DESCRIPTION
Since expand pipeline aggregates information that is already available for those with read permissions, it makes sense to have the expand endpoint match that level of accessibility. 