### PR TITLE
fix(api/schedule): make validateEntry more strict and set updated_by using claims

### DIFF
--- a/api/schedule/create.go
+++ b/api/schedule/create.go
@@ -209,21 +209,31 @@ func validateEntry(minimum time.Duration, entry string) error {
 		return fmt.Errorf("invalid entry of %s", entry)
 	}
 
-	// check the previous occurrence of the entry
-	prevTime, err := gronx.PrevTick(entry, true)
-	if err != nil {
-		return err
-	}
+	// iterate 5 times through ticks in an effort to catch scalene entries
+	tickForward := 5
 
-	// check the next occurrence of the entry
-	nextTime, err := gronx.NextTick(entry, true)
-	if err != nil {
-		return err
-	}
+	// start with now
+	t := time.Now().UTC()
 
-	// ensure the time between previous and next schedule exceeds the minimum duration
-	if nextTime.Sub(prevTime) < minimum {
-		return fmt.Errorf("entry needs to occur less frequently than every %s", minimum)
+	for i := 0; i < tickForward; i++ {
+		// check the previous occurrence of the entry
+		prevTime, err := gronx.PrevTickBefore(entry, t, true)
+		if err != nil {
+			return err
+		}
+
+		// check the next occurrence of the entry
+		nextTime, err := gronx.NextTickAfter(entry, t, false)
+		if err != nil {
+			return err
+		}
+
+		// ensure the time between previous and next schedule exceeds the minimum duration
+		if nextTime.Sub(prevTime) < minimum {
+			return fmt.Errorf("entry needs to occur less frequently than every %s", minimum)
+		}
+
+		t = nextTime
 	}
 
 	return nil

--- a/api/schedule/create_test.go
+++ b/api/schedule/create_test.go
@@ -36,6 +36,14 @@ func Test_validateEntry(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "exceeds minimum frequency with scalene entry pattern",
+			args: args{
+				minimum: 30 * time.Minute,
+				entry:   "1,2,45 * * * *",
+			},
+			wantErr: true,
+		},
+		{
 			name: "meets minimum frequency",
 			args: args{
 				minimum: 30 * time.Second,
@@ -48,6 +56,14 @@ func Test_validateEntry(t *testing.T) {
 			args: args{
 				minimum: 30 * time.Second,
 				entry:   "@hourly",
+			},
+			wantErr: false,
+		},
+		{
+			name: "meets minimum frequency with comma entry pattern",
+			args: args{
+				minimum: 15 * time.Minute,
+				entry:   "0,15,30,45 * * * *",
 			},
 			wantErr: false,
 		},

--- a/api/schedule/update.go
+++ b/api/schedule/update.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/repo"
 	"github.com/go-vela/server/router/middleware/schedule"
+	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/util"
 	"github.com/go-vela/types/library"
 	"github.com/sirupsen/logrus"
@@ -73,6 +74,7 @@ func UpdateSchedule(c *gin.Context) {
 	// capture middleware values
 	r := repo.Retrieve(c)
 	s := schedule.Retrieve(c)
+	u := user.Retrieve(c)
 	scheduleName := util.PathParameter(c, "schedule")
 	minimumFrequency := c.Value("scheduleminimumfrequency").(time.Duration)
 
@@ -121,6 +123,9 @@ func UpdateSchedule(c *gin.Context) {
 		// update entry if defined
 		s.SetEntry(input.GetEntry())
 	}
+
+	// set the updated by field using claims
+	s.SetUpdatedBy(u.GetName())
 
 	// update the schedule within the database
 	err = database.FromContext(c).UpdateSchedule(s, true)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       VELA_ENABLE_SECURE_COOKIE: 'false'
       VELA_REPO_ALLOWLIST: '*'
       VELA_SCHEDULE_ALLOWLIST: '*'
+      VELA_SCHEDULE_MINIMUM_FREQUENCY: 180m
     env_file:
       - .env
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,6 @@ services:
       VELA_ENABLE_SECURE_COOKIE: 'false'
       VELA_REPO_ALLOWLIST: '*'
       VELA_SCHEDULE_ALLOWLIST: '*'
-      VELA_SCHEDULE_MINIMUM_FREQUENCY: 180m
     env_file:
       - .env
     restart: always


### PR DESCRIPTION
Prior to this change, the entry `0 1,2,10,12 * * *` with a `VELA_SCHEDULE_MINIMUM_FREQUENCY` of `180m` would be considered valid if you added the schedule between the hours of 12:00 Zulu time and 1:00 Zulu time the next day.  Won't catch all cases, but I figured it would catch more than enough.

Also set `updated_by` in the update schedule endpoint.