### PR TITLE
refactor(api): moved common `Post*Stream` logic to helper func 

### DIFF
--- a/api/stream.go
+++ b/api/stream.go
@@ -116,7 +116,7 @@ func PostServiceStream(c *gin.Context) {
 		return
 	}
 
-	streamLog(c, logger, _log, "service", entry, r.GetTimeout())
+	streamLogToDatabase(c, logger, _log, "service", entry, r.GetTimeout())
 
 	c.JSON(http.StatusNoContent, nil)
 }
@@ -210,13 +210,13 @@ func PostStepStream(c *gin.Context) {
 		return
 	}
 
-	streamLog(c, logger, _log, "step", entry, r.GetTimeout())
+	streamLogToDatabase(c, logger, _log, "step", entry, r.GetTimeout())
 
 	c.JSON(http.StatusNoContent, nil)
 }
 
-// streamLog handles streaming logs to the database.
-func streamLog(c *gin.Context, logger *logrus.Entry, log *library.Log, entryType, entry string, timeout int64) {
+// streamLogToDatabase handles streaming logs to the database.
+func streamLogToDatabase(c *gin.Context, logger *logrus.Entry, log *library.Log, entryType, entry string, timeout int64) {
 	// create new buffer for uploading logs
 	logs := new(bytes.Buffer)
 	// create new channel for processing logs

--- a/api/stream.go
+++ b/api/stream.go
@@ -11,15 +11,15 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-vela/server/router/middleware/org"
-	"github.com/go-vela/server/router/middleware/user"
-
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/build"
+	"github.com/go-vela/server/router/middleware/org"
 	"github.com/go-vela/server/router/middleware/repo"
 	"github.com/go-vela/server/router/middleware/service"
 	"github.com/go-vela/server/router/middleware/step"
+	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/util"
+	"github.com/go-vela/types/library"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -85,9 +85,9 @@ const logUpdateInterval = 1 * time.Second
 //nolint:dupl // separate service/step functions for consistency with API
 func PostServiceStream(c *gin.Context) {
 	// capture middleware values
-	b := build.Retrieve(c)
 	o := org.Retrieve(c)
 	r := repo.Retrieve(c)
+	b := build.Retrieve(c)
 	s := service.Retrieve(c)
 	u := user.Retrieve(c)
 
@@ -97,21 +97,14 @@ func PostServiceStream(c *gin.Context) {
 	//
 	// https://pkg.go.dev/github.com/sirupsen/logrus?tab=doc#Entry.WithFields
 	logger := logrus.WithFields(logrus.Fields{
-		"build":   b.GetNumber(),
 		"org":     o,
 		"repo":    r.GetName(),
+		"build":   b.GetNumber(),
 		"service": s.GetNumber(),
 		"user":    u.GetName(),
 	})
 
 	logger.Infof("streaming logs for service %s/%d", entry, s.GetNumber())
-
-	// create new buffer for uploading logs
-	logs := new(bytes.Buffer)
-	// create new channel for processing logs
-	done := make(chan bool)
-	// defer closing channel to stop processing logs
-	defer close(done)
 
 	// send API call to capture the service logs
 	_log, err := database.FromContext(c).GetLogForService(s)
@@ -123,61 +116,7 @@ func PostServiceStream(c *gin.Context) {
 		return
 	}
 
-	go func() {
-		logger.Debugf("polling request body buffer for service %s/%d", entry, s.GetNumber())
-
-		// spawn "infinite" loop that will upload logs
-		// from the buffer until the channel is closed
-		for {
-			// sleep before attempting to upload logs
-			time.Sleep(logUpdateInterval)
-
-			// create a non-blocking select to check if the channel is closed
-			select {
-			// after repo timeout of idle (no response) end the stream
-			//
-			// this is a safety mechanism
-			case <-time.After(time.Duration(r.GetTimeout()) * time.Minute):
-				logger.Tracef("repo timeout of %d exceeded", r.GetTimeout())
-
-				return
-			// channel is closed
-			case <-done:
-				logger.Trace("channel closed for polling container logs")
-
-				// return out of the go routine
-				return
-			// channel is not closed
-			default:
-				// get the current size of log data
-				currBytesSize := len(_log.GetData())
-
-				// update the existing log with the new bytes if there is new data to add
-				if len(logs.Bytes()) > currBytesSize {
-					// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.SetData
-					_log.SetData(logs.Bytes())
-
-					// update the log in the database
-					err = database.FromContext(c).UpdateLog(_log)
-					if err != nil {
-						retErr := fmt.Errorf("unable to update logs for service %s/%d: %w", entry, s.GetNumber(), err)
-
-						util.HandleError(c, http.StatusInternalServerError, retErr)
-
-						return
-					}
-				}
-			}
-		}
-	}()
-
-	logger.Debugf("scanning request body for service %s/%d", entry, s.GetNumber())
-
-	scanner := bufio.NewScanner(c.Request.Body)
-	for scanner.Scan() {
-		// write all the logs from the scanner
-		logs.Write(append(scanner.Bytes(), []byte("\n")...))
-	}
+	streamLog(c, logger, _log, "service", entry, r.GetTimeout())
 
 	c.JSON(http.StatusNoContent, nil)
 }
@@ -240,9 +179,9 @@ func PostServiceStream(c *gin.Context) {
 //nolint:dupl // separate service/step functions for consistency with API
 func PostStepStream(c *gin.Context) {
 	// capture middleware values
-	b := build.Retrieve(c)
 	o := org.Retrieve(c)
 	r := repo.Retrieve(c)
+	b := build.Retrieve(c)
 	s := step.Retrieve(c)
 	u := user.Retrieve(c)
 
@@ -252,21 +191,14 @@ func PostStepStream(c *gin.Context) {
 	//
 	// https://pkg.go.dev/github.com/sirupsen/logrus?tab=doc#Entry.WithFields
 	logger := logrus.WithFields(logrus.Fields{
-		"build": b.GetNumber(),
 		"org":   o,
 		"repo":  r.GetName(),
+		"build": b.GetNumber(),
 		"step":  s.GetNumber(),
 		"user":  u.GetName(),
 	})
 
 	logger.Infof("streaming logs for step %s/%d", entry, s.GetNumber())
-
-	// create new buffer for uploading logs
-	logs := new(bytes.Buffer)
-	// create new channel for processing logs
-	done := make(chan bool)
-	// defer closing channel to stop processing logs
-	defer close(done)
 
 	// send API call to capture the step logs
 	_log, err := database.FromContext(c).GetLogForStep(s)
@@ -278,8 +210,22 @@ func PostStepStream(c *gin.Context) {
 		return
 	}
 
+	streamLog(c, logger, _log, "step", entry, r.GetTimeout())
+
+	c.JSON(http.StatusNoContent, nil)
+}
+
+// streamLog handles streaming logs to the database.
+func streamLog(c *gin.Context, logger *logrus.Entry, log *library.Log, entryType, entry string, timeout int64) {
+	// create new buffer for uploading logs
+	logs := new(bytes.Buffer)
+	// create new channel for processing logs
+	done := make(chan bool)
+	// defer closing channel to stop processing logs
+	defer close(done)
+
 	go func() {
-		logger.Debugf("polling request body buffer for step %s/%d", entry, s.GetNumber())
+		logger.Debugf("polling request body buffer for %s %s", entryType, entry)
 
 		// spawn "infinite" loop that will upload logs
 		// from the buffer until the channel is closed
@@ -292,30 +238,30 @@ func PostStepStream(c *gin.Context) {
 			// after repo timeout of idle (no response) end the stream
 			//
 			// this is a safety mechanism
-			case <-time.After(time.Duration(r.GetTimeout()) * time.Minute):
-				logger.Tracef("repo timeout of %d exceeded", r.GetTimeout())
+			case <-time.After(time.Duration(timeout) * time.Minute):
+				logger.Tracef("repo timeout of %d exceeded", timeout)
 
 				return
 			// channel is closed
 			case <-done:
-				logger.Trace("channel closed for polling container logs")
+				logger.Tracef("channel closed for polling %s logs", entryType)
 
 				// return out of the go routine
 				return
 				// channel is not closed
 			default:
 				// get the current size of log data
-				currBytesSize := len(_log.GetData())
+				currBytesSize := len(log.GetData())
 
 				// update the existing log with the new bytes if there is new data to add
 				if len(logs.Bytes()) > currBytesSize {
 					// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.SetData
-					_log.SetData(logs.Bytes())
+					log.SetData(logs.Bytes())
 
 					// update the log in the database
-					err = database.FromContext(c).UpdateLog(_log)
+					err := database.FromContext(c).UpdateLog(log)
 					if err != nil {
-						retErr := fmt.Errorf("unable to update logs for step %s/%d: %w", entry, s.GetNumber(), err)
+						retErr := fmt.Errorf("unable to update logs for %s %s: %w", entryType, entry, err)
 
 						util.HandleError(c, http.StatusInternalServerError, retErr)
 
@@ -326,13 +272,11 @@ func PostStepStream(c *gin.Context) {
 		}
 	}()
 
-	logger.Debugf("scanning request body for step %s/%d", entry, s.GetNumber())
+	logger.Debugf("scanning request body for %s %s", entryType, entry)
 
 	scanner := bufio.NewScanner(c.Request.Body)
 	for scanner.Scan() {
 		// write all the logs from the scanner
 		logs.Write(append(scanner.Bytes(), []byte("\n")...))
 	}
-
-	c.JSON(http.StatusNoContent, nil)
 }


### PR DESCRIPTION
`PostServiceStream` and `PostStepStream` have a lot of shared logic to manage streaming logs to the database.

This refactors the `Post*Stream` methods so they can share an implementation in a new `streamLogToDatabase` helper function.

This is pre-work for the InitStep proposal https://github.com/go-vela/community/pull/771, but this is separate and useful whether or not that proposal gets accepted. If the proposal is accepted, this will make it easier to add `PostInitStepStream` in a future PR without adding yet another copy of the shared log streaming logic. If the propsal is not accepted, DRYing this code could help with any performance refactors so that we have one place to update instead of 2 (or 3). And it makes the logic within the API method much easier to follow.