### PR TITLE
enhance(admin/api): remove collect all endpoints for DB resources

### DIFF
--- a/api/admin/build.go
+++ b/api/admin/build.go
@@ -20,45 +20,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// swagger:operation GET /api/v1/admin/builds admin AdminAllBuilds
-//
-// Get all of the builds in the database
-//
-// ---
-// produces:
-// - application/json
-// security:
-//   - ApiKeyAuth: []
-// responses:
-//   '200':
-//     description: Successfully retrieved all builds from the database
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/Build"
-//   '500':
-//     description: Unable to retrieve all builds from the database
-//     schema:
-//       "$ref": "#/definitions/Error"
-
-// AllBuilds represents the API handler to
-// captures all builds stored in the database.
-func AllBuilds(c *gin.Context) {
-	logrus.Info("Admin: reading all builds")
-
-	// send API call to capture all builds
-	b, err := database.FromContext(c).GetBuildList()
-	if err != nil {
-		retErr := fmt.Errorf("unable to capture all builds: %w", err)
-
-		util.HandleError(c, http.StatusInternalServerError, retErr)
-
-		return
-	}
-
-	c.JSON(http.StatusOK, b)
-}
-
 // swagger:operation GET /api/v1/admin/builds/queue admin AllBuildsQueue
 //
 // Get all of the running and pending builds in the database

--- a/api/admin/deployment.go
+++ b/api/admin/deployment.go
@@ -10,26 +10,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// swagger:operation GET /api/v1/admin/deployments admin AdminAllDeployments
-//
-// Get all of the deployments in the database (Not Implemented)
-//
-// ---
-// produces:
-// - application/json
-// parameters:
-// responses:
-//   '501':
-//     description: This endpoint is not implemented
-//     schema:
-//       type: string
-
-// AllDeployments represents the API handler to
-// captures all deployments stored in the database.
-func AllDeployments(c *gin.Context) {
-	c.JSON(http.StatusNotImplemented, "The server does not support the functionality required to fulfill the request.")
-}
-
 // swagger:operation PUT /api/v1/admin/deployment admin AdminUpdateDeployment
 //
 // Get All (Not Implemented)

--- a/api/admin/hook.go
+++ b/api/admin/hook.go
@@ -18,45 +18,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// swagger:operation GET /api/v1/admin/hooks admin AdminAllHooks
-//
-// Get all of the webhooks stored in the database
-//
-// ---
-// produces:
-// - application/json
-// security:
-//   - ApiKeyAuth: []
-// responses:
-//   '200':
-//     description: Successfully retrieved all hooks from the database
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/Webhook"
-//   '500':
-//     description: Unable to retrieve all hooks
-//     schema:
-//       "$ref": "#/definitions/Error"
-
-// AllHooks represents the API handler to
-// captures all hooks stored in the database.
-func AllHooks(c *gin.Context) {
-	logrus.Info("Admin: reading all hooks")
-
-	// send API call to capture all hooks
-	r, err := database.FromContext(c).GetHookList()
-	if err != nil {
-		retErr := fmt.Errorf("unable to capture all hooks: %w", err)
-
-		util.HandleError(c, http.StatusInternalServerError, retErr)
-
-		return
-	}
-
-	c.JSON(http.StatusOK, r)
-}
-
 // swagger:operation PUT /api/v1/admin/hook admin AdminUpdateHook
 //
 // Update a hook in the database

--- a/api/admin/repo.go
+++ b/api/admin/repo.go
@@ -18,45 +18,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// swagger:operation GET /api/v1/admin/repos admin AdminAllRepos
-//
-// Get all of the repos in the database
-//
-// ---
-// produces:
-// - application/json
-// security:
-//   - ApiKeyAuth: []
-// responses:
-//   '200':
-//     description: Successfully retrieved all repos from the database
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/Repo"
-//   '500':
-//     description: Unable to retrieve all repos from the database
-//     schema:
-//       "$ref": "#/definitions/Error"
-
-// AllRepos represents the API handler to
-// captures all repos stored in the database.
-func AllRepos(c *gin.Context) {
-	logrus.Info("Admin: reading all repos")
-
-	// send API call to capture all repos
-	r, err := database.FromContext(c).ListRepos()
-	if err != nil {
-		retErr := fmt.Errorf("unable to capture all repos: %w", err)
-
-		util.HandleError(c, http.StatusInternalServerError, retErr)
-
-		return
-	}
-
-	c.JSON(http.StatusOK, r)
-}
-
 // swagger:operation PUT /api/v1/admin/repo admin AdminUpdateRepo
 //
 // Update a repo in the database

--- a/api/admin/secret.go
+++ b/api/admin/secret.go
@@ -18,45 +18,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// swagger:operation GET /api/v1/admin/secrets admin AdminAllSecrets
-//
-// Get all of the secrets in the database
-//
-// ---
-// produces:
-// - application/json
-// security:
-//   - ApiKeyAuth: []
-// responses:
-//   '200':
-//     description: Successfully retrieved all secrets from the database
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/Secret"
-//   '500':
-//     description: Unable to retrieve all secrets from the database
-//     schema:
-//       "$ref": "#/definitions/Error"
-
-// AllSecrets represents the API handler to
-// captures all secrets stored in the database.
-func AllSecrets(c *gin.Context) {
-	logrus.Info("Admin: reading all secrets")
-
-	// send API call to capture all secrets
-	s, err := database.FromContext(c).GetSecretList()
-	if err != nil {
-		retErr := fmt.Errorf("unable to capture all secrets: %w", err)
-
-		util.HandleError(c, http.StatusInternalServerError, retErr)
-
-		return
-	}
-
-	c.JSON(http.StatusOK, s)
-}
-
 // swagger:operation PUT /api/v1/admin/secret admin AdminUpdateSecret
 //
 // Update a secret in the database

