### PR TITLE
enhance(queue): validate queue route and add error wrapping to clean build

### DIFF
--- a/api/webhook.go
+++ b/api/webhook.go
@@ -748,7 +748,7 @@ func publishToQueue(queue queue.Service, db database.Service, p *pipeline.Build,
 		logrus.Errorf("Failed to convert item to json for build %d for %s: %v", b.GetNumber(), r.GetFullName(), err)
 
 		// error out the build
-		cleanBuild(db, b, nil, nil)
+		cleanBuild(db, b, nil, nil, err)
 
 		return
 	}
@@ -760,7 +760,7 @@ func publishToQueue(queue queue.Service, db database.Service, p *pipeline.Build,
 		logrus.Errorf("unable to set route for build %d for %s: %v", b.GetNumber(), r.GetFullName(), err)
 
 		// error out the build
-		cleanBuild(db, b, nil, nil)
+		cleanBuild(db, b, nil, nil, err)
 
 		return
 	}
@@ -776,7 +776,7 @@ func publishToQueue(queue queue.Service, db database.Service, p *pipeline.Build,
 			logrus.Errorf("Failed to publish build %d for %s: %v", b.GetNumber(), r.GetFullName(), err)
 
 			// error out the build
-			cleanBuild(db, b, nil, nil)
+			cleanBuild(db, b, nil, nil, err)
 
 			return
 		}

--- a/queue/redis/route.go
+++ b/queue/redis/route.go
@@ -37,5 +37,13 @@ func (c *client) Route(w *pipeline.Worker) (string, error) {
 		buf.WriteString(fmt.Sprintf(":%s", w.Platform))
 	}
 
-	return strings.TrimLeft(buf.String(), ":"), nil
+	route := strings.TrimLeft(buf.String(), ":")
+
+	for _, r := range c.config.Channels {
+		if strings.EqualFold(route, r) {
+			return route, nil
+		}
+	}
+
+	return "", fmt.Errorf("invalid route %s provided", route)
 }

--- a/queue/redis/route_test.go
+++ b/queue/redis/route_test.go
@@ -14,32 +14,48 @@ import (
 
 func TestRedis_Client_Route(t *testing.T) {
 	// setup
-	client, _ := NewTest("vela")
+	client, _ := NewTest("vela", "16cpu8gb", "16cpu8gb:gcp", "gcp")
 	tests := []struct {
-		want   string
-		worker pipeline.Worker
+		success bool
+		want    string
+		worker  pipeline.Worker
 	}{
 
 		//  pipeline with not worker passed
 		{
-			want:   constants.DefaultRoute,
-			worker: pipeline.Worker{},
+			success: true,
+			want:    constants.DefaultRoute,
+			worker:  pipeline.Worker{},
 		},
 		{
-			want:   "vela",
-			worker: pipeline.Worker{},
+			success: true,
+			want:    "vela",
+			worker:  pipeline.Worker{},
 		},
 		{
-			want:   "16cpu8gb",
-			worker: pipeline.Worker{Flavor: "16cpu8gb"},
+			success: true,
+			want:    "16cpu8gb",
+			worker:  pipeline.Worker{Flavor: "16cpu8gb"},
 		},
 		{
-			want:   "16cpu8gb:gcp",
-			worker: pipeline.Worker{Flavor: "16cpu8gb", Platform: "gcp"},
+			success: true,
+			want:    "16cpu8gb:gcp",
+			worker:  pipeline.Worker{Flavor: "16cpu8gb", Platform: "gcp"},
 		},
 		{
-			want:   "gcp",
-			worker: pipeline.Worker{Platform: "gcp"},
+			success: true,
+			want:    "gcp",
+			worker:  pipeline.Worker{Platform: "gcp"},
+		},
+		{
+			success: false,
+			want:    "",
+			worker:  pipeline.Worker{Flavor: "bad", Platform: "route"},
+		},
+		{
+			success: false,
+			want:    "",
+			worker:  pipeline.Worker{Flavor: "bad"},
 		},
 	}
 
@@ -47,8 +63,12 @@ func TestRedis_Client_Route(t *testing.T) {
 	for _, test := range tests {
 		got, err := client.Route(&test.worker)
 
-		if err != nil {
+		if test.success && err != nil {
 			t.Errorf("Route returned err: %v", err)
+		}
+
+		if !test.success && err == nil {
+			t.Errorf("Route returned %s, want err", got)
 		}
 
 		if !strings.EqualFold(got, test.want) {


### PR DESCRIPTION
This change will verify that the user provided queue route matches the configured routes. This prevents poorly routed builds from sitting on the queue forever.

I also added error wrapping to `cleanBuild` because "unable to publish to queue" was too generic and only makes support for the product more challenging for platform admins.

Before: 
![Screenshot 2023-03-30 at 1 35 39 PM](https://user-images.githubusercontent.com/65553218/228932792-84f220e9-0c76-471e-92fd-5126990f784d.png)

After:
![Screenshot 2023-03-30 at 1 37 52 PM](https://user-images.githubusercontent.com/65553218/228932857-53f82eba-0a06-443c-afb0-d7c4a597fe9b.png)

