### PR TITLE
fix(scm): handle new go-github validation changes and ensure correct number for init hook

### DIFF
--- a/api/repo/repair.go
+++ b/api/repo/repair.go
@@ -77,8 +77,17 @@ func RepairRepo(c *gin.Context) {
 			return
 		}
 
+		hook, err := database.FromContext(c).LastHookForRepo(r)
+		if err != nil {
+			retErr := fmt.Errorf("unable to get last hook for %s: %w", r.GetFullName(), err)
+
+			util.HandleError(c, http.StatusInternalServerError, retErr)
+
+			return
+		}
+
 		// send API call to create the webhook
-		hook, _, err := scm.FromContext(c).Enable(u, r)
+		hook, _, err = scm.FromContext(c).Enable(u, r, hook)
 		if err != nil {
 			retErr := fmt.Errorf("unable to create webhook for %s: %w", r.GetFullName(), err)
 

--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -151,7 +151,7 @@ func (c *client) Disable(u *library.User, org, name string) error {
 }
 
 // Enable activates a repo by creating the webhook.
-func (c *client) Enable(u *library.User, r *library.Repo) (*library.Hook, string, error) {
+func (c *client) Enable(u *library.User, r *library.Repo, h *library.Hook) (*library.Hook, string, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),
@@ -200,7 +200,7 @@ func (c *client) Enable(u *library.User, r *library.Repo) (*library.Hook, string
 	webhook.SetSourceID(r.GetName() + "-" + eventInitialize)
 	webhook.SetCreated(hookInfo.GetCreatedAt().Unix())
 	webhook.SetEvent(eventInitialize)
-	webhook.SetNumber(1)
+	webhook.SetNumber(h.GetNumber() + 1)
 
 	switch resp.StatusCode {
 	case http.StatusUnprocessableEntity:

--- a/scm/github/repo_test.go
+++ b/scm/github/repo_test.go
@@ -621,7 +621,7 @@ func TestGithub_Enable(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, _, err := client.Enable(u, r)
+	got, _, err := client.Enable(u, r, new(library.Hook))
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Enable returned %v, want %v", resp.Code, http.StatusOK)

--- a/scm/github/webhook.go
+++ b/scm/github/webhook.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"mime"
 	"net/http"
 	"strconv"
 	"strings"
@@ -47,20 +48,16 @@ func (c *client) ProcessWebhook(request *http.Request) (*types.Webhook, error) {
 		h.SetHost(request.Header.Get("X-GitHub-Enterprise-Host"))
 	}
 
-	// grab signature we use for webhook verification
-	sig := request.Header.Get(github.SHA256SignatureHeader)
+	// get content type
+	contentType, _, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, err
+	}
 
-	// set both signature types to nothing in order to properly get payload information
-	request.Header.Set(github.SHA256SignatureHeader, "")
-	request.Header.Set(github.SHA1SignatureHeader, "")
-
-	payload, err := github.ValidatePayload(request, nil)
+	payload, err := github.ValidatePayloadFromBody(contentType, request.Body, "", nil)
 	if err != nil {
 		return &types.Webhook{Hook: h}, nil
 	}
-
-	// reset the signature so we can verify properly later
-	request.Header.Set(github.SHA256SignatureHeader, sig)
 
 	// parse the payload from the webhook
 	event, err := github.ParseWebHook(github.WebHookType(request), payload)

--- a/scm/service.go
+++ b/scm/service.go
@@ -98,7 +98,7 @@ type Service interface {
 	Disable(*library.User, string, string) error
 	// Enable defines a function that activates
 	// a repo by creating the webhook.
-	Enable(*library.User, *library.Repo) (*library.Hook, string, error)
+	Enable(*library.User, *library.Repo, *library.Hook) (*library.Hook, string, error)
 	// Update defines a function that updates
 	// a webhook for a specified repo.
 	Update(*library.User, *library.Repo, int64) error


### PR DESCRIPTION
With the release of [go-github/v51](https://github.com/google/go-github/releases/tag/v51.0.0), the `ValidatePayload` method now _requires_ secret validation in order to capture a payload ([ref](https://github.com/google/go-github/commit/b1c53f808b2218b2572fa7f8a8b4b4401a02ca96)). 

Since our webhook validation occurs [later](https://github.com/go-vela/server/blob/3fec46cbef8ae8224d7cad31680e96e4b5513498/api/webhook.go#L250), when we actually have our webhook secret, we cannot grab this payload unless we call `ValidatePayloadFromBody` with empty signature and secret values instead. 

Lastly, in [this change](https://github.com/go-vela/server/pull/679), I failed to account for situations where a repo was being re-enabled / repaired, and thus the `init` webhook would not have a number value of `1`