### PR TITLE
fix(mock): correct query param mocks

### DIFF
--- a/mock/server/build.go
+++ b/mock/server/build.go
@@ -342,18 +342,18 @@ func buildToken(c *gin.Context) {
 
 // cleanResources has a query param :before returns mock JSON for a http PUT
 //
-// Pass "0" to :before to test receiving a http 500 response. Pass "1" to :before
+// Pass "1" to :before to test receiving a http 500 response. Pass "2" to :before
 // to test receiving a http 401 response.
 func cleanResoures(c *gin.Context) {
 	before := c.Query("before")
 
-	if strings.EqualFold(before, "0") {
+	if strings.EqualFold(before, "1") {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, "")
 
 		return
 	}
 
-	if strings.EqualFold(before, "1") {
+	if strings.EqualFold(before, "2") {
 		c.AbortWithStatusJSON(http.StatusUnauthorized, "")
 	}
 


### PR DESCRIPTION
When trying to test a `0` for the query param, it won't add it to the url string [here](https://github.com/go-vela/sdk-go/blob/4c6fc715258ca3188897179b140672fd7bbf03a7/vela/client.go#L260-L264) where we build the query string in the SDK. This change makes sure the `500` response is actually testable. 