### PR TITLE
fix(database): revert column size bump to users token values

### DIFF
--- a/database/user/table.go
+++ b/database/user/table.go
@@ -16,8 +16,8 @@ IF NOT EXISTS
 users (
 	id             SERIAL PRIMARY KEY,
 	name           VARCHAR(250),
-	refresh_token  VARCHAR(1000),
-	token          VARCHAR(1000),
+	refresh_token  VARCHAR(500),
+	token          VARCHAR(500),
 	hash           VARCHAR(500),
 	favorites      VARCHAR(5000),
 	active         BOOLEAN,


### PR DESCRIPTION
It was determined that the bump in column size for the `token` value was not actually necessary. Better to be space-conscious with table sizes.