### PR TITLE
enhance(build): add ability to cancel pending builds

### DIFF
--- a/router/middleware/executors/executors.go
+++ b/router/middleware/executors/executors.go
@@ -31,6 +31,15 @@ func Establish() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		e := new([]library.Executor)
 		b := build.Retrieve(c)
+
+		// if build has no host, we cannot establish executors
+		if len(b.GetHost()) == 0 {
+			ToContext(c, *e)
+			c.Next()
+
+			return
+		}
+
 		// retrieve the worker
 		w, err := database.FromContext(c).GetWorkerForHostname(b.GetHost())
 		if err != nil {


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/485

This change will give users the ability to cancel builds that are in a pending state. The server will perform the necessary updates to the database to ensure the build (and its steps/services) has the correct status. The worker will pop that item off the queue and determine whether or not it has been cancelled. In other words, rather than scan the queue searching for the item to remove, it seems like a better strategy to let the workers do the cleaning.