### PR TITLE
fix(schedules): updated_at automatically updates to any change to row

### DIFF
--- a/api/schedule/create.go
+++ b/api/schedule/create.go
@@ -170,7 +170,7 @@ func CreateSchedule(c *gin.Context) {
 		dbSchedule.SetActive(true)
 
 		// send API call to update the schedule
-		err = database.FromContext(c).UpdateSchedule(dbSchedule)
+		err = database.FromContext(c).UpdateSchedule(dbSchedule, true)
 		if err != nil {
 			retErr := fmt.Errorf("unable to set schedule %s to active: %w", dbSchedule.GetName(), err)
 

--- a/api/schedule/update.go
+++ b/api/schedule/update.go
@@ -123,7 +123,7 @@ func UpdateSchedule(c *gin.Context) {
 	}
 
 	// update the schedule within the database
-	err = database.FromContext(c).UpdateSchedule(s)
+	err = database.FromContext(c).UpdateSchedule(s, true)
 	if err != nil {
 		retErr := fmt.Errorf("unable to update scheduled %s: %w", scheduleName, err)
 

--- a/cmd/vela-server/schedule.go
+++ b/cmd/vela-server/schedule.go
@@ -350,7 +350,7 @@ func processSchedule(s *library.Schedule, compiler compiler.Engine, database dat
 	}
 
 	// send API call to update schedule for ensuring scheduled_at field is set
-	err = database.UpdateSchedule(s)
+	err = database.UpdateSchedule(s, false)
 	if err != nil {
 		return fmt.Errorf("unable to update schedule %s/%s: %w", r.GetFullName(), s.GetName(), err)
 	}

--- a/database/schedule/interface.go
+++ b/database/schedule/interface.go
@@ -45,5 +45,5 @@ type ScheduleInterface interface {
 	// ListSchedulesForRepo defines a function that gets a list of schedules by repo ID.
 	ListSchedulesForRepo(*library.Repo, int, int) ([]*library.Schedule, int64, error)
 	// UpdateSchedule defines a function that updates an existing schedule.
-	UpdateSchedule(*library.Schedule) error
+	UpdateSchedule(*library.Schedule, bool) error
 }

--- a/database/schedule/update.go
+++ b/database/schedule/update.go
@@ -27,6 +27,9 @@ func (e *engine) UpdateSchedule(s *library.Schedule, fields bool) error {
 	}
 
 	// If "fields" is true, update entire record; otherwise, just update scheduled_at (part of processSchedule)
+	//
+	// we do this because Gorm will automatically set `updated_at` with the Save function
+	// and the `updated_at` field should reflect the last time a user updated the record, rather than the scheduler
 	if fields {
 		err = e.client.Table(constants.TableSchedule).Save(schedule).Error
 	} else {

--- a/database/schedule/update.go
+++ b/database/schedule/update.go
@@ -2,7 +2,6 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
-//nolint:dupl // ignore similar code with create.go
 package schedule
 
 import (
@@ -13,7 +12,7 @@ import (
 )
 
 // UpdateSchedule updates an existing schedule in the database.
-func (e *engine) UpdateSchedule(s *library.Schedule, config bool) error {
+func (e *engine) UpdateSchedule(s *library.Schedule, fields bool) error {
 	e.logger.WithFields(logrus.Fields{
 		"schedule": s.GetName(),
 	}).Tracef("updating schedule %s in the database", s.GetName())
@@ -27,8 +26,8 @@ func (e *engine) UpdateSchedule(s *library.Schedule, config bool) error {
 		return err
 	}
 
-	// if update is just setting the scheduled_at, then ignore updating other fields
-	if config {
+	// If "fields" is true, update entire record; otherwise, just update scheduled_at (part of processSchedule)
+	if fields {
 		err = e.client.Table(constants.TableSchedule).Save(schedule).Error
 	} else {
 		err = e.client.Table(constants.TableSchedule).Model(schedule).UpdateColumn("scheduled_at", s.GetScheduledAt()).Error

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       VELA_ENABLE_SECURE_COOKIE: 'false'
       VELA_REPO_ALLOWLIST: '*'
       VELA_SCHEDULE_ALLOWLIST: '*'
+      VELA_SCHEDULE_MINIMUM_FREQUENCY: 10m
     env_file:
       - .env
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,6 @@ services:
       VELA_ENABLE_SECURE_COOKIE: 'false'
       VELA_REPO_ALLOWLIST: '*'
       VELA_SCHEDULE_ALLOWLIST: '*'
-      VELA_SCHEDULE_MINIMUM_FREQUENCY: 10m
     env_file:
       - .env
     restart: always


### PR DESCRIPTION
Existing schedule:
```json
  {
    "id": 1,
    "repo_id": 1,
    "active": true,
    "name": "hourly",
    "entry": "0 * * * *",
    "created_at": 1641314085,
    "created_by": "octokitty",
    "updated_at": 1641314085,
    "updated_by": "octokitty",
    "scheduled_at": 0
  }
```

Old:
```go
s := existingSchedule
s.SetScheduledAt(now)
_ := db.UpdateSchedule(s)

s, _ := db.GetSchedule(existingSchedule)
fmt.Println(s.GetUpdatedAt())
// ... <now> ...
```

New:
```go
s := existingSchedule
s.SetScheduledAt(now)
_ := db.UpdateSchedule(s)

s, _ := db.GetSchedule(existingSchedule)
fmt.Println(s.GetUpdatedAt())
// ... 1641314085 ...
```

GORM auto updates `updated_at`. This change ensures that that field is still relevant.

RFC: separate DB function altogether, or will this boolean be fine?
