### PR TITLE
fix(api): support schedule in filter

### DIFF
--- a/api/build/list_org.go
+++ b/api/build/list_org.go
@@ -39,12 +39,12 @@ import (
 //   description: Filter by build event
 //   type: string
 //   enum:
-//   - push
-//   - pull_request
-//   - tag
-//   - deployment
 //   - comment
+//   - deployment
+//   - pull_request
+//   - push
 //   - schedule
+//   - tag
 // - in: query
 //   name: branch
 //   description: Filter builds by branch

--- a/api/build/list_org.go
+++ b/api/build/list_org.go
@@ -35,6 +35,33 @@ import (
 //   required: true
 //   type: string
 // - in: query
+//   name: event
+//   description: Filter by build event
+//   type: string
+//   enum:
+//   - push
+//   - pull_request
+//   - tag
+//   - deployment
+//   - comment
+//   - schedule
+// - in: query
+//   name: branch
+//   description: Filter builds by branch
+//   type: string
+// - in: query
+//   name: status
+//   description: Filter by build status
+//   type: string
+//   enum:
+//   - canceled
+//   - error
+//   - failure
+//   - killed
+//   - pending
+//   - running
+//   - success
+// - in: query
 //   name: page
 //   description: The page of results to retrieve
 //   type: integer
@@ -109,7 +136,7 @@ func ListBuildsForOrg(c *gin.Context) {
 		// verify the event provided is a valid event type
 		if event != constants.EventComment && event != constants.EventDeploy &&
 			event != constants.EventPush && event != constants.EventPull &&
-			event != constants.EventTag {
+			event != constants.EventTag && event != constants.EventSchedule {
 			retErr := fmt.Errorf("unable to process event %s: invalid event type provided", event)
 
 			util.HandleError(c, http.StatusBadRequest, retErr)

--- a/api/build/list_repo.go
+++ b/api/build/list_repo.go
@@ -50,6 +50,7 @@ import (
 //   - tag
 //   - deployment
 //   - comment
+//   - schedule
 // - in: query
 //   name: commit
 //   description: Filter builds based on the commit hash
@@ -159,7 +160,7 @@ func ListBuildsForRepo(c *gin.Context) {
 		// verify the event provided is a valid event type
 		if event != constants.EventComment && event != constants.EventDeploy &&
 			event != constants.EventPush && event != constants.EventPull &&
-			event != constants.EventTag {
+			event != constants.EventTag && event != constants.EventSchedule {
 			retErr := fmt.Errorf("unable to process event %s: invalid event type provided", event)
 
 			util.HandleError(c, http.StatusBadRequest, retErr)

--- a/api/build/list_repo.go
+++ b/api/build/list_repo.go
@@ -45,12 +45,12 @@ import (
 //   description: Filter by build event
 //   type: string
 //   enum:
-//   - push
-//   - pull_request
-//   - tag
-//   - deployment
 //   - comment
+//   - deployment
+//   - pull_request
+//   - push
 //   - schedule
+//   - tag
 // - in: query
 //   name: commit
 //   description: Filter builds based on the commit hash


### PR DESCRIPTION
adds "schedule" as an allowed event type for endpoints that accept event filter in query:
* /api/v1/repos/{org}/builds
* /api/v1/repos/{org}/{repo}/builds

also, adds missing query param filters to docs for `/api/v1/repos/{org}/builds`.