### PR TITLE
enhance(log)!: do not return log object for POST and PUT requests

### DIFF
--- a/api/log/create_service.go
+++ b/api/log/create_service.go
@@ -61,8 +61,6 @@ import (
 // responses:
 //   '201':
 //     description: Successfully created the service logs
-//     schema:
-//       "$ref": "#/definitions/Log"
 //   '400':
 //     description: Unable to create the service logs
 //     schema:
@@ -113,7 +111,7 @@ func CreateServiceLog(c *gin.Context) {
 	input.SetRepoID(r.GetID())
 
 	// send API call to create the logs
-	l, err := database.FromContext(c).CreateLog(input)
+	err = database.FromContext(c).CreateLog(input)
 	if err != nil {
 		retErr := fmt.Errorf("unable to create logs for service %s: %w", entry, err)
 
@@ -122,5 +120,5 @@ func CreateServiceLog(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusCreated, l)
+	c.JSON(http.StatusCreated, nil)
 }

--- a/api/log/create_step.go
+++ b/api/log/create_step.go
@@ -61,8 +61,6 @@ import (
 // responses:
 //   '201':
 //     description: Successfully created the logs for step
-//     schema:
-//       "$ref": "#/definitions/Log"
 //   '400':
 //     description: Unable to create the logs for a step
 //     schema:
@@ -113,7 +111,7 @@ func CreateStepLog(c *gin.Context) {
 	input.SetRepoID(r.GetID())
 
 	// send API call to create the logs
-	l, err := database.FromContext(c).CreateLog(input)
+	err = database.FromContext(c).CreateLog(input)
 	if err != nil {
 		retErr := fmt.Errorf("unable to create logs for step %s: %w", entry, err)
 
@@ -122,5 +120,5 @@ func CreateStepLog(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusCreated, l)
+	c.JSON(http.StatusCreated, nil)
 }

--- a/api/log/update_service.go
+++ b/api/log/update_service.go
@@ -124,7 +124,7 @@ func UpdateServiceLog(c *gin.Context) {
 	}
 
 	// send API call to update the log
-	l, err = database.FromContext(c).UpdateLog(l)
+	err = database.FromContext(c).UpdateLog(l)
 	if err != nil {
 		retErr := fmt.Errorf("unable to update logs for service %s: %w", entry, err)
 
@@ -133,5 +133,5 @@ func UpdateServiceLog(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, l)
+	c.JSON(http.StatusOK, nil)
 }

--- a/api/log/update_step.go
+++ b/api/log/update_step.go
@@ -124,7 +124,7 @@ func UpdateStepLog(c *gin.Context) {
 	}
 
 	// send API call to update the log
-	l, err = database.FromContext(c).UpdateLog(l)
+	err = database.FromContext(c).UpdateLog(l)
 	if err != nil {
 		retErr := fmt.Errorf("unable to update logs for step %s: %w", entry, err)
 
@@ -133,5 +133,5 @@ func UpdateStepLog(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, l)
+	c.JSON(http.StatusOK, nil)
 }

--- a/api/service/plan.go
+++ b/api/service/plan.go
@@ -61,7 +61,7 @@ func PlanServices(database database.Interface, p *pipeline.Build, b *library.Bui
 		l.SetData([]byte{})
 
 		// send API call to create the service logs
-		_, err = database.CreateLog(l)
+		err = database.CreateLog(l)
 		if err != nil {
 			return services, fmt.Errorf("unable to create service logs for service %s: %w", s.GetName(), err)
 		}

--- a/api/step/plan.go
+++ b/api/step/plan.go
@@ -88,7 +88,7 @@ func planStep(database database.Interface, b *library.Build, c *pipeline.Contain
 	l.SetData([]byte{})
 
 	// send API call to create the step logs
-	_, err = database.CreateLog(l)
+	err = database.CreateLog(l)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create logs for step %s: %w", s.GetName(), err)
 	}

--- a/database/log/count_build_test.go
+++ b/database/log/count_build_test.go
@@ -43,12 +43,12 @@ func TestLog_Engine_CountLogsForBuild(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateLog(_service)
+	err := _sqlite.CreateLog(_service)
 	if err != nil {
 		t.Errorf("unable to create test service log for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateLog(_step)
+	err = _sqlite.CreateLog(_step)
 	if err != nil {
 		t.Errorf("unable to create test step log for sqlite: %v", err)
 	}

--- a/database/log/count_test.go
+++ b/database/log/count_test.go
@@ -37,12 +37,12 @@ func TestLog_Engine_CountLogs(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateLog(_service)
+	err := _sqlite.CreateLog(_service)
 	if err != nil {
 		t.Errorf("unable to create test service log for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateLog(_step)
+	err = _sqlite.CreateLog(_step)
 	if err != nil {
 		t.Errorf("unable to create test step log for sqlite: %v", err)
 	}

--- a/database/log/create.go
+++ b/database/log/create.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CreateLog creates a new log in the database.
-func (e *engine) CreateLog(l *library.Log) (*library.Log, error) {
+func (e *engine) CreateLog(l *library.Log) error {
 	// check what the log entry is for
 	switch {
 	case l.GetServiceID() > 0:
@@ -33,7 +33,7 @@ func (e *engine) CreateLog(l *library.Log) (*library.Log, error) {
 	// https://pkg.go.dev/github.com/go-vela/types/database#Log.Validate
 	err := log.Validate()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// compress log data for the resource
@@ -43,14 +43,15 @@ func (e *engine) CreateLog(l *library.Log) (*library.Log, error) {
 	if err != nil {
 		switch {
 		case l.GetServiceID() > 0:
-			return nil, fmt.Errorf("unable to compress log for service %d for build %d: %w", l.GetServiceID(), l.GetBuildID(), err)
+			return fmt.Errorf("unable to compress log for service %d for build %d: %w", l.GetServiceID(), l.GetBuildID(), err)
 		case l.GetStepID() > 0:
-			return nil, fmt.Errorf("unable to compress log for step %d for build %d: %w", l.GetStepID(), l.GetBuildID(), err)
+			return fmt.Errorf("unable to compress log for step %d for build %d: %w", l.GetStepID(), l.GetBuildID(), err)
 		}
 	}
 
 	// send query to the database
-	result := e.client.Table(constants.TableLog).Create(log)
-
-	return log.ToLibrary(), result.Error
+	return e.client.
+		Table(constants.TableLog).
+		Create(log).
+		Error
 }

--- a/database/log/create_test.go
+++ b/database/log/create_test.go
@@ -73,7 +73,7 @@ VALUES ($1,$2,$3,$4,$5,$6) RETURNING "id"`).
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			for _, log := range test.logs {
-				_, err := test.database.CreateLog(log)
+				err := test.database.CreateLog(log)
 
 				if test.failure {
 					if err == nil {

--- a/database/log/delete_test.go
+++ b/database/log/delete_test.go
@@ -29,7 +29,7 @@ func TestLog_Engine_DeleteLog(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateLog(_log)
+	err := _sqlite.CreateLog(_log)
 	if err != nil {
 		t.Errorf("unable to create test log for sqlite: %v", err)
 	}

--- a/database/log/get_service_test.go
+++ b/database/log/get_service_test.go
@@ -42,7 +42,7 @@ func TestLog_Engine_GetLogForService(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateLog(_log)
+	err := _sqlite.CreateLog(_log)
 	if err != nil {
 		t.Errorf("unable to create test log for sqlite: %v", err)
 	}

--- a/database/log/get_step_test.go
+++ b/database/log/get_step_test.go
@@ -42,7 +42,7 @@ func TestLog_Engine_GetLogForStep(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateLog(_log)
+	err := _sqlite.CreateLog(_log)
 	if err != nil {
 		t.Errorf("unable to create test log for sqlite: %v", err)
 	}

--- a/database/log/get_test.go
+++ b/database/log/get_test.go
@@ -35,7 +35,7 @@ func TestLog_Engine_GetLog(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateLog(_log)
+	err := _sqlite.CreateLog(_log)
 	if err != nil {
 		t.Errorf("unable to create test log for sqlite: %v", err)
 	}

--- a/database/log/interface.go
+++ b/database/log/interface.go
@@ -31,7 +31,7 @@ type LogInterface interface {
 	// CountLogsForBuild defines a function that gets the count of logs by build ID.
 	CountLogsForBuild(*library.Build) (int64, error)
 	// CreateLog defines a function that creates a new log.
-	CreateLog(*library.Log) (*library.Log, error)
+	CreateLog(*library.Log) error
 	// DeleteLog defines a function that deletes an existing log.
 	DeleteLog(*library.Log) error
 	// GetLog defines a function that gets a log by ID.
@@ -45,5 +45,5 @@ type LogInterface interface {
 	// ListLogsForBuild defines a function that gets a list of logs by build ID.
 	ListLogsForBuild(*library.Build, int, int) ([]*library.Log, int64, error)
 	// UpdateLog defines a function that updates an existing log.
-	UpdateLog(*library.Log) (*library.Log, error)
+	UpdateLog(*library.Log) error
 }

--- a/database/log/list_build_test.go
+++ b/database/log/list_build_test.go
@@ -54,12 +54,12 @@ func TestLog_Engine_ListLogsForBuild(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateLog(_service)
+	err := _sqlite.CreateLog(_service)
 	if err != nil {
 		t.Errorf("unable to create test service log for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateLog(_step)
+	err = _sqlite.CreateLog(_step)
 	if err != nil {
 		t.Errorf("unable to create test step log for sqlite: %v", err)
 	}

--- a/database/log/list_test.go
+++ b/database/log/list_test.go
@@ -48,12 +48,12 @@ func TestLog_Engine_ListLogs(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateLog(_service)
+	err := _sqlite.CreateLog(_service)
 	if err != nil {
 		t.Errorf("unable to create test service log for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateLog(_step)
+	err = _sqlite.CreateLog(_step)
 	if err != nil {
 		t.Errorf("unable to create test step log for sqlite: %v", err)
 	}

--- a/database/log/update.go
+++ b/database/log/update.go
@@ -14,7 +14,7 @@ import (
 )
 
 // UpdateLog updates an existing log in the database.
-func (e *engine) UpdateLog(l *library.Log) (*library.Log, error) {
+func (e *engine) UpdateLog(l *library.Log) error {
 	// check what the log entry is for
 	switch {
 	case l.GetServiceID() > 0:
@@ -33,7 +33,7 @@ func (e *engine) UpdateLog(l *library.Log) (*library.Log, error) {
 	// https://pkg.go.dev/github.com/go-vela/types/database#Log.Validate
 	err := log.Validate()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// compress log data for the resource
@@ -43,14 +43,15 @@ func (e *engine) UpdateLog(l *library.Log) (*library.Log, error) {
 	if err != nil {
 		switch {
 		case l.GetServiceID() > 0:
-			return nil, fmt.Errorf("unable to compress log for service %d for build %d: %w", l.GetServiceID(), l.GetBuildID(), err)
+			return fmt.Errorf("unable to compress log for service %d for build %d: %w", l.GetServiceID(), l.GetBuildID(), err)
 		case l.GetStepID() > 0:
-			return nil, fmt.Errorf("unable to compress log for step %d for build %d: %w", l.GetStepID(), l.GetBuildID(), err)
+			return fmt.Errorf("unable to compress log for step %d for build %d: %w", l.GetStepID(), l.GetBuildID(), err)
 		}
 	}
 
 	// send query to the database
-	result := e.client.Table(constants.TableLog).Save(log)
-
-	return log.ToLibrary(), result.Error
+	return e.client.
+		Table(constants.TableLog).
+		Save(log).
+		Error
 }

--- a/database/log/update_test.go
+++ b/database/log/update_test.go
@@ -47,12 +47,12 @@ WHERE "id" = $6`).
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateLog(_service)
+	err := _sqlite.CreateLog(_service)
 	if err != nil {
 		t.Errorf("unable to create test service log for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateLog(_step)
+	err = _sqlite.CreateLog(_step)
 	if err != nil {
 		t.Errorf("unable to create test step log for sqlite: %v", err)
 	}
@@ -82,7 +82,7 @@ WHERE "id" = $6`).
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			for _, log := range test.logs {
-				_, err = test.database.UpdateLog(log)
+				err = test.database.UpdateLog(log)
 
 				if test.failure {
 					if err == nil {

--- a/mock/server/log.go
+++ b/mock/server/log.go
@@ -51,12 +51,7 @@ func getServiceLog(c *gin.Context) {
 
 // addServiceLog returns mock JSON for a http GET.
 func addServiceLog(c *gin.Context) {
-	data := []byte(LogResp)
-
-	var body library.Log
-	_ = json.Unmarshal(data, &body)
-
-	c.JSON(http.StatusCreated, body)
+	c.JSON(http.StatusCreated, nil)
 }
 
 // updateServiceLog has a param :service returns mock JSON for a http PUT.
@@ -73,12 +68,7 @@ func updateServiceLog(c *gin.Context) {
 		return
 	}
 
-	data := []byte(LogResp)
-
-	var body library.Log
-	_ = json.Unmarshal(data, &body)
-
-	c.JSON(http.StatusOK, body)
+	c.JSON(http.StatusOK, nil)
 }
 
 // removeServiceLog has a param :service returns mock JSON for a http DELETE.
@@ -122,12 +112,7 @@ func getStepLog(c *gin.Context) {
 
 // addStepLog returns mock JSON for a http GET.
 func addStepLog(c *gin.Context) {
-	data := []byte(LogResp)
-
-	var body library.Log
-	_ = json.Unmarshal(data, &body)
-
-	c.JSON(http.StatusCreated, body)
+	c.JSON(http.StatusCreated, nil)
 }
 
 // updateStepLog has a param :step returns mock JSON for a http PUT.
@@ -144,12 +129,7 @@ func updateStepLog(c *gin.Context) {
 		return
 	}
 
-	data := []byte(LogResp)
-
-	var body library.Log
-	_ = json.Unmarshal(data, &body)
-
-	c.JSON(http.StatusOK, body)
+	c.JSON(http.StatusOK, nil)
 }
 
 // removeStepLog has a param :step returns mock JSON for a http DELETE.


### PR DESCRIPTION
Sort of a revert of https://github.com/go-vela/server/pull/865 but this PR goes further and simply does not bother returning the log object on a successful `POST` or `PUT`.

I did a little bit of research on general HTTP practices, and it appears that this question of returning data on `200` and `201` codes is pretty much context-driven. Given that `CreateStepLog` + `CreateServiceLog` arguably shouldn't exist for user access and `UpdateStepLog` + `UpdateServiceLog` are locked behind worker permissions / platform admins, I think it's safe to say continuously returning the database object is not worth the overhead. 

The [only logic that utilizes this returned value](https://github.com/go-vela/worker/blob/0bac3d636f4bb0a35ea5b2b020d6d0d7db6343f0/executor/linux/step.go#L326-L331) in the entire codebase is a max-log-size check which can be performed with the in-memory `_log` value that is appended every second.

Merging this PR would result in downstream changes to the sdk-go, worker, and CLI