### PR TITLE
feat(templates): add ability to call templates within a template

### DIFF
--- a/cmd/vela-server/main.go
+++ b/cmd/vela-server/main.go
@@ -185,6 +185,12 @@ func main() {
 			Usage:   "modification retries, used by compiler, number of http requires that the modification http request will fail after",
 			Value:   5,
 		},
+		&cli.IntFlag{
+			EnvVars: []string{"VELA_MAX_TEMPLATE_DEPTH", "MAX_TEMPLATE_DEPTH"},
+			Name:    "max-template-depth",
+			Usage:   "max template depth, used by compiler, maximum number of templates that can be called in a template chain. Prevents circular depenendcies",
+			Value:   5,
+		},
 		&cli.DurationFlag{
 			EnvVars: []string{"VELA_WORKER_ACTIVE_INTERVAL", "WORKER_ACTIVE_INTERVAL"},
 			Name:    "worker-active-interval",

--- a/compiler/engine.go
+++ b/compiler/engine.go
@@ -74,7 +74,7 @@ type Engine interface {
 	ExpandStages(*yaml.Build, map[string]*yaml.Template) (*yaml.Build, error)
 	// ExpandSteps defines a function that injects the template
 	// for each templated step in a yaml configuration.
-	ExpandSteps(*yaml.Build, map[string]*yaml.Template) (*yaml.Build, error)
+	ExpandSteps(*yaml.Build, map[string]*yaml.Template, int) (*yaml.Build, error)
 
 	// Init Compiler Interface Functions
 

--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -82,7 +82,7 @@ func (c *client) Compile(v interface{}) (*pipeline.Build, *library.Pipeline, err
 
 	switch {
 	case p.Metadata.RenderInline:
-		newPipeline, err := c.compileInline(p, nil, c.TemplateDepth)
+		newPipeline, err := c.compileInline(p, nil)
 		if err != nil {
 			return nil, _pipeline, err
 		}
@@ -117,7 +117,7 @@ func (c *client) CompileLite(v interface{}, template, substitute bool, localTemp
 	_pipeline.SetType(c.repo.GetPipelineType())
 
 	if p.Metadata.RenderInline {
-		newPipeline, err := c.compileInline(p, localTemplates, c.TemplateDepth)
+		newPipeline, err := c.compileInline(p, localTemplates)
 		if err != nil {
 			return nil, _pipeline, err
 		}
@@ -194,11 +194,7 @@ func (c *client) CompileLite(v interface{}, template, substitute bool, localTemp
 }
 
 // compileInline parses and expands out inline pipelines.
-func (c *client) compileInline(p *yaml.Build, localTemplates []string, depth int) (*yaml.Build, error) {
-	if depth == 0 {
-		return nil, fmt.Errorf("reached maximum template depth of %d", c.TemplateDepth)
-	}
-
+func (c *client) compileInline(p *yaml.Build, localTemplates []string) (*yaml.Build, error) {
 	newPipeline := *p
 
 	for _, template := range p.Templates {
@@ -276,13 +272,6 @@ func (c *client) compileInline(p *yaml.Build, localTemplates []string, depth int
 		if len(newPipeline.Stages) > 0 && len(newPipeline.Steps) > 0 {
 			//nolint:lll // ignore long line length due to error message
 			return nil, fmt.Errorf("invalid template %s provided: templates cannot mix stages and steps", template.Name)
-		}
-
-		if len(parsed.Templates) > 0 {
-			parsed, err = c.compileInline(parsed, nil, depth-1)
-			if err != nil {
-				return nil, err
-			}
 		}
 	}
 

--- a/compiler/native/compile_test.go
+++ b/compiler/native/compile_test.go
@@ -38,6 +38,7 @@ func TestNative_Compile_StagesPipeline(t *testing.T) {
 	// setup types
 	set := flag.NewFlagSet("test", 0)
 	set.String("clone-image", defaultCloneImage, "doc")
+	set.Int("max-template-depth", 5, "doc")
 	c := cli.NewContext(nil, set, nil)
 
 	m := &types.Metadata{
@@ -417,6 +418,7 @@ func TestNative_Compile_StepsPipeline(t *testing.T) {
 	// setup types
 	set := flag.NewFlagSet("test", 0)
 	set.String("clone-image", defaultCloneImage, "doc")
+	set.Int("max-template-depth", 5, "doc")
 	c := cli.NewContext(nil, set, nil)
 
 	m := &types.Metadata{
@@ -619,6 +621,7 @@ func TestNative_Compile_StagesPipelineTemplate(t *testing.T) {
 	set.String("github-url", s.URL, "doc")
 	set.String("github-token", "", "doc")
 	set.String("clone-image", defaultCloneImage, "doc")
+	set.Int("max-template-depth", 5, "doc")
 	c := cli.NewContext(nil, set, nil)
 
 	m := &types.Metadata{
@@ -883,6 +886,7 @@ func TestNative_Compile_StepsPipelineTemplate(t *testing.T) {
 	set.String("github-url", s.URL, "doc")
 	set.String("github-token", "", "doc")
 	set.String("clone-image", defaultCloneImage, "doc")
+	set.Int("max-template-depth", 5, "doc")
 	c := cli.NewContext(nil, set, nil)
 
 	m := &types.Metadata{
@@ -1112,6 +1116,7 @@ func TestNative_Compile_StepsPipelineTemplate_VelaFunction_TemplateName(t *testi
 	set.String("github-url", s.URL, "doc")
 	set.String("github-token", "", "doc")
 	set.String("clone-image", defaultCloneImage, "doc")
+	set.Int("max-template-depth", 5, "doc")
 	c := cli.NewContext(nil, set, nil)
 
 	m := &types.Metadata{
@@ -1231,6 +1236,7 @@ func TestNative_Compile_StepsPipelineTemplate_VelaFunction_TemplateName_Inline(t
 	set.String("github-url", s.URL, "doc")
 	set.String("github-token", "", "doc")
 	set.String("clone-image", defaultCloneImage, "doc")
+	set.Int("max-template-depth", 5, "doc")
 	c := cli.NewContext(nil, set, nil)
 
 	m := &types.Metadata{
@@ -1346,6 +1352,7 @@ func TestNative_Compile_InvalidType(t *testing.T) {
 	set.Bool("github-driver", true, "doc")
 	set.String("github-url", s.URL, "doc")
 	set.String("github-token", "", "doc")
+	set.Int("max-template-depth", 5, "doc")
 	c := cli.NewContext(nil, set, nil)
 
 	m := &types.Metadata{
@@ -1402,6 +1409,7 @@ func TestNative_Compile_Clone(t *testing.T) {
 	set.Bool("github-driver", true, "doc")
 	set.String("github-token", "", "doc")
 	set.String("clone-image", defaultCloneImage, "doc")
+	set.Int("max-template-depth", 5, "doc")
 	c := cli.NewContext(nil, set, nil)
 
 	m := &types.Metadata{
@@ -1592,6 +1600,7 @@ func TestNative_Compile_Pipeline_Type(t *testing.T) {
 	set.Bool("github-driver", true, "doc")
 	set.String("github-token", "", "doc")
 	set.String("clone-image", defaultCloneImage, "doc")
+	set.Int("max-template-depth", 5, "doc")
 	c := cli.NewContext(nil, set, nil)
 
 	m := &types.Metadata{
@@ -2161,6 +2170,7 @@ func Test_Compile_Inline(t *testing.T) {
 	set.String("github-url", s.URL, "doc")
 	set.String("github-token", "", "doc")
 	set.String("clone-image", defaultCloneImage, "doc")
+	set.Int("max-template-depth", 5, "doc")
 	c := cli.NewContext(nil, set, nil)
 
 	m := &types.Metadata{
@@ -2944,6 +2954,7 @@ func Test_CompileLite(t *testing.T) {
 	set.Bool("github-driver", true, "doc")
 	set.String("github-url", s.URL, "doc")
 	set.String("github-token", "", "doc")
+	set.Int("max-template-depth", 5, "doc")
 	c := cli.NewContext(nil, set, nil)
 
 	m := &types.Metadata{
@@ -2993,7 +3004,22 @@ func Test_CompileLite(t *testing.T) {
 					RenderInline: true,
 					Environment:  []string{"steps", "services", "secrets"},
 				},
-				Templates: []*yaml.Template{},
+				Environment: raw.StringSliceMap{},
+				Templates: []*yaml.Template{
+					{
+						Name:      "golang",
+						Source:    "github.example.com/github/octocat/golang_inline_stages.yml",
+						Format:    "golang",
+						Type:      "github",
+						Variables: map[string]any{"image": string("golang:latest")},
+					},
+					{
+						Name:   "starlark",
+						Source: "github.example.com/github/octocat/starlark_inline_stages.star",
+						Format: "starlark",
+						Type:   "github",
+					},
+				},
 				Stages: []*yaml.Stage{
 					{
 						Name:  "test",
@@ -3085,6 +3111,7 @@ func Test_CompileLite(t *testing.T) {
 					RenderInline: true,
 					Environment:  []string{"steps", "services", "secrets"},
 				},
+				Environment: raw.StringSliceMap{},
 				Steps: yaml.StepSlice{
 					{
 						Commands: raw.StringSlice{"echo from inline"},
@@ -3123,7 +3150,20 @@ func Test_CompileLite(t *testing.T) {
 						Pull:     "not_present",
 					},
 				},
-				Templates: yaml.TemplateSlice{},
+				Templates: yaml.TemplateSlice{
+					{
+						Name:   "golang",
+						Source: "github.example.com/github/octocat/golang_inline_steps.yml",
+						Format: "golang",
+						Type:   "github",
+					},
+					{
+						Name:   "starlark",
+						Source: "github.example.com/github/octocat/starlark_inline_steps.star",
+						Format: "starlark",
+						Type:   "github",
+					},
+				},
 			},
 			wantErr: false,
 		},

--- a/compiler/native/expand_test.go
+++ b/compiler/native/expand_test.go
@@ -42,6 +42,7 @@ func TestNative_ExpandStages(t *testing.T) {
 	set.Bool("github-driver", true, "doc")
 	set.String("github-url", s.URL, "doc")
 	set.String("github-token", "", "doc")
+	set.Int("max-template-depth", 5, "doc")
 	c := cli.NewContext(nil, set, nil)
 
 	tmpls := map[string]*yaml.Template{
@@ -189,6 +190,7 @@ func TestNative_ExpandSteps(t *testing.T) {
 	set.Bool("github-driver", true, "doc")
 	set.String("github-url", s.URL, "doc")
 	set.String("github-token", "", "doc")
+	set.Int("max-template-depth", 5, "doc")
 	c := cli.NewContext(nil, set, nil)
 
 	testBuild := new(library.Build)
@@ -321,7 +323,7 @@ func TestNative_ExpandSteps(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			build, err := compiler.ExpandSteps(&yaml.Build{Steps: steps, Services: yaml.ServiceSlice{}, Environment: globalEnvironment}, test.tmpls)
+			build, err := compiler.ExpandSteps(&yaml.Build{Steps: steps, Services: yaml.ServiceSlice{}, Environment: globalEnvironment}, test.tmpls, compiler.TemplateDepth)
 			if err != nil {
 				t.Errorf("ExpandSteps_Type%s returned err: %v", test.name, err)
 			}
@@ -372,6 +374,7 @@ func TestNative_ExpandStepsMulti(t *testing.T) {
 	set.Bool("github-driver", true, "doc")
 	set.String("github-url", s.URL, "doc")
 	set.String("github-token", "", "doc")
+	set.Int("max-template-depth", 5, "doc")
 	c := cli.NewContext(nil, set, nil)
 
 	tmpls := map[string]*yaml.Template{
@@ -557,7 +560,7 @@ func TestNative_ExpandStepsMulti(t *testing.T) {
 		t.Errorf("Creating new compiler returned err: %v", err)
 	}
 
-	build, err := compiler.ExpandSteps(&yaml.Build{Steps: steps, Services: yaml.ServiceSlice{}, Environment: raw.StringSliceMap{}}, tmpls)
+	build, err := compiler.ExpandSteps(&yaml.Build{Steps: steps, Services: yaml.ServiceSlice{}, Environment: raw.StringSliceMap{}}, tmpls, compiler.TemplateDepth)
 	if err != nil {
 		t.Errorf("ExpandSteps returned err: %v", err)
 	}
@@ -601,6 +604,7 @@ func TestNative_ExpandStepsStarlark(t *testing.T) {
 	set.Bool("github-driver", true, "doc")
 	set.String("github-url", s.URL, "doc")
 	set.String("github-token", "", "doc")
+	set.Int("max-template-depth", 5, "doc")
 	c := cli.NewContext(nil, set, nil)
 
 	tmpls := map[string]*yaml.Template{
@@ -644,7 +648,7 @@ func TestNative_ExpandStepsStarlark(t *testing.T) {
 		t.Errorf("Creating new compiler returned err: %v", err)
 	}
 
-	build, err := compiler.ExpandSteps(&yaml.Build{Steps: steps, Secrets: yaml.SecretSlice{}, Services: yaml.ServiceSlice{}, Environment: raw.StringSliceMap{}}, tmpls)
+	build, err := compiler.ExpandSteps(&yaml.Build{Steps: steps, Secrets: yaml.SecretSlice{}, Services: yaml.ServiceSlice{}, Environment: raw.StringSliceMap{}}, tmpls, compiler.TemplateDepth)
 	if err != nil {
 		t.Errorf("ExpandSteps returned err: %v", err)
 	}
@@ -663,6 +667,259 @@ func TestNative_ExpandStepsStarlark(t *testing.T) {
 
 	if diff := cmp.Diff(build.Environment, wantEnvironment); diff != "" {
 		t.Errorf("ExpandSteps() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestNative_ExpandSteps_TemplateCallTemplate(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	resp := httptest.NewRecorder()
+	_, engine := gin.CreateTestContext(resp)
+
+	// setup mock server
+	engine.GET("/api/v3/repos/foo/bar/contents/:path", func(c *gin.Context) {
+		c.Header("Content-Type", "application/json")
+		c.Status(http.StatusOK)
+		c.File("testdata/template.json")
+	})
+
+	engine.GET("/api/v3/repos/faz/baz/contents/:path", func(c *gin.Context) {
+		c.Header("Content-Type", "application/json")
+		c.Status(http.StatusOK)
+		c.File("testdata/template-calls-template.json")
+	})
+
+	s := httptest.NewServer(engine)
+	defer s.Close()
+
+	// setup types
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("github-driver", true, "doc")
+	set.String("github-url", s.URL, "doc")
+	set.String("github-token", "", "doc")
+	set.Int("max-template-depth", 5, "doc")
+	c := cli.NewContext(nil, set, nil)
+
+	testBuild := new(library.Build)
+
+	testBuild.SetID(1)
+	testBuild.SetCommit("123abc456def")
+
+	testRepo := new(library.Repo)
+
+	testRepo.SetID(1)
+	testRepo.SetOrg("foo")
+	testRepo.SetName("bar")
+
+	tests := []struct {
+		name  string
+		tmpls map[string]*yaml.Template
+	}{
+		{
+			name: "Test 1",
+			tmpls: map[string]*yaml.Template{
+				"chain": {
+					Name:   "chain",
+					Source: "github.example.com/faz/baz/template.yml",
+					Type:   "github",
+				},
+			},
+		},
+	}
+
+	steps := yaml.StepSlice{
+		&yaml.Step{
+			Name: "sample",
+			Template: yaml.StepTemplate{
+				Name: "chain",
+			},
+		},
+	}
+
+	globalEnvironment := raw.StringSliceMap{
+		"foo": "test1",
+		"bar": "test2",
+	}
+
+	wantSteps := yaml.StepSlice{
+		&yaml.Step{
+			Commands: []string{"./gradlew downloadDependencies"},
+			Environment: raw.StringSliceMap{
+				"GRADLE_OPTS":      "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false",
+				"GRADLE_USER_HOME": ".gradle",
+			},
+			Image: "openjdk:latest",
+			Name:  "sample_call template_install",
+			Pull:  "always",
+		},
+		&yaml.Step{
+			Commands: []string{"./gradlew check"},
+			Environment: raw.StringSliceMap{
+				"GRADLE_OPTS":      "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false",
+				"GRADLE_USER_HOME": ".gradle",
+			},
+			Image: "openjdk:latest",
+			Name:  "sample_call template_test",
+			Pull:  "always",
+		},
+		&yaml.Step{
+			Commands: []string{"./gradlew build"},
+			Environment: raw.StringSliceMap{
+				"GRADLE_OPTS":      "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false",
+				"GRADLE_USER_HOME": ".gradle",
+			},
+			Image: "openjdk:latest",
+			Name:  "sample_call template_build",
+			Pull:  "always",
+		},
+	}
+
+	wantSecrets := yaml.SecretSlice{
+		&yaml.Secret{
+			Name:   "docker_username",
+			Key:    "org/repo/foo/bar",
+			Engine: "native",
+			Type:   "repo",
+			Origin: yaml.Origin{},
+		},
+		&yaml.Secret{
+			Name:   "foo_password",
+			Key:    "org/repo/foo/password",
+			Engine: "vault",
+			Type:   "repo",
+			Origin: yaml.Origin{},
+		},
+	}
+
+	wantServices := yaml.ServiceSlice{
+		&yaml.Service{
+			Image: "postgres:12",
+			Name:  "postgres",
+			Pull:  "not_present",
+		},
+	}
+
+	wantEnvironment := raw.StringSliceMap{
+		"foo":  "test1",
+		"bar":  "test2",
+		"star": "test3",
+	}
+
+	// run test
+	compiler, err := New(c)
+	if err != nil {
+		t.Errorf("Creating new compiler returned err: %v", err)
+	}
+
+	compiler.WithBuild(testBuild).WithRepo(testRepo)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			build, err := compiler.ExpandSteps(&yaml.Build{Steps: steps, Services: yaml.ServiceSlice{}, Environment: globalEnvironment}, test.tmpls, compiler.TemplateDepth)
+			if err != nil {
+				t.Errorf("ExpandSteps_Type%s returned err: %v", test.name, err)
+			}
+
+			if diff := cmp.Diff(build.Steps, wantSteps); diff != "" {
+				t.Errorf("ExpandSteps()_Type%s mismatch (-want +got):\n%s", test.name, diff)
+			}
+
+			if diff := cmp.Diff(build.Secrets, wantSecrets); diff != "" {
+				t.Errorf("ExpandSteps()_Type%s mismatch (-want +got):\n%s", test.name, diff)
+			}
+
+			if diff := cmp.Diff(build.Services, wantServices); diff != "" {
+				t.Errorf("ExpandSteps()_Type%s mismatch (-want +got):\n%s", test.name, diff)
+			}
+
+			if diff := cmp.Diff(build.Environment, wantEnvironment); diff != "" {
+				t.Errorf("ExpandSteps()_Type%s mismatch (-want +got):\n%s", test.name, diff)
+			}
+		})
+	}
+}
+
+func TestNative_ExpandSteps_TemplateCallTemplate_CircularFail(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	resp := httptest.NewRecorder()
+	_, engine := gin.CreateTestContext(resp)
+
+	engine.GET("/api/v3/repos/bad/design/contents/:path", func(c *gin.Context) {
+		c.Header("Content-Type", "application/json")
+		c.Status(http.StatusOK)
+		c.File("testdata/template-calls-itself.json")
+	})
+
+	s := httptest.NewServer(engine)
+	defer s.Close()
+
+	// setup types
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("github-driver", true, "doc")
+	set.String("github-url", s.URL, "doc")
+	set.String("github-token", "", "doc")
+	set.Int("max-template-depth", 5, "doc")
+	c := cli.NewContext(nil, set, nil)
+
+	testBuild := new(library.Build)
+
+	testBuild.SetID(1)
+	testBuild.SetCommit("123abc456def")
+
+	testRepo := new(library.Repo)
+
+	testRepo.SetID(1)
+	testRepo.SetOrg("foo")
+	testRepo.SetName("bar")
+
+	tests := []struct {
+		name  string
+		tmpls map[string]*yaml.Template
+	}{
+		{
+			name: "Test 1",
+			tmpls: map[string]*yaml.Template{
+				"circle": {
+					Name:   "circle",
+					Source: "github.example.com/bad/design/template.yml",
+					Type:   "github",
+				},
+			},
+		},
+	}
+
+	steps := yaml.StepSlice{
+		&yaml.Step{
+			Name: "sample",
+			Template: yaml.StepTemplate{
+				Name: "circle",
+			},
+		},
+	}
+
+	globalEnvironment := raw.StringSliceMap{
+		"foo": "test1",
+		"bar": "test2",
+	}
+
+	// run test
+	compiler, err := New(c)
+	if err != nil {
+		t.Errorf("Creating new compiler returned err: %v", err)
+	}
+
+	compiler.WithBuild(testBuild).WithRepo(testRepo)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := compiler.ExpandSteps(&yaml.Build{Steps: steps, Services: yaml.ServiceSlice{}, Environment: globalEnvironment}, test.tmpls, compiler.TemplateDepth)
+			if err == nil {
+				t.Errorf("ExpandSteps_Type%s should have returned an error", test.name)
+			}
+		})
 	}
 }
 

--- a/compiler/native/native.go
+++ b/compiler/native/native.go
@@ -32,6 +32,7 @@ type client struct {
 	UsePrivateGithub    bool
 	ModificationService ModificationConfig
 	CloneImage          string
+	TemplateDepth       int
 
 	build    *library.Build
 	comment  string
@@ -69,6 +70,8 @@ func New(ctx *cli.Context) (*client, error) {
 
 	// set the clone image to use for the injected clone step
 	c.CloneImage = ctx.String("clone-image")
+
+	c.TemplateDepth = ctx.Int("max-template-depth")
 
 	if ctx.Bool("github-driver") {
 		logrus.Tracef("setting up Private GitHub Client for %s", ctx.String("github-url"))
@@ -109,6 +112,7 @@ func (c *client) Duplicate() compiler.Engine {
 	cc.UsePrivateGithub = c.UsePrivateGithub
 	cc.ModificationService = c.ModificationService
 	cc.CloneImage = c.CloneImage
+	cc.TemplateDepth = c.TemplateDepth
 
 	return cc
 }

--- a/compiler/native/testdata/template-calls-itself.json
+++ b/compiler/native/testdata/template-calls-itself.json
@@ -1,0 +1,18 @@
+{
+  "type": "file",
+  "encoding": "base64",
+  "size": 5362,
+  "name": "template.yml",
+  "path": "template.yml",
+  "content": "dmVyc2lvbjogIjEiCgp0ZW1wbGF0ZXM6CiAgLSBuYW1lOiB0ZXN0CiAgICBzb3VyY2U6IGdpdGh1Yi5leGFtcGxlLmNvbS9iYWQvZGVzaWduL3RlbXBsYXRlLnltbAogICAgdHlwZTogZ2l0aHViCgpzdGVwczoKICAtIG5hbWU6IGNhbGwgdGVtcGxhdGUKICAgIHRlbXBsYXRlOgogICAgICBuYW1lOiB0ZXN0Cg==",
+  "sha": "3d21ec53a331a6f037a91c368710b99387d012c1",
+  "url": "https://api.github.com/repos/octokit/octokit.rb/contents/template.yml",
+  "git_url": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+  "html_url": "https://github.com/octokit/octokit.rb/blob/master/template.yml",
+  "download_url": "https://raw.githubusercontent.com/octokit/octokit.rb/master/template.yml",
+  "_links": {
+    "git": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+    "self": "https://api.github.com/repos/octokit/octokit.rb/contents/template.yml",
+    "html": "https://github.com/octokit/octokit.rb/blob/master/template.yml"
+  }
+}

--- a/compiler/native/testdata/template-calls-template.json
+++ b/compiler/native/testdata/template-calls-template.json
@@ -1,0 +1,18 @@
+{
+  "type": "file",
+  "encoding": "base64",
+  "size": 5362,
+  "name": "template.yml",
+  "path": "template.yml",
+  "content": "dmVyc2lvbjogIjEiCgp0ZW1wbGF0ZXM6CiAgLSBuYW1lOiB0ZXN0CiAgICBzb3VyY2U6IGdpdGh1Yi5leGFtcGxlLmNvbS9mb28vYmFyL3RlbXBsYXRlLnltbAogICAgdHlwZTogZ2l0aHViCgpzdGVwczoKICAtIG5hbWU6IGNhbGwgdGVtcGxhdGUKICAgIHRlbXBsYXRlOgogICAgICBuYW1lOiB0ZXN0CiAgICAgIHZhcnM6CiAgICAgICAgaW1hZ2U6IG9wZW5qZGs6bGF0ZXN0CiAgICAgICAgZW52aXJvbm1lbnQ6ICJ7IEdSQURMRV9VU0VSX0hPTUU6IC5ncmFkbGUsIEdSQURMRV9PUFRTOiAtRG9yZy5ncmFkbGUuZGFlbW9uPWZhbHNlIC1Eb3JnLmdyYWRsZS53b3JrZXJzLm1heD0xIC1Eb3JnLmdyYWRsZS5wYXJhbGxlbD1mYWxzZSB9IgogICAgICAgIHB1bGxfcG9saWN5OiAicHVsbDogdHJ1ZSIK",
+  "sha": "3d21ec53a331a6f037a91c368710b99387d012c1",
+  "url": "https://api.github.com/repos/octokit/octokit.rb/contents/template.yml",
+  "git_url": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+  "html_url": "https://github.com/octokit/octokit.rb/blob/master/template.yml",
+  "download_url": "https://raw.githubusercontent.com/octokit/octokit.rb/master/template.yml",
+  "_links": {
+    "git": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+    "self": "https://api.github.com/repos/octokit/octokit.rb/contents/template.yml",
+    "html": "https://github.com/octokit/octokit.rb/blob/master/template.yml"
+  }
+}

--- a/compiler/native/validate.go
+++ b/compiler/native/validate.go
@@ -16,7 +16,7 @@ import (
 func (c *client) Validate(p *yaml.Build) error {
 	var result error
 	// check a version is provided
-	if len(p.Version) == 0 && !p.Metadata.Template {
+	if len(p.Version) == 0 {
 		result = multierror.Append(result, fmt.Errorf("no \"version:\" YAML property provided"))
 	}
 

--- a/compiler/native/validate.go
+++ b/compiler/native/validate.go
@@ -16,7 +16,7 @@ import (
 func (c *client) Validate(p *yaml.Build) error {
 	var result error
 	// check a version is provided
-	if len(p.Version) == 0 {
+	if len(p.Version) == 0 && !p.Metadata.Template {
 		result = multierror.Append(result, fmt.Errorf("no \"version:\" YAML property provided"))
 	}
 

--- a/compiler/template/native/render.go
+++ b/compiler/template/native/render.go
@@ -61,7 +61,7 @@ func Render(tmpl string, name string, tName string, environment raw.StringSliceM
 		config.Steps[index].Name = fmt.Sprintf("%s_%s", name, newStep.Name)
 	}
 
-	return &types.Build{Steps: config.Steps, Secrets: config.Secrets, Services: config.Services, Environment: config.Environment}, nil
+	return &types.Build{Steps: config.Steps, Secrets: config.Secrets, Services: config.Services, Environment: config.Environment, Templates: config.Templates}, nil
 }
 
 // RenderBuild renders the templated build.


### PR DESCRIPTION
Closes https://github.com/go-vela/community/issues/256

Using a configurable max depth, this change would allow Vela users to call templates within templates.

Note: since `compileInline` doesn't call `ExpandSteps` and my first few passes on getting it to work similarly failed, I left support for `render_inline` as TO-DO.  