### PR TITLE
fix(deps): update process push webhook to account for changes in v52

### DIFF
--- a/api/webhook.go
+++ b/api/webhook.go
@@ -471,14 +471,8 @@ func PostWebhook(c *gin.Context) {
 		}
 
 		// update repo fields with any changes from SCM process
-		// TODO: eventually remove this in favor of some sync scripting?
-		if len(r.GetTopics()) != 0 {
-			repo.SetTopics(r.GetTopics())
-		}
-
-		if !strings.EqualFold(repo.GetBranch(), r.GetBranch()) {
-			repo.SetBranch(r.GetBranch())
-		}
+		repo.SetTopics(r.GetTopics())
+		repo.SetBranch(r.GetBranch())
 
 		// set the parent equal to the current repo counter
 		b.SetParent(repo.GetCounter())

--- a/scm/github/testdata/hooks/push.json
+++ b/scm/github/testdata/hooks/push.json
@@ -156,7 +156,11 @@
     "watchers": 0,
     "default_branch": "master",
     "stargazers": 0,
-    "master_branch": "master"
+    "master_branch": "master",
+    "topics": [
+      "go",
+      "vela"
+    ]
   },
   "pusher": {
     "name": "Codertocat",

--- a/scm/github/testdata/hooks/push_no_sender.json
+++ b/scm/github/testdata/hooks/push_no_sender.json
@@ -156,7 +156,11 @@
     "watchers": 0,
     "default_branch": "master",
     "stargazers": 0,
-    "master_branch": "master"
+    "master_branch": "master",
+    "topics": [
+      "go",
+      "vela"
+    ]
   },
   "pusher": {
     "name": "Codertocat",

--- a/scm/github/webhook.go
+++ b/scm/github/webhook.go
@@ -145,8 +145,7 @@ func (c *client) processPushEvent(h *library.Hook, payload *github.PushEvent) (*
 	r.SetClone(repo.GetCloneURL())
 	r.SetBranch(repo.GetDefaultBranch())
 	r.SetPrivate(repo.GetPrivate())
-	// uncomment this line when next version (>v51.0.0) of go-github is released
-	// r.SetTopics(repo.Topics)
+	r.SetTopics(repo.Topics)
 
 	// convert payload to library build
 	b := new(library.Build)

--- a/scm/github/webhook_test.go
+++ b/scm/github/webhook_test.go
@@ -66,6 +66,7 @@ func TestGithub_ProcessWebhook_Push(t *testing.T) {
 	wantRepo.SetClone("https://github.com/Codertocat/Hello-World.git")
 	wantRepo.SetBranch("master")
 	wantRepo.SetPrivate(false)
+	wantRepo.SetTopics([]string{"go", "vela"})
 
 	wantBuild := new(library.Build)
 	wantBuild.SetEvent("push")
@@ -144,6 +145,7 @@ func TestGithub_ProcessWebhook_Push_NoSender(t *testing.T) {
 	wantRepo.SetClone("https://github.com/Codertocat/Hello-World.git")
 	wantRepo.SetBranch("master")
 	wantRepo.SetPrivate(false)
+	wantRepo.SetTopics([]string{"go", "vela"})
 
 	wantBuild := new(library.Build)
 	wantBuild.SetEvent("push")


### PR DESCRIPTION
Now we can set topics from push events. Though we keep this field updated on repository events, some repos enabled prior to the v0.19 release will not benefit from that unless they manually change their topics.