--- a/api/admin/service.go
+++ b/api/admin/service.go
@@ -18,45 +18,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// swagger:operation GET /api/v1/admin/services admin AdminAllServices
-//
-// Get all of the services in the database
-//
-// ---
-// produces:
-// - application/json
-// security:
-//   - ApiKeyAuth: []
-// responses:
-//   '200':
-//     description: Successfully retrieved all services from the database
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/Service"
-//   '500':
-//     description: Unable to retrieve all services from the database
-//     schema:
-//       "$ref": "#/definitions/Error"
-
-// AllServices represents the API handler to
-// captures all services stored in the database.
-func AllServices(c *gin.Context) {
-	logrus.Info("Admin: reading all services")
-
-	// send API call to capture all services
-	s, err := database.FromContext(c).GetServiceList()
-	if err != nil {
-		retErr := fmt.Errorf("unable to capture all services: %w", err)
-
-		util.HandleError(c, http.StatusInternalServerError, retErr)
-
-		return
-	}
-
-	c.JSON(http.StatusOK, s)
-}
-
 // swagger:operation PUT /api/v1/admin/service admin AdminUpdateService
 //
 // Update a hook in the database

--- a/api/admin/step.go
+++ b/api/admin/step.go
@@ -18,45 +18,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// swagger:operation GET /api/v1/admin/steps admin AdminAllSteps
-//
-// Get all of the steps in the database
-//
-// ---
-// produces:
-// - application/json
-// security:
-//   - ApiKeyAuth: []
-// responses:
-//   '200':
-//     description: Successfully retrieved all steps from the database
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/Step"
-//   '500':
-//     description: Unable to retrieve all steps from the database
-//     schema:
-//       "$ref": "#/definitions/Error"
-
-// AllSteps represents the API handler to
-// captures all steps stored in the database.
-func AllSteps(c *gin.Context) {
-	logrus.Info("Admin: reading all steps")
-
-	// send API call to capture all steps
-	s, err := database.FromContext(c).GetStepList()
-	if err != nil {
-		retErr := fmt.Errorf("unable to capture all steps: %w", err)
-
-		util.HandleError(c, http.StatusInternalServerError, retErr)
-
-		return
-	}
-
-	c.JSON(http.StatusOK, s)
-}
-
 // swagger:operation PUT /api/v1/admin/step admin AdminUpdateStep
 //
 // Update a step in the database

--- a/api/admin/user.go
+++ b/api/admin/user.go
@@ -18,45 +18,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// swagger:operation GET /api/v1/admin/users admin AdminAllUsers
-//
-// Get all of the users in the database
-//
-// ---
-// produces:
-// - application/json
-// security:
-//   - ApiKeyAuth: []
-// responses:
-//   '200':
-//     description: Successfully retrieved all users from the database
-//     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/User"
-//   '500':
-//     description: Unable to retrieve all users from the database
-//     schema:
-//       type: string
-
-// AllUsers represents the API handler to
-// captures all users stored in the database.
-func AllUsers(c *gin.Context) {
-	logrus.Info("Admin: reading all users")
-
-	// send API call to capture all users
-	u, err := database.FromContext(c).ListUsers()
-	if err != nil {
-		retErr := fmt.Errorf("unable to capture all users: %w", err)
-
-		util.HandleError(c, http.StatusInternalServerError, retErr)
-
-		return
-	}
-
-	c.JSON(http.StatusOK, u)
-}
-
 // swagger:operation PUT /api/v1/admin/user admin AdminUpdateUser
 //
 // Update a user in the database

--- a/router/admin.go
+++ b/router/admin.go
@@ -35,36 +35,28 @@ func AdminHandlers(base *gin.RouterGroup) {
 	_admin := base.Group("/admin", perm.MustPlatformAdmin())
 	{
 		// Admin build endpoints
-		_admin.GET("/builds", admin.AllBuilds)
 		_admin.GET("/builds/queue", admin.AllBuildsQueue)
 		_admin.PUT("/build", admin.UpdateBuild)
 
 		// Admin deployment endpoints
-		_admin.GET("/deployments", admin.AllDeployments)
 		_admin.PUT("/deployment", admin.UpdateDeployment)
 
 		// Admin hook endpoints
-		_admin.GET("/hooks", admin.AllHooks)
 		_admin.PUT("/hook", admin.UpdateHook)
 
 		// Admin repo endpoints
-		_admin.GET("/repos", admin.AllRepos)
 		_admin.PUT("/repo", admin.UpdateRepo)
 
 		// Admin secret endpoints
-		_admin.GET("/secrets", admin.AllSecrets)
 		_admin.PUT("/secret", admin.UpdateSecret)
 
 		// Admin service endpoints
-		_admin.GET("/services", admin.AllServices)
 		_admin.PUT("/service", admin.UpdateService)
 
 		// Admin step endpoints
-		_admin.GET("/steps", admin.AllSteps)
 		_admin.PUT("/step", admin.UpdateStep)
 
 		// Admin user endpoints
-		_admin.GET("/users", admin.AllUsers)
 		_admin.PUT("/user", admin.UpdateUser)
 	} // end of admin endpoints
 }


### PR DESCRIPTION
Closes https://github.com/go-vela/community/issues/713

Platform admins will no longer be able to pull all sensitive resources (such as secrets, repos, and users) as well as resources which have typically very large tables in the DB (builds, steps, services). 