### PR TITLE
fix(webhook): more general error message for redelivery failure

### DIFF
--- a/scm/github/webhook.go
+++ b/scm/github/webhook.go
@@ -502,7 +502,7 @@ func (c *client) getDeliveryID(ctx context.Context, ghClient *github.Client, r *
 	}
 
 	// if not found, webhook was not recent enough for GitHub
-	err = fmt.Errorf("webhook not one of the 100 most recent deliveries")
+	err = fmt.Errorf("webhook no longer available to be redelivered")
 
 	return 0, err
 }


### PR DESCRIPTION
Sometimes the webhook delivery will no longer be available due to how old it is, not whether it is in the 100 most recent. Upon failure, it's a better idea to give a general error to avoid confusing the user.