### PR TITLE
chore(queue): update go-redis to v9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/drone/envsubst v1.0.3
 	github.com/gin-gonic/gin v1.9.0
 	github.com/go-playground/assert/v2 v2.2.0
-	github.com/go-redis/redis/v9 v9.0.2
 	github.com/go-vela/types v0.17.1-0.20230223155025-1c8a34f71425
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/go-cmp v0.5.9
@@ -27,6 +26,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
+	github.com/redis/go-redis/v9 v9.0.2
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/afero v1.9.4
 	github.com/urfave/cli/v2 v2.24.4
@@ -49,7 +49,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/sonic v1.8.0 // indirect
 	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
-	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/drone/envsubst v1.0.3
 	github.com/gin-gonic/gin v1.9.0
 	github.com/go-playground/assert/v2 v2.2.0
-	github.com/go-redis/redis/v8 v8.11.5
+	github.com/go-redis/redis/v9 v9.0.2
 	github.com/go-vela/types v0.17.1-0.20230223155025-1c8a34f71425
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bsm/ginkgo/v2 v2.5.0 h1:aOAnND1T40wEdAtkGSkvSICWeQ8L3UASX7YVCqQx+eQ=
+github.com/bsm/gomega v1.20.0 h1:JhAwLmtRzXFTx2AkALSLa8ijZafntmhSoU63Ok18Uq8=
 github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3 h1:q+sMKdA6L8LyGVudTkpGoC73h6ak2iWSPFiFo/pFOU8=
 github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3/go.mod h1:5hCug3EZaHXU3FdCA3gJm0YTNi+V+ooA2qNTiVpky4A=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
@@ -84,8 +86,9 @@ github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 h1:qSGYFH7+jGhDF8vLC+iwCD4WpbV1EBDSzWkJODFLams=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=
@@ -115,7 +118,6 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
@@ -144,8 +146,6 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.11.2 h1:q3SHpufmypg+erIExEKUmsgmhDTyhcJ38oeKGACXohU=
 github.com/go-playground/validator/v10 v10.11.2/go.mod h1:NieE624vt4SCTJtD87arVLvdmjPAeV8BQlHtMnw9D7s=
-github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
-github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
 github.com/go-vela/types v0.17.1-0.20230223155025-1c8a34f71425 h1:tdjas7NJLWlU2vmETaU36wjbd+zvWPLtznE4uwtnFlw=
@@ -352,9 +352,6 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
-github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
-github.com/onsi/gomega v1.23.0 h1:/oxKu9c2HVap+F3PfKort2Hw5DEU+HGlW8n+tguWsys=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -391,6 +388,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
+github.com/redis/go-redis/v9 v9.0.2 h1:BA426Zqe/7r56kCcvxYLWe1mkaz71LKF77GwgFzSxfE=
+github.com/redis/go-redis/v9 v9.0.2/go.mod h1:/xDTe9EF1LM61hek62Poq2nzQSGj0xSrEtEHbBQevps=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
@@ -798,7 +797,6 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
 gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 h1:yiW+nvdHb9LVqSHQBXfZCieqV4fzYhNBql77zY0ykqs=
 gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637/go.mod h1:BHsqpu/nsuzkT5BpiH1EMZPLyqSMM8JbIavyFACoFNk=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/queue/redis/pop.go
+++ b/queue/redis/pop.go
@@ -9,8 +9,8 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/go-redis/redis/v8"
 	"github.com/go-vela/types"
+	"github.com/redis/go-redis/v9"
 )
 
 // Pop grabs an item from the specified channel off the queue.

