### PR TITLE
fix(build/ruleset): handle legacy PR ruleset for restarted build

### DIFF
--- a/api/build.go
+++ b/api/build.go
@@ -990,6 +990,14 @@ func RestartBuild(c *gin.Context) {
 	b.SetRuntime("")
 	b.SetDistribution("")
 
+	// update the PR event if action was never set
+	if b.GetEvent() == constants.EventPull && b.GetEventAction() == "" {
+		// technically, the action could have been opened or synchronize.
+		// will not affect behavior of the pipeline since we did not
+		// support actions for builds where this would be the case.
+		b.SetEventAction(constants.ActionOpened)
+	}
+
 	// set the parent equal to the restarted build number
 	b.SetParent(b.GetNumber())
 	// update the build numbers based off repo counter

--- a/api/build.go
+++ b/api/build.go
@@ -991,6 +991,7 @@ func RestartBuild(c *gin.Context) {
 	b.SetDistribution("")
 
 	// update the PR event action if action was never set
+	// for backwards compatibility with pre-0.14 releases
 	if b.GetEvent() == constants.EventPull && b.GetEventAction() == "" {
 		// technically, the action could have been opened or synchronize.
 		// will not affect behavior of the pipeline since we did not

--- a/api/build.go
+++ b/api/build.go
@@ -991,7 +991,7 @@ func RestartBuild(c *gin.Context) {
 	b.SetDistribution("")
 
 	// update the PR event action if action was never set
-	// for backwards compatibility with pre-0.14 releases
+	// for backwards compatibility with pre-0.14 releases.
 	if b.GetEvent() == constants.EventPull && b.GetEventAction() == "" {
 		// technically, the action could have been opened or synchronize.
 		// will not affect behavior of the pipeline since we did not

--- a/api/build.go
+++ b/api/build.go
@@ -990,7 +990,7 @@ func RestartBuild(c *gin.Context) {
 	b.SetRuntime("")
 	b.SetDistribution("")
 
-	// update the PR event if action was never set
+	// update the PR event action if action was never set
 	if b.GetEvent() == constants.EventPull && b.GetEventAction() == "" {
 		// technically, the action could have been opened or synchronize.
 		// will not affect behavior of the pipeline since we did not

--- a/router/pipeline.go
+++ b/router/pipeline.go
@@ -38,9 +38,9 @@ func PipelineHandlers(base *gin.RouterGroup) {
 			_pipeline.PUT("", perm.MustWrite(), pipeline.UpdatePipeline)
 			_pipeline.DELETE("", perm.MustPlatformAdmin(), pipeline.DeletePipeline)
 			_pipeline.GET("/templates", perm.MustRead(), pipeline.GetTemplates)
-			_pipeline.POST("/compile", perm.MustWrite(), pipeline.CompilePipeline)
-			_pipeline.POST("/expand", perm.MustWrite(), pipeline.ExpandPipeline)
-			_pipeline.POST("/validate", perm.MustWrite(), pipeline.ValidatePipeline)
+			_pipeline.POST("/compile", perm.MustRead(), pipeline.CompilePipeline)
+			_pipeline.POST("/expand", perm.MustRead(), pipeline.ExpandPipeline)
+			_pipeline.POST("/validate", perm.MustRead(), pipeline.ValidatePipeline)
 		} // end of pipeline endpoints
 	} // end of pipelines endpoints
 }


### PR DESCRIPTION
Any pull request build ran before 0.14 will not have the action field populated, thus upon restarting, it will not run properly against steps with a `event: pull_request` ruleset. 