### PR TITLE
fix(perm): allow workers with build tokens to access MustRead() for private visibility repos

### DIFF
--- a/router/middleware/perm/perm.go
+++ b/router/middleware/perm/perm.go
@@ -444,6 +444,12 @@ func MustRead() gin.HandlerFunc {
 			if cl.BuildID == b.GetID() {
 				return
 			}
+
+			retErr := fmt.Errorf("user %s does not have 'read' permissions for repo %s", u.GetName(), r.GetFullName())
+
+			util.HandleError(c, http.StatusUnauthorized, retErr)
+
+			return
 		}
 
 		logger.Debugf("verifying user %s has 'read' permissions for repo %s", u.GetName(), r.GetFullName())

--- a/router/middleware/perm/perm.go
+++ b/router/middleware/perm/perm.go
@@ -417,6 +417,7 @@ func MustWrite() gin.HandlerFunc {
 // MustRead ensures the user has admin, write or read access to the repo.
 func MustRead() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		cl := claims.Retrieve(c)
 		o := org.Retrieve(c)
 		r := repo.Retrieve(c)
 		u := user.Retrieve(c)
@@ -437,8 +438,17 @@ func MustRead() gin.HandlerFunc {
 			return
 		}
 
+		// return if request is from worker with build token access
+		if strings.EqualFold(cl.TokenType, constants.WorkerBuildTokenType) {
+			b := build.Retrieve(c)
+			if cl.BuildID == b.GetID() {
+				return
+			}
+		}
+
 		logger.Debugf("verifying user %s has 'read' permissions for repo %s", u.GetName(), r.GetFullName())
 
+		// return if user is platform admin
 		if u.GetAdmin() {
 			return
 		}

--- a/router/middleware/perm/perm.go
+++ b/router/middleware/perm/perm.go
@@ -445,7 +445,7 @@ func MustRead() gin.HandlerFunc {
 				return
 			}
 
-			retErr := fmt.Errorf("user %s does not have 'read' permissions for repo %s", u.GetName(), r.GetFullName())
+			retErr := fmt.Errorf("subject %s does not have 'read' permissions for repo %s", cl.Subject, r.GetFullName())
 
 			util.HandleError(c, http.StatusUnauthorized, retErr)
 


### PR DESCRIPTION
Initial [build token implementation](https://github.com/go-vela/server/pull/765) failed to address repos with a private visibility status. Since the worker is not treated as a platform admin, it will fail the SCM check to verify read permissions. 

This fix adds logic to allow workers to access `MustRead` endpoints from private repos so long as the build token is still accurate.  I also added a related test.

I double checked the worker's flow and determined that it does not call endpoints behind `MustWrite` or `MustAdmin`, so I've decided to leave the build token logic out of those functions.