--- a/queue/redis/pop_test.go
+++ b/queue/redis/pop_test.go
@@ -58,6 +58,12 @@ func TestRedis_Pop(t *testing.T) {
 	// overwrite channel to be invalid
 	badChannel.config.Channels = nil
 
+	// push something to badChannel queue
+	err = badChannel.Redis.RPush(context.Background(), "vela", bytes).Err()
+	if err != nil {
+		t.Errorf("unable to push item to queue: %v", err)
+	}
+
 	// setup tests
 	tests := []struct {
 		failure bool

--- a/queue/redis/pop_test.go
+++ b/queue/redis/pop_test.go
@@ -59,22 +59,22 @@ func TestRedis_Pop(t *testing.T) {
 	badChannel.config.Channels = nil
 
 	// push nothing to queue
-	err = badChannel.Redis.RPush(context.Background(), "vela", nil).Err()
-	if err != nil {
-		t.Errorf("unable to push item to queue: %v", err)
-	}
+	// err = badChannel.Redis.RPush(context.Background(), "vela", nil).Err()
+	// if err != nil {
+	// 	t.Errorf("unable to push item to queue: %v", err)
+	// }
 
 	// setup badItem redis mock
-	badItem, err := NewTest("vela")
-	if err != nil {
-		t.Errorf("unable to create queue service: %v", err)
-	}
+	// badItem, err := NewTest("vela")
+	// if err != nil {
+	// 	t.Errorf("unable to create queue service: %v", err)
+	// }
 
 	// push nothing to queue
-	err = badItem.Redis.RPush(context.Background(), "vela", nil).Err()
-	if err != nil {
-		t.Errorf("unable to push item to queue: %v", err)
-	}
+	// err = badItem.Redis.RPush(context.Background(), "vela", nil).Err()
+	// if err != nil {
+	// 	t.Errorf("unable to push item to queue: %v", err)
+	// }
 
 	// setup tests
 	tests := []struct {
@@ -97,11 +97,11 @@ func TestRedis_Pop(t *testing.T) {
 			redis:   badChannel,
 			want:    nil,
 		},
-		{
-			failure: true,
-			redis:   badItem,
-			want:    nil,
-		},
+		// {
+		// 	failure: true,
+		// 	redis:   badItem,
+		// 	want:    nil,
+		// },
 	}
 
 	// run tests

--- a/queue/redis/pop_test.go
+++ b/queue/redis/pop_test.go
@@ -58,24 +58,6 @@ func TestRedis_Pop(t *testing.T) {
 	// overwrite channel to be invalid
 	badChannel.config.Channels = nil
 
-	// push nothing to queue
-	// err = badChannel.Redis.RPush(context.Background(), "vela", nil).Err()
-	// if err != nil {
-	// 	t.Errorf("unable to push item to queue: %v", err)
-	// }
-
-	// setup badItem redis mock
-	// badItem, err := NewTest("vela")
-	// if err != nil {
-	// 	t.Errorf("unable to create queue service: %v", err)
-	// }
-
-	// push nothing to queue
-	// err = badItem.Redis.RPush(context.Background(), "vela", nil).Err()
-	// if err != nil {
-	// 	t.Errorf("unable to push item to queue: %v", err)
-	// }
-
 	// setup tests
 	tests := []struct {
 		failure bool
@@ -97,11 +79,6 @@ func TestRedis_Pop(t *testing.T) {
 			redis:   badChannel,
 			want:    nil,
 		},
-		// {
-		// 	failure: true,
-		// 	redis:   badItem,
-		// 	want:    nil,
-		// },
 	}
 
 	// run tests

--- a/queue/redis/push.go
+++ b/queue/redis/push.go
@@ -13,6 +13,10 @@ import (
 func (c *client) Push(ctx context.Context, channel string, item []byte) error {
 	c.Logger.Tracef("pushing item to queue %s", channel)
 
+	// ensure the item to be pushed is valid
+	// go-redis RPush does not support nil as of v9.0.2
+	//
+	// https://github.com/redis/go-redis/pull/1960
 	if item == nil {
 		return errors.New("item is nil")
 	}

--- a/queue/redis/push.go
+++ b/queue/redis/push.go
@@ -6,11 +6,16 @@ package redis
 
 import (
 	"context"
+	"errors"
 )
 
 // Push inserts an item to the specified channel in the queue.
 func (c *client) Push(ctx context.Context, channel string, item []byte) error {
 	c.Logger.Tracef("pushing item to queue %s", channel)
+
+	if item == nil {
+		return errors.New("item is nil")
+	}
 
 	// build a redis queue command to push an item to queue
 	//

--- a/queue/redis/push_test.go
+++ b/queue/redis/push_test.go
@@ -23,7 +23,7 @@ func TestRedis_Push(t *testing.T) {
 	}
 
 	// setup queue item
-	bytes, err := json.Marshal(_item)
+	_bytes, err := json.Marshal(_item)
 	if err != nil {
 		t.Errorf("unable to marshal queue item: %v", err)
 	}
@@ -34,20 +34,33 @@ func TestRedis_Push(t *testing.T) {
 		t.Errorf("unable to create queue service: %v", err)
 	}
 
+	// setup redis mock
+	badItem, err := NewTest("vela")
+	if err != nil {
+		t.Errorf("unable to create queue service: %v", err)
+	}
+
 	// setup tests
 	tests := []struct {
 		failure bool
 		redis   *client
+		bytes   []byte
 	}{
 		{
 			failure: false,
 			redis:   _redis,
+			bytes:   _bytes,
+		},
+		{
+			failure: true,
+			redis:   badItem,
+			bytes:   nil,
 		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		err := _redis.Push(context.Background(), "vela", bytes)
+		err := test.redis.Push(context.Background(), "vela", test.bytes)
 
 		if test.failure {
 			if err == nil {

--- a/queue/redis/redis.go
+++ b/queue/redis/redis.go
@@ -108,6 +108,7 @@ func failoverFromOptions(source *redis.Options) *redis.FailoverOptions {
 		WriteTimeout:    source.WriteTimeout,
 		PoolSize:        source.PoolSize,
 		MinIdleConns:    source.MinIdleConns,
+		MaxIdleConns:    source.MaxIdleConns,
 		ConnMaxLifetime: source.ConnMaxLifetime,
 		PoolTimeout:     source.PoolTimeout,
 		ConnMaxIdleTime: source.ConnMaxIdleTime,

--- a/queue/redis/redis.go
+++ b/queue/redis/redis.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/go-redis/redis/v8"
+	"github.com/redis/go-redis/v9"
 	"github.com/sirupsen/logrus"
 )
 
@@ -97,22 +97,21 @@ func New(opts ...ClientOpt) (*client, error) {
 // the failover options from the parse options.
 func failoverFromOptions(source *redis.Options) *redis.FailoverOptions {
 	target := &redis.FailoverOptions{
-		OnConnect:          source.OnConnect,
-		Password:           source.Password,
-		DB:                 source.DB,
-		MaxRetries:         source.MaxRetries,
-		MinRetryBackoff:    source.MinRetryBackoff,
-		MaxRetryBackoff:    source.MaxRetryBackoff,
-		DialTimeout:        source.DialTimeout,
-		ReadTimeout:        source.ReadTimeout,
-		WriteTimeout:       source.WriteTimeout,
-		PoolSize:           source.PoolSize,
-		MinIdleConns:       source.MinIdleConns,
-		MaxConnAge:         source.MaxConnAge,
-		PoolTimeout:        source.PoolTimeout,
-		IdleTimeout:        source.IdleTimeout,
-		IdleCheckFrequency: source.IdleCheckFrequency,
-		TLSConfig:          source.TLSConfig,
+		OnConnect:       source.OnConnect,
+		Password:        source.Password,
+		DB:              source.DB,
+		MaxRetries:      source.MaxRetries,
+		MinRetryBackoff: source.MinRetryBackoff,
+		MaxRetryBackoff: source.MaxRetryBackoff,
+		DialTimeout:     source.DialTimeout,
+		ReadTimeout:     source.ReadTimeout,
+		WriteTimeout:    source.WriteTimeout,
+		PoolSize:        source.PoolSize,
+		MinIdleConns:    source.MinIdleConns,
+		ConnMaxLifetime: source.ConnMaxLifetime,
+		PoolTimeout:     source.PoolTimeout,
+		ConnMaxIdleTime: source.ConnMaxIdleTime,
+		TLSConfig:       source.TLSConfig,
 	}
 
 	// trim auto appended :6379 from address


### PR DESCRIPTION
**NOTE** this PR updates redis to v9 which requires the following changes: 
- `MaxConnAge` changed to `ConnMaxLifetime`
- `IdleTimeout` changed to `ConnMaxIdleTime ` 
- `IdleCheckFrequency` was replaced in favor of `MaxIdleConns`
- `RPush` no longer supports adding `nil` items, so a check has been added to the `Push` wrapper. tests have been updated to reflect the change. see: https://github.com/redis/go-redis/pull/1960 and https://github.com/redis/go-redis/releases/tag/v9.0.2


see the [CHANGELOG](https://github.com/redis/go-redis/blob/master/CHANGELOG.md) for more information