### PR TITLE
fix(compiler): convert local templates to an engine field for nested templates

### DIFF
--- a/api/pipeline/compile.go
+++ b/api/pipeline/compile.go
@@ -97,7 +97,7 @@ func CompilePipeline(c *gin.Context) {
 	compiler := compiler.FromContext(c).Duplicate().WithCommit(p.GetCommit()).WithMetadata(m).WithRepo(r).WithUser(u)
 
 	// compile the pipeline
-	pipeline, _, err := compiler.CompileLite(p.GetData(), true, true, nil)
+	pipeline, _, err := compiler.CompileLite(p.GetData(), true, true)
 	if err != nil {
 		retErr := fmt.Errorf("unable to compile pipeline %s: %w", entry, err)
 

--- a/api/pipeline/expand.go
+++ b/api/pipeline/expand.go
@@ -98,7 +98,7 @@ func ExpandPipeline(c *gin.Context) {
 	compiler := compiler.FromContext(c).Duplicate().WithCommit(p.GetCommit()).WithMetadata(m).WithRepo(r).WithUser(u)
 
 	// expand the templates in the pipeline
-	pipeline, _, err := compiler.CompileLite(p.GetData(), true, false, nil)
+	pipeline, _, err := compiler.CompileLite(p.GetData(), true, false)
 	if err != nil {
 		retErr := fmt.Errorf("unable to expand pipeline %s: %w", entry, err)
 

--- a/api/pipeline/validate.go
+++ b/api/pipeline/validate.go
@@ -105,7 +105,7 @@ func ValidatePipeline(c *gin.Context) {
 	}
 
 	// validate the pipeline
-	pipeline, _, err := compiler.CompileLite(p.GetData(), template, false, nil)
+	pipeline, _, err := compiler.CompileLite(p.GetData(), template, false)
 	if err != nil {
 		retErr := fmt.Errorf("unable to validate pipeline %s: %w", entry, err)
 

--- a/compiler/engine.go
+++ b/compiler/engine.go
@@ -25,7 +25,7 @@ type Engine interface {
 	// CompileLite defines a function that produces an light executable
 	// representation of a pipeline from an object. This calls
 	// Parse internally to convert the object to a yaml configuration.
-	CompileLite(interface{}, bool, bool, []string) (*yaml.Build, *library.Pipeline, error)
+	CompileLite(interface{}, bool, bool) (*yaml.Build, *library.Pipeline, error)
 
 	// Duplicate defines a function that
 	// creates a clone of the Engine.
@@ -130,6 +130,9 @@ type Engine interface {
 	// WithLocal defines a function that sets
 	// the compiler local field in the Engine.
 	WithLocal(bool) Engine
+	// WithLocalTemplates defines a function that sets
+	// the compiler local templates field in the Engine.
+	WithLocalTemplates([]string) Engine
 	// WithMetadata defines a function that sets
 	// the compiler Metadata type in the Engine.
 	WithMetadata(*types.Metadata) Engine

--- a/compiler/native/compile_test.go
+++ b/compiler/native/compile_test.go
@@ -3422,7 +3422,7 @@ func Test_CompileLite(t *testing.T) {
 				t.Errorf("Reading yaml file return err: %v", err)
 			}
 
-			got, _, err := compiler.CompileLite(yaml, tt.args.template, tt.args.substitute, nil)
+			got, _, err := compiler.CompileLite(yaml, tt.args.template, tt.args.substitute)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CompileLite() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/compiler/native/native.go
+++ b/compiler/native/native.go
@@ -34,14 +34,15 @@ type client struct {
 	CloneImage          string
 	TemplateDepth       int
 
-	build    *library.Build
-	comment  string
-	commit   string
-	files    []string
-	local    bool
-	metadata *types.Metadata
-	repo     *library.Repo
-	user     *library.User
+	build          *library.Build
+	comment        string
+	commit         string
+	files          []string
+	local          bool
+	localTemplates []string
+	metadata       *types.Metadata
+	repo           *library.Repo
+	user           *library.User
 }
 
 // New returns a Pipeline implementation that integrates with the supported registries.
@@ -157,6 +158,13 @@ func (c *client) WithFiles(f []string) compiler.Engine {
 // WithLocal sets the compiler metadata type in the Engine.
 func (c *client) WithLocal(local bool) compiler.Engine {
 	c.local = local
+
+	return c
+}
+
+// WithLocalTemplates sets the compiler local templates in the Engine.
+func (c *client) WithLocalTemplates(templates []string) compiler.Engine {
+	c.localTemplates = templates
 
 	return c
 }

--- a/compiler/native/native_test.go
+++ b/compiler/native/native_test.go
@@ -202,6 +202,26 @@ func TestNative_WithLocal(t *testing.T) {
 	}
 }
 
+func TestNative_WithLocalTemplates(t *testing.T) {
+	// setup types
+	set := flag.NewFlagSet("test", 0)
+	c := cli.NewContext(nil, set, nil)
+
+	localTemplates := []string{"example:tmpl.yml", "exmpl:template.yml"}
+	want, _ := New(c)
+	want.localTemplates = []string{"example:tmpl.yml", "exmpl:template.yml"}
+
+	// run test
+	got, err := New(c)
+	if err != nil {
+		t.Errorf("Unable to create new compiler: %v", err)
+	}
+
+	if !reflect.DeepEqual(got.WithLocalTemplates(localTemplates), want) {
+		t.Errorf("WithLocalTemplates is %v, want %v", got, want)
+	}
+}
+
 func TestNative_WithMetadata(t *testing.T) {
 	// setup types
 	set := flag.NewFlagSet("test", 0)


### PR DESCRIPTION
When leveraging `vela validate pipeline --template --template-file exampleOne:one.yml,exampleTwo:two.yml` in a nested template sense (exampleTwo is called within exampleOne), the current implementation of local template retrieval can't handle that. 

By adding local templates to the engine itself, we can access the provided info at any time during compilation, allowing proper local retrieval deep within a template chain. 