### PR TITLE
fix(compiler): add commit field to compiler engine to handle file type template lite compilation

### DIFF
--- a/api/build.go
+++ b/api/build.go
@@ -271,6 +271,7 @@ func CreateBuild(c *gin.Context) {
 	p, compiled, err = compiler.FromContext(c).
 		Duplicate().
 		WithBuild(input).
+		WithCommit(input.GetCommit()).
 		WithFiles(files).
 		WithMetadata(m).
 		WithRepo(r).
@@ -1200,6 +1201,7 @@ func RestartBuild(c *gin.Context) {
 	p, compiled, err = compiler.FromContext(c).
 		Duplicate().
 		WithBuild(b).
+		WithCommit(b.GetCommit()).
 		WithFiles(files).
 		WithMetadata(m).
 		WithRepo(r).

--- a/api/pipeline/compile.go
+++ b/api/pipeline/compile.go
@@ -94,7 +94,7 @@ func CompilePipeline(c *gin.Context) {
 	r.SetPipelineType(p.GetType())
 
 	// create the compiler object
-	compiler := compiler.FromContext(c).Duplicate().WithMetadata(m).WithRepo(r).WithUser(u)
+	compiler := compiler.FromContext(c).Duplicate().WithCommit(p.GetCommit()).WithMetadata(m).WithRepo(r).WithUser(u)
 
 	// compile the pipeline
 	pipeline, _, err := compiler.CompileLite(p.GetData(), true, true, nil)

--- a/api/pipeline/expand.go
+++ b/api/pipeline/expand.go
@@ -95,7 +95,7 @@ func ExpandPipeline(c *gin.Context) {
 	r.SetPipelineType(p.GetType())
 
 	// create the compiler object
-	compiler := compiler.FromContext(c).Duplicate().WithMetadata(m).WithRepo(r).WithUser(u)
+	compiler := compiler.FromContext(c).Duplicate().WithCommit(p.GetCommit()).WithMetadata(m).WithRepo(r).WithUser(u)
 
 	// expand the templates in the pipeline
 	pipeline, _, err := compiler.CompileLite(p.GetData(), true, false, nil)

--- a/api/pipeline/template.go
+++ b/api/pipeline/template.go
@@ -96,7 +96,7 @@ func GetTemplates(c *gin.Context) {
 	}).Infof("reading templates from pipeline %s", entry)
 
 	// create the compiler object
-	compiler := compiler.FromContext(c).Duplicate().WithMetadata(m).WithRepo(r).WithUser(u)
+	compiler := compiler.FromContext(c).Duplicate().WithCommit(p.GetCommit()).WithMetadata(m).WithRepo(r).WithUser(u)
 
 	// parse the pipeline configuration
 	pipeline, _, err := compiler.Parse(p.GetData(), p.GetType(), new(yaml.Template))

--- a/api/pipeline/validate.go
+++ b/api/pipeline/validate.go
@@ -94,7 +94,7 @@ func ValidatePipeline(c *gin.Context) {
 	r.SetPipelineType(p.GetType())
 
 	// create the compiler object
-	compiler := compiler.FromContext(c).Duplicate().WithMetadata(m).WithRepo(r).WithUser(u)
+	compiler := compiler.FromContext(c).Duplicate().WithCommit(p.GetCommit()).WithMetadata(m).WithRepo(r).WithUser(u)
 
 	// capture optional template query parameter
 	template, err := strconv.ParseBool(c.DefaultQuery("template", "true"))

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -511,6 +511,7 @@ func PostWebhook(c *gin.Context) {
 			Duplicate().
 			WithBuild(b).
 			WithComment(webhook.Comment).
+			WithCommit(b.GetCommit()).
 			WithFiles(files).
 			WithMetadata(m).
 			WithRepo(repo).

--- a/compiler/engine.go
+++ b/compiler/engine.go
@@ -121,6 +121,9 @@ type Engine interface {
 	// WithComment defines a function that sets
 	// the comment in the Engine.
 	WithComment(string) Engine
+	// WithCommit defines a function that sets
+	// the commit in the Engine.
+	WithCommit(string) Engine
 	// WithFiles defines a function that sets
 	// the changeset files in the Engine.
 	WithFiles([]string) Engine

--- a/compiler/native/expand.go
+++ b/compiler/native/expand.go
@@ -235,7 +235,7 @@ func (c *client) getTemplate(tmpl *yaml.Template, name string) ([]byte, error) {
 			Org:  c.repo.GetOrg(),
 			Repo: c.repo.GetName(),
 			Name: tmpl.Source,
-			Ref:  c.build.GetCommit(),
+			Ref:  c.commit,
 		}
 
 		if !c.UsePrivateGithub {

--- a/compiler/native/expand_test.go
+++ b/compiler/native/expand_test.go
@@ -192,11 +192,6 @@ func TestNative_ExpandSteps(t *testing.T) {
 	set.String("github-token", "", "doc")
 	c := cli.NewContext(nil, set, nil)
 
-	testBuild := new(library.Build)
-
-	testBuild.SetID(1)
-	testBuild.SetCommit("123abc456def")
-
 	testRepo := new(library.Repo)
 
 	testRepo.SetID(1)
@@ -318,7 +313,7 @@ func TestNative_ExpandSteps(t *testing.T) {
 		t.Errorf("Creating new compiler returned err: %v", err)
 	}
 
-	compiler.WithBuild(testBuild).WithRepo(testRepo)
+	compiler.WithCommit("123abc456def").WithRepo(testRepo)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/compiler/native/native.go
+++ b/compiler/native/native.go
@@ -35,6 +35,7 @@ type client struct {
 
 	build    *library.Build
 	comment  string
+	commit   string
 	files    []string
 	local    bool
 	metadata *types.Metadata
@@ -126,6 +127,15 @@ func (c *client) WithBuild(b *library.Build) compiler.Engine {
 func (c *client) WithComment(cmt string) compiler.Engine {
 	if cmt != "" {
 		c.comment = cmt
+	}
+
+	return c
+}
+
+// WithCommit sets the comment in the Engine.
+func (c *client) WithCommit(cmt string) compiler.Engine {
+	if cmt != "" {
+		c.commit = cmt
 	}
 
 	return c

--- a/router/middleware/pipeline/pipeline.go
+++ b/router/middleware/pipeline/pipeline.go
@@ -77,6 +77,7 @@ func Establish() gin.HandlerFunc {
 			// parse and compile the pipeline configuration file
 			_, pipeline, err = compiler.FromContext(c).
 				Duplicate().
+				WithCommit(p).
 				WithMetadata(c.MustGet("metadata").(*types.Metadata)).
 				WithRepo(r).
 				WithUser(u).


### PR DESCRIPTION
When using any compiler function which does not involve instantiating the compiler with a build (`compiler.FromContext(c).WithBuild(b)`), any time a [lite compilation](https://github.com/go-vela/server/blob/afd00ce206085f6e03ae86722061fc85c573cbb8/compiler/native/compile.go#L108) is requested (many pipeline API endpoints), the compiler fails to grab the correct template from the SCM due to [this line](https://github.com/go-vela/server/blob/afd00ce206085f6e03ae86722061fc85c573cbb8/compiler/native/expand.go#L238). This change addresses the bug by adding a `commit` field to the compiler engine, which felt like the least invasive way of holding the commit SHA during compilation / template fetching. Open to other ideas as well.