### PR TITLE
fix(schedules): increment repo counter after read

### DIFF
--- a/cmd/vela-server/schedule.go
+++ b/cmd/vela-server/schedule.go
@@ -233,10 +233,10 @@ func processSchedule(s *library.Schedule, compiler compiler.Engine, database dat
 		}
 
 		// set the build numbers based off repo counter
-		r.SetCounter(r.GetCounter() + 1)
 		b.SetNumber(r.GetCounter() + 1)
 		// set the parent equal to the current repo counter
 		b.SetParent(r.GetCounter())
+		r.SetCounter(r.GetCounter() + 1)
 		// check if the parent is set to 0
 		if b.GetParent() == 0 {
 			// parent should be "1" if it's the first build ran

--- a/cmd/vela-server/schedule.go
+++ b/cmd/vela-server/schedule.go
@@ -236,12 +236,12 @@ func processSchedule(s *library.Schedule, compiler compiler.Engine, database dat
 		b.SetNumber(r.GetCounter() + 1)
 		// set the parent equal to the current repo counter
 		b.SetParent(r.GetCounter())
-		r.SetCounter(r.GetCounter() + 1)
 		// check if the parent is set to 0
 		if b.GetParent() == 0 {
 			// parent should be "1" if it's the first build ran
 			b.SetParent(1)
 		}
+		r.SetCounter(r.GetCounter() + 1)
 
 		// set the build link if a web address is provided
 		if len(metadata.Vela.WebAddress) > 0 {


### PR DESCRIPTION
fixes a double-increment bug. scheduled builds get assigned counter+2 

if it helps, here's the webhook builds code https://github.com/go-vela/server/blob/main/api/webhook/post.go#L472-L484