### PR TITLE
fix(router): establish claims before user on logout

### DIFF
--- a/router/middleware/user/user.go
+++ b/router/middleware/user/user.go
@@ -29,8 +29,8 @@ func Establish() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		cl := claims.Retrieve(c)
 
-		// if token is not a user token, establish empty user to better handle nil checks
-		if !strings.EqualFold(cl.TokenType, constants.UserAccessTokenType) {
+		// if token is not a user token or claims were not retrieved, establish empty user to better handle nil checks
+		if cl == nil || !strings.EqualFold(cl.TokenType, constants.UserAccessTokenType) {
 			u := new(library.User)
 
 			ToContext(c, u)

--- a/router/router.go
+++ b/router/router.go
@@ -69,7 +69,7 @@ func Load(options ...gin.HandlerFunc) *gin.Engine {
 	r.GET("/login", auth.Login)
 
 	// Logout endpoint
-	r.GET("/logout", user.Establish(), auth.Logout)
+	r.GET("/logout", claims.Establish(), user.Establish(), auth.Logout)
 
 	// Refresh Access Token endpoint
 	r.GET("/token-refresh", auth.RefreshAccessToken)


### PR DESCRIPTION
Upon logging out, server would panic due to claims not being established prior to user. This solves that.