### PR TITLE
fix(metrics/spec): add queued_build_count to spec

### DIFF
--- a/api/metrics.go
+++ b/api/metrics.go
@@ -121,6 +121,11 @@ var (
 //   type: boolean
 //   default: false
 // - in: query
+//   name: queued_build_count
+//   description: Indicates a request for queued build count
+//   type: boolean
+//   default: false
+// - in: query
 //   name: failure_build_count
 //   description: Indicates a request for failure build count
 //   type: boolean


### PR DESCRIPTION
Just noticed I left this out from https://github.com/go-vela/server/pull/802