### PR TITLE
enhance(metrics): gather queued builds

### DIFF
--- a/queue/redis/length.go
+++ b/queue/redis/length.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package redis
+
+import (
+	"context"
+)
+
+// Length tallies all items present in the configured channels in the queue.
+func (c *client) Length(ctx context.Context) (int64, error) {
+	c.Logger.Tracef("reading length of all configured channels in queue")
+
+	total := int64(0)
+
+	for _, channel := range c.config.Channels {
+		items, err := c.Redis.LLen(ctx, channel).Result()
+		if err != nil {
+			return 0, err
+		}
+
+		total += items
+	}
+
+	return total, nil
+}

--- a/queue/redis/length_test.go
+++ b/queue/redis/length_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package redis
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/go-vela/types"
+	"gopkg.in/square/go-jose.v2/json"
+)
+
+func TestRedis_Length(t *testing.T) {
+	// setup types
+	// use global variables in redis_test.go
+	_item := &types.Item{
+		Build:    _build,
+		Pipeline: _steps,
+		Repo:     _repo,
+		User:     _user,
+	}
+
+	// setup queue item
+	bytes, err := json.Marshal(_item)
+	if err != nil {
+		t.Errorf("unable to marshal queue item: %v", err)
+	}
+
+	// setup redis mock
+	_redis, err := NewTest("vela", "vela:second", "vela:third")
+	if err != nil {
+		t.Errorf("unable to create queue service: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		channels []string
+		want     int64
+	}{
+		{
+			channels: []string{"vela"},
+			want:     1,
+		},
+		{
+			channels: []string{"vela", "vela:second", "vela:third"},
+			want:     4,
+		},
+		{
+			channels: []string{"vela", "vela:second", "phony"},
+			want:     6,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		for _, channel := range test.channels {
+			err := _redis.Push(context.Background(), channel, bytes)
+			if err != nil {
+				t.Errorf("unable to push item to queue: %v", err)
+			}
+		}
+		got, err := _redis.Length(context.Background())
+
+		if err != nil {
+			t.Errorf("Length returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("Length is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/queue/service.go
+++ b/queue/service.go
@@ -20,6 +20,10 @@ type Service interface {
 	// the configured queue driver.
 	Driver() string
 
+	// Length defines a function that outputs
+	// the length of a queue channel
+	Length(context.Context) (int64, error)
+
 	// Pop defines a function that grabs an
 	// item off the queue.
 	Pop(context.Context) (*types.Item, error)


### PR DESCRIPTION
There have been several cases where a build has found itself in a `pending` state due to some error in the webhook flow (typically around `publishToQueue`). These builds never make it to the queue and are still left as `pending`. This additional query to the metrics endpoint gives a much more accurate representation of queue size.