### PR TITLE
fix(jwt): set issued_at to nil prior to validating claims

### DIFF
--- a/internal/token/parse.go
+++ b/internal/token/parse.go
@@ -34,7 +34,7 @@ func (tm *Manager) ParseToken(token string) (*Claims, error) {
 		claims = t.Claims.(*Claims)
 		name := claims.Subject
 
-		// according to JWT RFC, the iat field is optional for security purposes and is purely informational.
+		// according to JWT, the iat field is optional for security purposes and is purely informational.
 		// setting it to nil avoids any worries of race conditions.
 		claims.IssuedAt = nil
 

--- a/internal/token/parse.go
+++ b/internal/token/parse.go
@@ -34,6 +34,10 @@ func (tm *Manager) ParseToken(token string) (*Claims, error) {
 		claims = t.Claims.(*Claims)
 		name := claims.Subject
 
+		// according to JWT RFC, the iat field is optional for security purposes and is purely informational.
+		// setting it to nil avoids any worries of race conditions.
+		claims.IssuedAt = nil
+
 		// check if subject has a value in claims;
 		// we can save a db lookup attempt
 		if len(name) == 0 {

--- a/internal/token/parse_test.go
+++ b/internal/token/parse_test.go
@@ -51,7 +51,7 @@ func TestTokenManager_ParseToken(t *testing.T) {
 				TokenType: constants.UserAccessTokenType,
 				RegisteredClaims: jwt.RegisteredClaims{
 					Subject:   u.GetName(),
-					IssuedAt:  jwt.NewNumericDate(now),
+					IssuedAt:  nil,
 					ExpiresAt: jwt.NewNumericDate(now.Add(time.Minute * 5)),
 				},
 			},
@@ -69,7 +69,7 @@ func TestTokenManager_ParseToken(t *testing.T) {
 				TokenType: constants.UserRefreshTokenType,
 				RegisteredClaims: jwt.RegisteredClaims{
 					Subject:   u.GetName(),
-					IssuedAt:  jwt.NewNumericDate(now),
+					IssuedAt:  nil,
 					ExpiresAt: jwt.NewNumericDate(now.Add(time.Minute * 30)),
 				},
 			},
@@ -89,7 +89,7 @@ func TestTokenManager_ParseToken(t *testing.T) {
 				TokenType: constants.WorkerBuildTokenType,
 				RegisteredClaims: jwt.RegisteredClaims{
 					Subject:   "worker",
-					IssuedAt:  jwt.NewNumericDate(now),
+					IssuedAt:  nil,
 					ExpiresAt: jwt.NewNumericDate(now.Add(time.Minute * 90)),
 				},
 			},

--- a/router/middleware/claims/claims_test.go
+++ b/router/middleware/claims/claims_test.go
@@ -88,7 +88,7 @@ func TestClaims_Establish(t *testing.T) {
 				IsActive:  true,
 				RegisteredClaims: jwt.RegisteredClaims{
 					Subject:   "foo",
-					IssuedAt:  jwt.NewNumericDate(now),
+					IssuedAt:  nil,
 					ExpiresAt: jwt.NewNumericDate(now.Add(time.Minute * 5)),
 				},
 			},
@@ -108,7 +108,7 @@ func TestClaims_Establish(t *testing.T) {
 				Repo:      "foo/bar",
 				RegisteredClaims: jwt.RegisteredClaims{
 					Subject:   "host",
-					IssuedAt:  jwt.NewNumericDate(now),
+					IssuedAt:  nil,
 					ExpiresAt: jwt.NewNumericDate(now.Add(time.Minute * 35)),
 				},
 			},


### PR DESCRIPTION
Due to some clock skew, we began seeing `token used before issued` errors. We noticed [this issue](https://github.com/golang-jwt/jwt/issues/98) in the JWT library, which appears to be resolved in their upcoming `v5` release. In that release, they will be making `issued_at` unchecked by default, due to its optional nature. I elaborated on this in the code comments as well.