### PR TITLE
fix(scm): correct init hook status and send accurate events

### DIFF
--- a/api/repo/create.go
+++ b/api/repo/create.go
@@ -239,8 +239,18 @@ func CreateRepo(c *gin.Context) {
 	}
 
 	h := new(library.Hook)
+
+	// err being nil means we have a record of this repo (dbRepo)
 	if err == nil {
 		h, _ = database.FromContext(c).LastHookForRepo(dbRepo)
+
+		// make sure our record of the repo allowed events matches what we send to SCM
+		// what the dbRepo has should override default events on enable
+		r.SetAllowComment(dbRepo.GetAllowComment())
+		r.SetAllowDeploy(dbRepo.GetAllowDeploy())
+		r.SetAllowPull(dbRepo.GetAllowPull())
+		r.SetAllowPush(dbRepo.GetAllowPush())
+		r.SetAllowTag(dbRepo.GetAllowTag())
 	}
 
 	// check if we should create the webhook

--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -201,6 +201,7 @@ func (c *client) Enable(u *library.User, r *library.Repo, h *library.Hook) (*lib
 	webhook.SetCreated(hookInfo.GetCreatedAt().Unix())
 	webhook.SetEvent(eventInitialize)
 	webhook.SetNumber(h.GetNumber() + 1)
+	webhook.SetStatus(constants.StatusSuccess)
 
 	switch resp.StatusCode {
 	case http.StatusUnprocessableEntity:

--- a/scm/github/repo_test.go
+++ b/scm/github/repo_test.go
@@ -608,6 +608,7 @@ func TestGithub_Enable(t *testing.T) {
 	wantHook.SetCreated(1315329987)
 	wantHook.SetNumber(1)
 	wantHook.SetEvent("initialize")
+	wantHook.SetStatus("success")
 
 	r := new(library.Repo)
 	r.SetID(1)


### PR DESCRIPTION
Noticed that `init` webhooks were set to a failed status.

Also saw that when we already have a record of a repo and are in the process of re-enabling it, we should make sure the events specified for that record match what we send the SCM, rather than the default events. 