### PR TITLE
fix(scm/webhook): turn off pr:edited events

### DIFF
--- a/scm/github/webhook.go
+++ b/scm/github/webhook.go
@@ -215,10 +215,9 @@ func (c *client) processPREvent(h *library.Hook, payload *github.PullRequestEven
 		return &types.Webhook{Hook: h}, nil
 	}
 
-	// skip if the pull request action is not opened, synchronize, or edited
+	// skip if the pull request action is not opened, synchronize
 	if !strings.EqualFold(payload.GetAction(), "opened") &&
-		!strings.EqualFold(payload.GetAction(), "synchronize") &&
-		!strings.EqualFold(payload.GetAction(), "edited") {
+		!strings.EqualFold(payload.GetAction(), "synchronize") {
 		return &types.Webhook{Hook: h}, nil
 	}
 


### PR DESCRIPTION
Until we give users the ability to opt-in for the `edited` action for PR events, the added webhook noise is resulting in unexpected behavior. 

For example, if a user has a step:
```yaml
- name: example
   image: alpine
   ruleset:
      event: pull_request
```

That step is ignored due to the fact that `pull_request` == `pull_request:opened, pull_request:synchronize`. Another way to say this: we accommodated legacy pull request ruleset on the yaml side but not the webhook side. 

As a band-aid, we can turn off the firehose for edited actions until we have a more robust way of handling it.