### PR TITLE
fix(queue/metrics): include default route in queued build count

### DIFF
--- a/queue/redis/length.go
+++ b/queue/redis/length.go
@@ -6,14 +6,21 @@ package redis
 
 import (
 	"context"
+
+	"github.com/go-vela/types/constants"
 )
 
 // Length tallies all items present in the configured channels in the queue.
 func (c *client) Length(ctx context.Context) (int64, error) {
 	c.Logger.Tracef("reading length of all configured channels in queue")
 
-	total := int64(0)
+	// get length of default route
+	total, err := c.Redis.LLen(ctx, constants.DefaultRoute).Result()
+	if err != nil {
+		return 0, err
+	}
 
+	// iterate through any supplied routes in config
 	for _, channel := range c.config.Channels {
 		items, err := c.Redis.LLen(ctx, channel).Result()
 		if err != nil {

--- a/queue/redis/length_test.go
+++ b/queue/redis/length_test.go
@@ -30,7 +30,7 @@ func TestRedis_Length(t *testing.T) {
 	}
 
 	// setup redis mock
-	_redis, err := NewTest("vela", "vela:second", "vela:third")
+	_redis, err := NewTest("vela:first", "vela:second", "vela:third")
 	if err != nil {
 		t.Errorf("unable to create queue service: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestRedis_Length(t *testing.T) {
 			want:     4,
 		},
 		{
-			channels: []string{"vela", "vela:second", "phony"},
+			channels: []string{"vela:first", "vela:second", "phony"},
 			want:     6,
 		},
 	}


### PR DESCRIPTION
When gathering queued builds, if an admin supplies specific queue routes, they get overwrite the default route from the channel slice.