### PR TITLE
feat(api/admin): add endpoint to clean pending / running builds

### DIFF
--- a/api/admin/clean.go
+++ b/api/admin/clean.go
@@ -63,7 +63,7 @@ import (
 // update any user stored in the database.
 func CleanResources(c *gin.Context) {
 	u := user.Retrieve(c)
-	logrus.Infof("Admin %s: updating pending resources in database", u.GetName())
+	logrus.Infof("platform admin %s: updating pending resources in database", u.GetName())
 
 	// default error message
 	msg := "build cleaned by platform admin"
@@ -104,6 +104,7 @@ func CleanResources(c *gin.Context) {
 
 		return
 	}
+	logrus.Infof("platform admin %s: cleaned %d builds in database", u.GetName(), builds)
 
 	// clean services
 	services, err := database.FromContext(c).CleanServices(before)
@@ -114,6 +115,7 @@ func CleanResources(c *gin.Context) {
 
 		return
 	}
+	logrus.Infof("platform admin %s: cleaned %d services in database", u.GetName(), services)
 
 	// clean steps
 	steps, err := database.FromContext(c).CleanSteps(before)
@@ -124,6 +126,7 @@ func CleanResources(c *gin.Context) {
 
 		return
 	}
+	logrus.Infof("platform admin %s: cleaned %d steps in database", u.GetName(), steps)
 
 	c.JSON(http.StatusOK, fmt.Sprintf("%d builds cleaned. %d services cleaned. %d steps cleaned.", builds, services, steps))
 }

--- a/api/admin/clean.go
+++ b/api/admin/clean.go
@@ -104,10 +104,11 @@ func CleanResources(c *gin.Context) {
 
 		return
 	}
+
 	logrus.Infof("platform admin %s: cleaned %d builds in database", u.GetName(), builds)
 
 	// clean services
-	services, err := database.FromContext(c).CleanServices(before)
+	services, err := database.FromContext(c).CleanServices(msg, before)
 	if err != nil {
 		retErr := fmt.Errorf("%d builds cleaned. unable to update services: %w", builds, err)
 
@@ -115,10 +116,11 @@ func CleanResources(c *gin.Context) {
 
 		return
 	}
+
 	logrus.Infof("platform admin %s: cleaned %d services in database", u.GetName(), services)
 
 	// clean steps
-	steps, err := database.FromContext(c).CleanSteps(before)
+	steps, err := database.FromContext(c).CleanSteps(msg, before)
 	if err != nil {
 		retErr := fmt.Errorf("%d builds cleaned. %d services cleaned. unable to update steps: %w", builds, services, err)
 
@@ -126,6 +128,7 @@ func CleanResources(c *gin.Context) {
 
 		return
 	}
+
 	logrus.Infof("platform admin %s: cleaned %d steps in database", u.GetName(), steps)
 
 	c.JSON(http.StatusOK, fmt.Sprintf("%d builds cleaned. %d services cleaned. %d steps cleaned.", builds, services, steps))

--- a/api/admin/clean.go
+++ b/api/admin/clean.go
@@ -65,6 +65,7 @@ func CleanResources(c *gin.Context) {
 	u := user.Retrieve(c)
 	logrus.Infof("Admin %s: updating pending resources in database", u.GetName())
 
+	// default error message
 	msg := "build cleaned by platform admin"
 
 	// capture body from API request
@@ -79,6 +80,7 @@ func CleanResources(c *gin.Context) {
 		return
 	}
 
+	// if a message is provided, set the error message to that
 	if input.Message != nil {
 		msg = *input.Message
 	}

--- a/database/build/clean.go
+++ b/database/build/clean.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package build
+
+import (
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+	"github.com/sirupsen/logrus"
+)
+
+// CleanBuilds updates builds to an error with a provided message with a created timestamp prior to a defined moment.
+func (e *engine) CleanBuilds(msg string, before int64) (int64, error) {
+	logrus.Tracef("cleaning pending or running builds in the database created prior to %d", before)
+
+	b := new(library.Build)
+	b.SetStatus(constants.StatusError)
+	b.SetError(msg)
+
+	build := database.BuildFromLibrary(b)
+
+	// send query to the database
+	result := e.client.
+		Table(constants.TableBuild).
+		Where("created < ?", before).
+		Where("status = 'running' OR status = 'pending'").
+		Updates(build)
+
+	return result.RowsAffected, result.Error
+}

--- a/database/build/clean.go
+++ b/database/build/clean.go
@@ -5,6 +5,8 @@
 package build
 
 import (
+	"time"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -18,6 +20,7 @@ func (e *engine) CleanBuilds(msg string, before int64) (int64, error) {
 	b := new(library.Build)
 	b.SetStatus(constants.StatusError)
 	b.SetError(msg)
+	b.SetFinished(time.Now().UTC().Unix())
 
 	build := database.BuildFromLibrary(b)
 

--- a/database/build/clean_test.go
+++ b/database/build/clean_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package build
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestBuild_Engine_CleanBuilds(t *testing.T) {
+	// setup types
+	_buildOne := testBuild()
+	_buildOne.SetID(1)
+	_buildOne.SetRepoID(1)
+	_buildOne.SetNumber(1)
+	_buildOne.SetCreated(1)
+	_buildOne.SetStatus("pending")
+
+	_buildTwo := testBuild()
+	_buildTwo.SetID(2)
+	_buildTwo.SetRepoID(1)
+	_buildTwo.SetNumber(2)
+	_buildTwo.SetCreated(2)
+	_buildTwo.SetStatus("running")
+
+	// setup types
+	_buildThree := testBuild()
+	_buildThree.SetID(3)
+	_buildThree.SetRepoID(1)
+	_buildThree.SetNumber(3)
+	_buildThree.SetCreated(1)
+	_buildThree.SetStatus("success")
+
+	_buildFour := testBuild()
+	_buildFour.SetID(4)
+	_buildFour.SetRepoID(1)
+	_buildFour.SetNumber(4)
+	_buildFour.SetCreated(5)
+	_buildFour.SetStatus("running")
+
+	_postgres, _mock := testPostgres(t)
+	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
+
+	// ensure the mock expects the name query
+	_mock.ExpectExec(`UPDATE "builds" SET "status"=$1,"error"=$2,"deploy_payload"=$3 WHERE created < $4 AND (status = 'running' OR status = 'pending')`).
+		WithArgs("error", "msg", AnyArgument{}, 3).
+		WillReturnResult(sqlmock.NewResult(1, 2))
+
+	_sqlite := testSqlite(t)
+	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
+
+	err := _sqlite.CreateBuild(_buildOne)
+	if err != nil {
+		t.Errorf("unable to create test build for sqlite: %v", err)
+	}
+
+	err = _sqlite.CreateBuild(_buildTwo)
+	if err != nil {
+		t.Errorf("unable to create test build for sqlite: %v", err)
+	}
+
+	err = _sqlite.CreateBuild(_buildThree)
+	if err != nil {
+		t.Errorf("unable to create test build for sqlite: %v", err)
+	}
+
+	err = _sqlite.CreateBuild(_buildFour)
+	if err != nil {
+		t.Errorf("unable to create test build for sqlite: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure  bool
+		name     string
+		database *engine
+		want     int64
+	}{
+		{
+			failure:  false,
+			name:     "postgres",
+			database: _postgres,
+			want:     2,
+		},
+		{
+			failure:  false,
+			name:     "sqlite3",
+			database: _sqlite,
+			want:     2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.database.CleanBuilds("msg", 3)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("CleanBuilds for %s should have returned err", test.name)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("CleanBuilds for %s returned err: %v", test.name, err)
+			}
+
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("CleanBuilds for %s is %v, want %v", test.name, got, test.want)
+			}
+		})
+	}
+}

--- a/database/build/clean_test.go
+++ b/database/build/clean_test.go
@@ -7,6 +7,7 @@ package build
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 )
@@ -46,8 +47,8 @@ func TestBuild_Engine_CleanBuilds(t *testing.T) {
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the name query
-	_mock.ExpectExec(`UPDATE "builds" SET "status"=$1,"error"=$2,"deploy_payload"=$3 WHERE created < $4 AND (status = 'running' OR status = 'pending')`).
-		WithArgs("error", "msg", AnyArgument{}, 3).
+	_mock.ExpectExec(`UPDATE "builds" SET "status"=$1,"error"=$2,"finished"=$3,"deploy_payload"=$4 WHERE created < $5 AND (status = 'running' OR status = 'pending')`).
+		WithArgs("error", "msg", time.Now().UTC().Unix(), AnyArgument{}, 3).
 		WillReturnResult(sqlmock.NewResult(1, 2))
 
 	_sqlite := testSqlite(t)

--- a/database/build/interface.go
+++ b/database/build/interface.go
@@ -26,6 +26,8 @@ type BuildInterface interface {
 	//
 	// https://en.wikipedia.org/wiki/Data_manipulation_language
 
+	// CleanBuilds defines a function that sets pending or running builds to error created before a given time.
+	CleanBuilds(string, int64) (int64, error)
 	// CountBuilds defines a function that gets the count of all builds.
 	CountBuilds() (int64, error)
 	// CountBuildsForDeployment defines a function that gets the count of builds by deployment url.

--- a/database/service/clean.go
+++ b/database/service/clean.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package service
+
+import (
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+	"github.com/sirupsen/logrus"
+)
+
+// CleanServices updates services to an error with a created timestamp prior to a defined moment.
+func (e *engine) CleanServices(before int64) (int64, error) {
+	logrus.Tracef("cleaning pending or running steps in the database created prior to %d", before)
+
+	s := new(library.Service)
+	s.SetStatus(constants.StatusError)
+
+	service := database.ServiceFromLibrary(s)
+
+	// send query to the database
+	result := e.client.
+		Table(constants.TableService).
+		Where("created < ?", before).
+		Where("status = 'running' OR status = 'pending'").
+		Updates(service)
+
+	return result.RowsAffected, result.Error
+}

--- a/database/service/clean.go
+++ b/database/service/clean.go
@@ -5,6 +5,8 @@
 package service
 
 import (
+	"time"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -12,11 +14,13 @@ import (
 )
 
 // CleanServices updates services to an error with a created timestamp prior to a defined moment.
-func (e *engine) CleanServices(before int64) (int64, error) {
+func (e *engine) CleanServices(msg string, before int64) (int64, error) {
 	logrus.Tracef("cleaning pending or running steps in the database created prior to %d", before)
 
 	s := new(library.Service)
 	s.SetStatus(constants.StatusError)
+	s.SetError(msg)
+	s.SetFinished(time.Now().UTC().Unix())
 
 	service := database.ServiceFromLibrary(s)
 

--- a/database/service/clean_test.go
+++ b/database/service/clean_test.go
@@ -7,6 +7,7 @@ package service
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 )
@@ -57,8 +58,8 @@ func TestService_Engine_CleanService(t *testing.T) {
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the name query
-	_mock.ExpectExec(`UPDATE "services" SET "status"=$1 WHERE created < $2 AND (status = 'running' OR status = 'pending')`).
-		WithArgs("error", 3).
+	_mock.ExpectExec(`UPDATE "services" SET "status"=$1,"error"=$2,"finished"=$3 WHERE created < $4 AND (status = 'running' OR status = 'pending')`).
+		WithArgs("error", "msg", time.Now().UTC().Unix(), 3).
 		WillReturnResult(sqlmock.NewResult(1, 2))
 
 	_sqlite := testSqlite(t)
@@ -108,7 +109,7 @@ func TestService_Engine_CleanService(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CleanServices(3)
+			got, err := test.database.CleanServices("msg", 3)
 
 			if test.failure {
 				if err == nil {

--- a/database/service/clean_test.go
+++ b/database/service/clean_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package service
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestService_Engine_CleanService(t *testing.T) {
+	// setup types
+	_serviceOne := testService()
+	_serviceOne.SetID(1)
+	_serviceOne.SetRepoID(1)
+	_serviceOne.SetBuildID(1)
+	_serviceOne.SetNumber(1)
+	_serviceOne.SetName("foo")
+	_serviceOne.SetImage("bar")
+	_serviceOne.SetCreated(1)
+	_serviceOne.SetStatus("running")
+
+	_serviceTwo := testService()
+	_serviceTwo.SetID(2)
+	_serviceTwo.SetRepoID(1)
+	_serviceTwo.SetBuildID(1)
+	_serviceTwo.SetNumber(2)
+	_serviceTwo.SetName("foo")
+	_serviceTwo.SetImage("bar")
+	_serviceTwo.SetCreated(1)
+	_serviceTwo.SetStatus("pending")
+
+	_serviceThree := testService()
+	_serviceThree.SetID(3)
+	_serviceThree.SetRepoID(1)
+	_serviceThree.SetBuildID(1)
+	_serviceThree.SetNumber(3)
+	_serviceThree.SetName("foo")
+	_serviceThree.SetImage("bar")
+	_serviceThree.SetCreated(1)
+	_serviceThree.SetStatus("success")
+
+	_serviceFour := testService()
+	_serviceFour.SetID(4)
+	_serviceFour.SetRepoID(1)
+	_serviceFour.SetBuildID(1)
+	_serviceFour.SetNumber(4)
+	_serviceFour.SetName("foo")
+	_serviceFour.SetImage("bar")
+	_serviceFour.SetCreated(5)
+	_serviceFour.SetStatus("pending")
+
+	_postgres, _mock := testPostgres(t)
+	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
+
+	// ensure the mock expects the name query
+	_mock.ExpectExec(`UPDATE "services" SET "status"=$1 WHERE created < $2 AND (status = 'running' OR status = 'pending')`).
+		WithArgs("error", 3).
+		WillReturnResult(sqlmock.NewResult(1, 2))
+
+	_sqlite := testSqlite(t)
+	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
+
+	err := _sqlite.CreateService(_serviceOne)
+	if err != nil {
+		t.Errorf("unable to create test service for sqlite: %v", err)
+	}
+
+	err = _sqlite.CreateService(_serviceTwo)
+	if err != nil {
+		t.Errorf("unable to create test service for sqlite: %v", err)
+	}
+
+	err = _sqlite.CreateService(_serviceThree)
+	if err != nil {
+		t.Errorf("unable to create test service for sqlite: %v", err)
+	}
+
+	err = _sqlite.CreateService(_serviceFour)
+	if err != nil {
+		t.Errorf("unable to create test service for sqlite: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure  bool
+		name     string
+		database *engine
+		want     int64
+	}{
+		{
+			failure:  false,
+			name:     "postgres",
+			database: _postgres,
+			want:     2,
+		},
+		{
+			failure:  false,
+			name:     "sqlite3",
+			database: _sqlite,
+			want:     2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.database.CleanServices(3)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("CleanServices for %s should have returned err", test.name)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("CleanServices for %s returned err: %v", test.name, err)
+			}
+
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("CleanServices for %s is %v, want %v", test.name, got, test.want)
+			}
+		})
+	}
+}

--- a/database/service/interface.go
+++ b/database/service/interface.go
@@ -24,6 +24,8 @@ type ServiceInterface interface {
 	//
 	// https://en.wikipedia.org/wiki/Data_manipulation_language
 
+	// CleanServices defines a function that sets running or pending services to error status before a given created time.
+	CleanServices(int64) (int64, error)
 	// CountServices defines a function that gets the count of all services.
 	CountServices() (int64, error)
 	// CountServicesForBuild defines a function that gets the count of services by build ID.

--- a/database/service/interface.go
+++ b/database/service/interface.go
@@ -25,7 +25,7 @@ type ServiceInterface interface {
 	// https://en.wikipedia.org/wiki/Data_manipulation_language
 
 	// CleanServices defines a function that sets running or pending services to error status before a given created time.
-	CleanServices(int64) (int64, error)
+	CleanServices(string, int64) (int64, error)
 	// CountServices defines a function that gets the count of all services.
 	CountServices() (int64, error)
 	// CountServicesForBuild defines a function that gets the count of services by build ID.

--- a/database/step/clean.go
+++ b/database/step/clean.go
@@ -5,6 +5,8 @@
 package step
 
 import (
+	"time"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -12,11 +14,13 @@ import (
 )
 
 // CleanSteps updates steps to an error with a created timestamp prior to a defined moment.
-func (e *engine) CleanSteps(before int64) (int64, error) {
+func (e *engine) CleanSteps(msg string, before int64) (int64, error) {
 	logrus.Tracef("cleaning pending or running steps in the database created prior to %d", before)
 
 	s := new(library.Step)
 	s.SetStatus(constants.StatusError)
+	s.SetError(msg)
+	s.SetFinished(time.Now().UTC().Unix())
 
 	step := database.StepFromLibrary(s)
 

--- a/database/step/clean.go
+++ b/database/step/clean.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package step
+
+import (
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+	"github.com/sirupsen/logrus"
+)
+
+// CleanSteps updates steps to an error with a created timestamp prior to a defined moment.
+func (e *engine) CleanSteps(before int64) (int64, error) {
+	logrus.Tracef("cleaning pending or running steps in the database created prior to %d", before)
+
+	s := new(library.Step)
+	s.SetStatus(constants.StatusError)
+
+	step := database.StepFromLibrary(s)
+
+	// send query to the database
+	result := e.client.
+		Table(constants.TableStep).
+		Where("created < ?", before).
+		Where("status = 'running' OR status = 'pending'").
+		Updates(step)
+
+	return result.RowsAffected, result.Error
+}

--- a/database/step/clean_test.go
+++ b/database/step/clean_test.go
@@ -7,6 +7,7 @@ package step
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 )
@@ -57,8 +58,8 @@ func TestStep_Engine_CleanStep(t *testing.T) {
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the name query
-	_mock.ExpectExec(`UPDATE "steps" SET "status"=$1 WHERE created < $2 AND (status = 'running' OR status = 'pending')`).
-		WithArgs("error", 3).
+	_mock.ExpectExec(`UPDATE "steps" SET "status"=$1,"error"=$2,"finished"=$3 WHERE created < $4 AND (status = 'running' OR status = 'pending')`).
+		WithArgs("error", "msg", time.Now().UTC().Unix(), 3).
 		WillReturnResult(sqlmock.NewResult(1, 2))
 
 	_sqlite := testSqlite(t)
@@ -108,7 +109,7 @@ func TestStep_Engine_CleanStep(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CleanSteps(3)
+			got, err := test.database.CleanSteps("msg", 3)
 
 			if test.failure {
 				if err == nil {

--- a/database/step/clean_test.go
+++ b/database/step/clean_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package step
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestStep_Engine_CleanStep(t *testing.T) {
+	// setup types
+	_stepOne := testStep()
+	_stepOne.SetID(1)
+	_stepOne.SetRepoID(1)
+	_stepOne.SetBuildID(1)
+	_stepOne.SetNumber(1)
+	_stepOne.SetName("foo")
+	_stepOne.SetImage("bar")
+	_stepOne.SetCreated(1)
+	_stepOne.SetStatus("running")
+
+	_stepTwo := testStep()
+	_stepTwo.SetID(2)
+	_stepTwo.SetRepoID(1)
+	_stepTwo.SetBuildID(1)
+	_stepTwo.SetNumber(2)
+	_stepTwo.SetName("foo")
+	_stepTwo.SetImage("bar")
+	_stepTwo.SetCreated(1)
+	_stepTwo.SetStatus("pending")
+
+	_stepThree := testStep()
+	_stepThree.SetID(3)
+	_stepThree.SetRepoID(1)
+	_stepThree.SetBuildID(1)
+	_stepThree.SetNumber(3)
+	_stepThree.SetName("foo")
+	_stepThree.SetImage("bar")
+	_stepThree.SetCreated(1)
+	_stepThree.SetStatus("success")
+
+	_stepFour := testStep()
+	_stepFour.SetID(4)
+	_stepFour.SetRepoID(1)
+	_stepFour.SetBuildID(1)
+	_stepFour.SetNumber(4)
+	_stepFour.SetName("foo")
+	_stepFour.SetImage("bar")
+	_stepFour.SetCreated(5)
+	_stepFour.SetStatus("pending")
+
+	_postgres, _mock := testPostgres(t)
+	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
+
+	// ensure the mock expects the name query
+	_mock.ExpectExec(`UPDATE "steps" SET "status"=$1 WHERE created < $2 AND (status = 'running' OR status = 'pending')`).
+		WithArgs("error", 3).
+		WillReturnResult(sqlmock.NewResult(1, 2))
+
+	_sqlite := testSqlite(t)
+	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
+
+	err := _sqlite.CreateStep(_stepOne)
+	if err != nil {
+		t.Errorf("unable to create test step for sqlite: %v", err)
+	}
+
+	err = _sqlite.CreateStep(_stepTwo)
+	if err != nil {
+		t.Errorf("unable to create test step for sqlite: %v", err)
+	}
+
+	err = _sqlite.CreateStep(_stepThree)
+	if err != nil {
+		t.Errorf("unable to create test step for sqlite: %v", err)
+	}
+
+	err = _sqlite.CreateStep(_stepFour)
+	if err != nil {
+		t.Errorf("unable to create test step for sqlite: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure  bool
+		name     string
+		database *engine
+		want     int64
+	}{
+		{
+			failure:  false,
+			name:     "postgres",
+			database: _postgres,
+			want:     2,
+		},
+		{
+			failure:  false,
+			name:     "sqlite3",
+			database: _sqlite,
+			want:     2,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.database.CleanSteps(3)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("CleanSteps for %s should have returned err", test.name)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("CleanSteps for %s returned err: %v", test.name, err)
+			}
+
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("CleanSteps for %s is %v, want %v", test.name, got, test.want)
+			}
+		})
+	}
+}

--- a/database/step/interface.go
+++ b/database/step/interface.go
@@ -25,7 +25,7 @@ type StepInterface interface {
 	// https://en.wikipedia.org/wiki/Data_manipulation_language
 
 	// CleanSteps defines a function that sets running or pending steps to error status before a given created time.
-	CleanSteps(int64) (int64, error)
+	CleanSteps(string, int64) (int64, error)
 	// CountSteps defines a function that gets the count of all steps.
 	CountSteps() (int64, error)
 	// CountStepsForBuild defines a function that gets the count of steps by build ID.

--- a/database/step/interface.go
+++ b/database/step/interface.go
@@ -24,6 +24,8 @@ type StepInterface interface {
 	//
 	// https://en.wikipedia.org/wiki/Data_manipulation_language
 
+	// CleanSteps defines a function that sets running or pending steps to error status before a given created time.
+	CleanSteps(int64) (int64, error)
 	// CountSteps defines a function that gets the count of all steps.
 	CountSteps() (int64, error)
 	// CountStepsForBuild defines a function that gets the count of steps by build ID.

--- a/mock/server/build.go
+++ b/mock/server/build.go
@@ -345,7 +345,7 @@ func buildToken(c *gin.Context) {
 // Pass "0" to :before to test receiving a http 500 response. Pass "1" to :before
 // to test receiving a http 401 response.
 func cleanResoures(c *gin.Context) {
-	before := c.DefaultQuery("before", "42")
+	before := c.Query("before")
 
 	if strings.EqualFold(before, "0") {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, "")

--- a/mock/server/build.go
+++ b/mock/server/build.go
@@ -149,6 +149,8 @@ const (
 	BuildTokenResp = `{
     "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJidWlsZF9pZCI6MSwicmVwbyI6ImZvby9iYXIiLCJzdWIiOiJPY3RvY2F0IiwiaWF0IjoxNTE2MjM5MDIyfQ.hD7gXpaf9acnLBdOBa4GOEa5KZxdzd0ZvK6fGwaN4bc"
   }`
+
+	CleanResourcesResp = "42 builds cleaned. 42 services cleaned. 42 steps cleaned."
 )
 
 // getBuilds returns mock JSON for a http GET.
@@ -336,4 +338,24 @@ func buildToken(c *gin.Context) {
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
+}
+
+// cleanResources has a query param :before returns mock JSON for a http PUT
+//
+// Pass "0" to :before to test receiving a http 500 response. Pass "1" to :before
+// to test receiving a http 401 response.
+func cleanResoures(c *gin.Context) {
+	before := c.DefaultQuery("before", "42")
+
+	if strings.EqualFold(before, "0") {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, "")
+
+		return
+	}
+
+	if strings.EqualFold(before, "1") {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, "")
+	}
+
+	c.JSON(http.StatusOK, CleanResourcesResp)
 }

--- a/mock/server/server.go
+++ b/mock/server/server.go
@@ -30,6 +30,7 @@ func FakeHandler() http.Handler {
 	e.PUT("/api/v1/admin/step", updateStep)
 	e.PUT("/api/v1/admin/user", updateUser)
 	e.POST("/api/v1/admin/workers/:worker/register-token", registerToken)
+	e.PUT("api/v1/admin/clean", cleanResoures)
 
 	// mock endpoints for build calls
 	e.GET("/api/v1/repos/:org/:repo/builds/:build", getBuild)

--- a/router/admin.go
+++ b/router/admin.go
@@ -16,6 +16,7 @@ import (
 // GET    /api/v1/admin/builds/queue
 // GET    /api/v1/admin/build/:id
 // PUT    /api/v1/admin/build
+// PUT    /api/v1/admin/clean
 // PUT    /api/v1/admin/deployment
 // PUT    /api/v1/admin/hook
 // PUT    /api/v1/admin/repo
@@ -32,6 +33,9 @@ func AdminHandlers(base *gin.RouterGroup) {
 
 		// Admin build endpoint
 		_admin.PUT("/build", admin.UpdateBuild)
+
+		// Admin clean endpoint
+		_admin.PUT("/clean", admin.CleanResources)
 
 		// Admin deployment endpoint
 		_admin.PUT("/deployment", admin.UpdateDeployment)


### PR DESCRIPTION
Oftentimes during upgrades, network blips, or failures in worker-server communication, builds, steps, and or services, never make it out of `pending` or `running` states. This endpoint gives platform admins the power to clean build resources that have been pending or running for longer than a specified time as well as give the builds a specified error message.