### PR TITLE
chore: add context to build functions

### DIFF
--- a/api/admin/build.go
+++ b/api/admin/build.go
@@ -50,13 +50,16 @@ import (
 // AllBuildsQueue represents the API handler to
 // captures all running and pending builds stored in the database.
 func AllBuildsQueue(c *gin.Context) {
+	// capture middleware values
+	ctx := c.Request.Context()
+
 	logrus.Info("Admin: reading running and pending builds")
 
 	// default timestamp to 24 hours ago if user did not provide it as query parameter
 	after := c.DefaultQuery("after", strconv.FormatInt(time.Now().UTC().Add(-24*time.Hour).Unix(), 10))
 
 	// send API call to capture pending and running builds
-	b, err := database.FromContext(c).ListPendingAndRunningBuilds(after)
+	b, err := database.FromContext(c).ListPendingAndRunningBuilds(ctx, after)
 	if err != nil {
 		retErr := fmt.Errorf("unable to capture all running and pending builds: %w", err)
 
@@ -103,6 +106,9 @@ func AllBuildsQueue(c *gin.Context) {
 func UpdateBuild(c *gin.Context) {
 	logrus.Info("Admin: updating build in database")
 
+	// capture middleware values
+	ctx := c.Request.Context()
+
 	// capture body from API request
 	input := new(library.Build)
 
@@ -116,7 +122,7 @@ func UpdateBuild(c *gin.Context) {
 	}
 
 	// send API call to update the build
-	b, err := database.FromContext(c).UpdateBuild(input)
+	b, err := database.FromContext(c).UpdateBuild(ctx, input)
 	if err != nil {
 		retErr := fmt.Errorf("unable to update build %d: %w", input.GetID(), err)
 

--- a/api/admin/clean.go
+++ b/api/admin/clean.go
@@ -62,7 +62,10 @@ import (
 // CleanResources represents the API handler to
 // update any user stored in the database.
 func CleanResources(c *gin.Context) {
+	// capture middleware values
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
+
 	logrus.Infof("platform admin %s: updating pending resources in database", u.GetName())
 
 	// default error message
@@ -96,7 +99,7 @@ func CleanResources(c *gin.Context) {
 	}
 
 	// send API call to clean builds
-	builds, err := database.FromContext(c).CleanBuilds(msg, before)
+	builds, err := database.FromContext(c).CleanBuilds(ctx, msg, before)
 	if err != nil {
 		retErr := fmt.Errorf("unable to update builds: %w", err)
 

--- a/api/badge.go
+++ b/api/badge.go
@@ -46,6 +46,8 @@ func GetBadge(c *gin.Context) {
 	// capture middleware values
 	o := org.Retrieve(c)
 	r := repo.Retrieve(c)
+	ctx := c.Request.Context()
+
 	branch := util.QueryParameter(c, "branch", r.GetBranch())
 
 	// update engine logger with API metadata
@@ -57,7 +59,7 @@ func GetBadge(c *gin.Context) {
 	}).Infof("creating latest build badge for repo %s on branch %s", r.GetFullName(), branch)
 
 	// send API call to capture the last build for the repo and branch
-	b, err := database.FromContext(c).LastBuildForRepo(r, branch)
+	b, err := database.FromContext(c).LastBuildForRepo(ctx, r, branch)
 	if err != nil {
 		c.String(http.StatusOK, constants.BadgeUnknown)
 		return

--- a/api/build/cancel.go
+++ b/api/build/cancel.go
@@ -80,6 +80,7 @@ func CancelBuild(c *gin.Context) {
 	o := org.Retrieve(c)
 	r := repo.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%d", r.GetFullName(), b.GetNumber())
 
@@ -190,7 +191,7 @@ func CancelBuild(c *gin.Context) {
 	// update the status in the build table
 	b.SetStatus(constants.StatusCanceled)
 
-	b, err := database.FromContext(c).UpdateBuild(b)
+	b, err := database.FromContext(c).UpdateBuild(ctx, b)
 	if err != nil {
 		retErr := fmt.Errorf("unable to update status for build %s: %w", entry, err)
 		util.HandleError(c, http.StatusInternalServerError, retErr)

--- a/api/build/clean.go
+++ b/api/build/clean.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -18,14 +19,14 @@ import (
 // without execution. This will kill all resources,
 // like steps and services, for the build in the
 // configured backend.
-func CleanBuild(database database.Interface, b *library.Build, services []*library.Service, steps []*library.Step, e error) {
+func CleanBuild(ctx context.Context, database database.Interface, b *library.Build, services []*library.Service, steps []*library.Step, e error) {
 	// update fields in build object
 	b.SetError(fmt.Sprintf("unable to publish to queue: %s", e.Error()))
 	b.SetStatus(constants.StatusError)
 	b.SetFinished(time.Now().UTC().Unix())
 
 	// send API call to update the build
-	b, err := database.UpdateBuild(b)
+	b, err := database.UpdateBuild(ctx, b)
 	if err != nil {
 		logrus.Errorf("unable to kill build %d: %v", b.GetNumber(), err)
 	}

--- a/api/build/create.go
+++ b/api/build/create.go
@@ -85,6 +85,7 @@ func CreateBuild(c *gin.Context) {
 	o := org.Retrieve(c)
 	r := repo.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	// update engine logger with API metadata
 	//
@@ -137,7 +138,7 @@ func CreateBuild(c *gin.Context) {
 	}
 
 	// send API call to capture the number of pending or running builds for the repo
-	builds, err := database.FromContext(c).CountBuildsForRepo(r, filters)
+	builds, err := database.FromContext(c).CountBuildsForRepo(ctx, r, filters)
 	if err != nil {
 		retErr := fmt.Errorf("unable to create new build: unable to get count of builds for repo %s", r.GetFullName())
 
@@ -321,7 +322,7 @@ func CreateBuild(c *gin.Context) {
 	input.SetPipelineID(pipeline.GetID())
 
 	// create the objects from the pipeline in the database
-	err = PlanBuild(database.FromContext(c), p, input, r)
+	err = PlanBuild(ctx, database.FromContext(c), p, input, r)
 	if err != nil {
 		util.HandleError(c, http.StatusInternalServerError, err)
 
@@ -339,7 +340,7 @@ func CreateBuild(c *gin.Context) {
 	}
 
 	// send API call to capture the created build
-	input, _ = database.FromContext(c).GetBuildForRepo(r, input.GetNumber())
+	input, _ = database.FromContext(c).GetBuildForRepo(ctx, r, input.GetNumber())
 
 	c.JSON(http.StatusCreated, input)
 
@@ -351,6 +352,7 @@ func CreateBuild(c *gin.Context) {
 
 	// publish the build to the queue
 	go PublishToQueue(
+		ctx,
 		queue.FromGinContext(c),
 		database.FromContext(c),
 		p,

--- a/api/build/delete.go
+++ b/api/build/delete.go
@@ -65,6 +65,7 @@ func DeleteBuild(c *gin.Context) {
 	o := org.Retrieve(c)
 	r := repo.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%d", r.GetFullName(), b.GetNumber())
 
@@ -79,7 +80,7 @@ func DeleteBuild(c *gin.Context) {
 	}).Infof("deleting build %s", entry)
 
 	// send API call to remove the build
-	err := database.FromContext(c).DeleteBuild(b)
+	err := database.FromContext(c).DeleteBuild(ctx, b)
 	if err != nil {
 		retErr := fmt.Errorf("unable to delete build %s: %w", entry, err)
 

--- a/api/build/get_id.go
+++ b/api/build/get_id.go
@@ -58,6 +58,7 @@ func GetBuildByID(c *gin.Context) {
 
 	// Capture user from middleware
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	// Parse build ID from path
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
@@ -79,7 +80,7 @@ func GetBuildByID(c *gin.Context) {
 	}).Infof("reading build %d", id)
 
 	// Get build from database
-	b, err = database.FromContext(c).GetBuild(id)
+	b, err = database.FromContext(c).GetBuild(ctx, id)
 	if err != nil {
 		retErr := fmt.Errorf("unable to get build: %w", err)
 

--- a/api/build/list_org.go
+++ b/api/build/list_org.go
@@ -110,6 +110,7 @@ func ListBuildsForOrg(c *gin.Context) {
 	// capture middleware values
 	o := org.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	// update engine logger with API metadata
 	//
@@ -199,7 +200,7 @@ func ListBuildsForOrg(c *gin.Context) {
 	}
 
 	// send API call to capture the list of builds for the org (and event type if passed in)
-	b, t, err = database.FromContext(c).ListBuildsForOrg(o, filters, page, perPage)
+	b, t, err = database.FromContext(c).ListBuildsForOrg(ctx, o, filters, page, perPage)
 
 	if err != nil {
 		retErr := fmt.Errorf("unable to list builds for org %s: %w", o, err)

--- a/api/build/list_repo.go
+++ b/api/build/list_repo.go
@@ -131,6 +131,7 @@ func ListBuildsForRepo(c *gin.Context) {
 	o := org.Retrieve(c)
 	r := repo.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	// update engine logger with API metadata
 	//
@@ -238,7 +239,7 @@ func ListBuildsForRepo(c *gin.Context) {
 		return
 	}
 
-	b, t, err = database.FromContext(c).ListBuildsForRepo(r, filters, before, after, page, perPage)
+	b, t, err = database.FromContext(c).ListBuildsForRepo(ctx, r, filters, before, after, page, perPage)
 	if err != nil {
 		retErr := fmt.Errorf("unable to list builds for repo %s: %w", r.GetFullName(), err)
 

--- a/api/build/plan.go
+++ b/api/build/plan.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -20,13 +21,13 @@ import (
 // and services, for the build in the configured backend.
 // TODO:
 // - return build and error.
-func PlanBuild(database database.Interface, p *pipeline.Build, b *library.Build, r *library.Repo) error {
+func PlanBuild(ctx context.Context, database database.Interface, p *pipeline.Build, b *library.Build, r *library.Repo) error {
 	// update fields in build object
 	b.SetCreated(time.Now().UTC().Unix())
 
 	// send API call to create the build
 	// TODO: return created build and error instead of just error
-	b, err := database.CreateBuild(b)
+	b, err := database.CreateBuild(ctx, b)
 	if err != nil {
 		// clean up the objects from the pipeline in the database
 		// TODO:
@@ -35,7 +36,7 @@ func PlanBuild(database database.Interface, p *pipeline.Build, b *library.Build,
 		//   of UPDATE-ing the existing build - which results in
 		//   a constraint error (repo_id, number)
 		// - do we want to update the build or just delete it?
-		CleanBuild(database, b, nil, nil, err)
+		CleanBuild(ctx, database, b, nil, nil, err)
 
 		return fmt.Errorf("unable to create new build for %s: %w", r.GetFullName(), err)
 	}
@@ -44,7 +45,7 @@ func PlanBuild(database database.Interface, p *pipeline.Build, b *library.Build,
 	services, err := service.PlanServices(database, p, b)
 	if err != nil {
 		// clean up the objects from the pipeline in the database
-		CleanBuild(database, b, services, nil, err)
+		CleanBuild(ctx, database, b, services, nil, err)
 
 		return err
 	}
@@ -53,7 +54,7 @@ func PlanBuild(database database.Interface, p *pipeline.Build, b *library.Build,
 	steps, err := step.PlanSteps(database, p, b)
 	if err != nil {
 		// clean up the objects from the pipeline in the database
-		CleanBuild(database, b, services, steps, err)
+		CleanBuild(ctx, database, b, services, steps, err)
 
 		return err
 	}

--- a/api/build/publish.go
+++ b/api/build/publish.go
@@ -19,7 +19,7 @@ import (
 
 // PublishToQueue is a helper function that creates
 // a build item and publishes it to the queue.
-func PublishToQueue(queue queue.Service, db database.Interface, p *pipeline.Build, b *library.Build, r *library.Repo, u *library.User) {
+func PublishToQueue(ctx context.Context, queue queue.Service, db database.Interface, p *pipeline.Build, b *library.Build, r *library.Repo, u *library.User) {
 	item := types.ToItem(p, b, r, u)
 
 	logrus.Infof("Converting queue item to json for build %d for %s", b.GetNumber(), r.GetFullName())
@@ -29,7 +29,7 @@ func PublishToQueue(queue queue.Service, db database.Interface, p *pipeline.Buil
 		logrus.Errorf("Failed to convert item to json for build %d for %s: %v", b.GetNumber(), r.GetFullName(), err)
 
 		// error out the build
-		CleanBuild(db, b, nil, nil, err)
+		CleanBuild(ctx, db, b, nil, nil, err)
 
 		return
 	}
@@ -41,7 +41,7 @@ func PublishToQueue(queue queue.Service, db database.Interface, p *pipeline.Buil
 		logrus.Errorf("unable to set route for build %d for %s: %v", b.GetNumber(), r.GetFullName(), err)
 
 		// error out the build
-		CleanBuild(db, b, nil, nil, err)
+		CleanBuild(ctx, db, b, nil, nil, err)
 
 		return
 	}
@@ -57,7 +57,7 @@ func PublishToQueue(queue queue.Service, db database.Interface, p *pipeline.Buil
 			logrus.Errorf("Failed to publish build %d for %s: %v", b.GetNumber(), r.GetFullName(), err)
 
 			// error out the build
-			CleanBuild(db, b, nil, nil, err)
+			CleanBuild(ctx, db, b, nil, nil, err)
 
 			return
 		}
@@ -67,7 +67,7 @@ func PublishToQueue(queue queue.Service, db database.Interface, p *pipeline.Buil
 	b.SetEnqueued(time.Now().UTC().Unix())
 
 	// update the build in the db to reflect the time it was enqueued
-	_, err = db.UpdateBuild(b)
+	_, err = db.UpdateBuild(ctx, b)
 	if err != nil {
 		logrus.Errorf("Failed to update build %d during publish to queue for %s: %v", b.GetNumber(), r.GetFullName(), err)
 	}

--- a/api/build/restart.go
+++ b/api/build/restart.go
@@ -86,6 +86,7 @@ func RestartBuild(c *gin.Context) {
 	o := org.Retrieve(c)
 	r := repo.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%d", r.GetFullName(), b.GetNumber())
 
@@ -117,7 +118,7 @@ func RestartBuild(c *gin.Context) {
 	}
 
 	// send API call to capture the number of pending or running builds for the repo
-	builds, err := database.FromContext(c).CountBuildsForRepo(r, filters)
+	builds, err := database.FromContext(c).CountBuildsForRepo(ctx, r, filters)
 	if err != nil {
 		retErr := fmt.Errorf("unable to restart build: unable to get count of builds for repo %s", r.GetFullName())
 
@@ -312,7 +313,7 @@ func RestartBuild(c *gin.Context) {
 	b.SetPipelineID(pipeline.GetID())
 
 	// create the objects from the pipeline in the database
-	err = PlanBuild(database.FromContext(c), p, b, r)
+	err = PlanBuild(ctx, database.FromContext(c), p, b, r)
 	if err != nil {
 		util.HandleError(c, http.StatusInternalServerError, err)
 
@@ -329,7 +330,7 @@ func RestartBuild(c *gin.Context) {
 	}
 
 	// send API call to capture the restarted build
-	b, _ = database.FromContext(c).GetBuildForRepo(r, b.GetNumber())
+	b, _ = database.FromContext(c).GetBuildForRepo(ctx, r, b.GetNumber())
 
 	c.JSON(http.StatusCreated, b)
 
@@ -341,6 +342,7 @@ func RestartBuild(c *gin.Context) {
 
 	// publish the build to the queue
 	go PublishToQueue(
+		ctx,
 		queue.FromGinContext(c),
 		database.FromContext(c),
 		p,

--- a/api/build/update.go
+++ b/api/build/update.go
@@ -74,6 +74,7 @@ func UpdateBuild(c *gin.Context) {
 	b := build.Retrieve(c)
 	o := org.Retrieve(c)
 	r := repo.Retrieve(c)
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%d", r.GetFullName(), b.GetNumber())
 
@@ -151,7 +152,7 @@ func UpdateBuild(c *gin.Context) {
 	}
 
 	// send API call to update the build
-	b, err = database.FromContext(c).UpdateBuild(b)
+	b, err = database.FromContext(c).UpdateBuild(ctx, b)
 	if err != nil {
 		retErr := fmt.Errorf("unable to update build %s: %w", entry, err)
 

--- a/api/deployment/list.go
+++ b/api/deployment/list.go
@@ -82,6 +82,7 @@ func ListDeployments(c *gin.Context) {
 	o := org.Retrieve(c)
 	r := repo.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	// update engine logger with API metadata
 	//
@@ -138,7 +139,7 @@ func ListDeployments(c *gin.Context) {
 	dWithBs := []*library.Deployment{}
 
 	for _, deployment := range d {
-		b, _, err := database.FromContext(c).ListBuildsForDeployment(deployment, nil, 1, 3)
+		b, _, err := database.FromContext(c).ListBuildsForDeployment(ctx, deployment, nil, 1, 3)
 		if err != nil {
 			retErr := fmt.Errorf("unable to get builds for deployment %d: %w", deployment.GetID(), err)
 

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -234,6 +234,9 @@ func CustomMetrics(c *gin.Context) {
 //
 //nolint:funlen,gocyclo // ignore function length and cyclomatic complexity
 func recordGauges(c *gin.Context) {
+	// capture middleware values
+	ctx := c.Request.Context()
+
 	// variable to store query parameters
 	q := MetricsQueryParameters{}
 
@@ -269,7 +272,7 @@ func recordGauges(c *gin.Context) {
 	// build_count
 	if q.BuildCount {
 		// send API call to capture the total number of builds
-		b, err := database.FromContext(c).CountBuilds()
+		b, err := database.FromContext(c).CountBuilds(ctx)
 		if err != nil {
 			logrus.Errorf("unable to get count of all builds: %v", err)
 		}
@@ -280,7 +283,7 @@ func recordGauges(c *gin.Context) {
 	// running_build_count
 	if q.RunningBuildCount {
 		// send API call to capture the total number of running builds
-		bRun, err := database.FromContext(c).CountBuildsForStatus("running", nil)
+		bRun, err := database.FromContext(c).CountBuildsForStatus(ctx, "running", nil)
 		if err != nil {
 			logrus.Errorf("unable to get count of all running builds: %v", err)
 		}
@@ -291,7 +294,7 @@ func recordGauges(c *gin.Context) {
 	// pending_build_count
 	if q.PendingBuildCount {
 		// send API call to capture the total number of pending builds
-		bPen, err := database.FromContext(c).CountBuildsForStatus("pending", nil)
+		bPen, err := database.FromContext(c).CountBuildsForStatus(ctx, "pending", nil)
 		if err != nil {
 			logrus.Errorf("unable to get count of all pending builds: %v", err)
 		}
@@ -313,7 +316,7 @@ func recordGauges(c *gin.Context) {
 	// failure_build_count
 	if q.FailureBuildCount {
 		// send API call to capture the total number of failure builds
-		bFail, err := database.FromContext(c).CountBuildsForStatus("failure", nil)
+		bFail, err := database.FromContext(c).CountBuildsForStatus(ctx, "failure", nil)
 		if err != nil {
 			logrus.Errorf("unable to get count of all failure builds: %v", err)
 		}
@@ -324,7 +327,7 @@ func recordGauges(c *gin.Context) {
 	// killed_build_count
 	if q.KilledBuildCount {
 		// send API call to capture the total number of killed builds
-		bKill, err := database.FromContext(c).CountBuildsForStatus("killed", nil)
+		bKill, err := database.FromContext(c).CountBuildsForStatus(ctx, "killed", nil)
 		if err != nil {
 			logrus.Errorf("unable to get count of all killed builds: %v", err)
 		}
@@ -335,7 +338,7 @@ func recordGauges(c *gin.Context) {
 	// success_build_count
 	if q.SuccessBuildCount {
 		// send API call to capture the total number of success builds
-		bSucc, err := database.FromContext(c).CountBuildsForStatus("success", nil)
+		bSucc, err := database.FromContext(c).CountBuildsForStatus(ctx, "success", nil)
 		if err != nil {
 			logrus.Errorf("unable to get count of all success builds: %v", err)
 		}
@@ -346,7 +349,7 @@ func recordGauges(c *gin.Context) {
 	// error_build_count
 	if q.ErrorBuildCount {
 		// send API call to capture the total number of error builds
-		bErr, err := database.FromContext(c).CountBuildsForStatus("error", nil)
+		bErr, err := database.FromContext(c).CountBuildsForStatus(ctx, "error", nil)
 		if err != nil {
 			logrus.Errorf("unable to get count of all error builds: %v", err)
 		}

--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -6,7 +6,6 @@ package webhook
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -76,11 +75,12 @@ func PostWebhook(c *gin.Context) {
 
 	// capture middleware values
 	m := c.MustGet("metadata").(*types.Metadata)
+	ctx := c.Request.Context()
 
 	// duplicate request so we can perform operations on the request body
 	//
 	// https://golang.org/pkg/net/http/#Request.Clone
-	dupRequest := c.Request.Clone(context.TODO())
+	dupRequest := c.Request.Clone(ctx)
 
 	// -------------------- Start of TODO: --------------------
 	//
@@ -313,7 +313,7 @@ func PostWebhook(c *gin.Context) {
 	}
 
 	// send API call to capture the number of pending or running builds for the repo
-	builds, err := database.FromContext(c).CountBuildsForRepo(repo, filters)
+	builds, err := database.FromContext(c).CountBuildsForRepo(ctx, repo, filters)
 	if err != nil {
 		retErr := fmt.Errorf("%s: unable to get count of builds for repo %s", baseErr, repo.GetFullName())
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -591,7 +591,7 @@ func PostWebhook(c *gin.Context) {
 		//   using the same Number and thus create a constraint
 		//   conflict; consider deleting the partially created
 		//   build object in the database
-		err = build.PlanBuild(database.FromContext(c), p, b, repo)
+		err = build.PlanBuild(ctx, database.FromContext(c), p, b, repo)
 		if err != nil {
 			retErr := fmt.Errorf("%s: %w", baseErr, err)
 
@@ -655,7 +655,7 @@ func PostWebhook(c *gin.Context) {
 	}
 
 	// send API call to capture the triggered build
-	b, err = database.FromContext(c).GetBuildForRepo(repo, b.GetNumber())
+	b, err = database.FromContext(c).GetBuildForRepo(ctx, repo, b.GetNumber())
 	if err != nil {
 		retErr := fmt.Errorf("%s: failed to get new build %s/%d: %w", baseErr, repo.GetFullName(), b.GetNumber(), err)
 		util.HandleError(c, http.StatusInternalServerError, retErr)
@@ -679,6 +679,7 @@ func PostWebhook(c *gin.Context) {
 
 	// publish the build to the queue
 	go build.PublishToQueue(
+		ctx,
 		queue.FromGinContext(c),
 		database.FromContext(c),
 		p,
@@ -782,6 +783,10 @@ func handleRepositoryEvent(c *gin.Context, m *types.Metadata, h *library.Hook, r
 // associated with that repo as well as build links for the UI.
 func renameRepository(h *library.Hook, r *library.Repo, c *gin.Context, m *types.Metadata) (*library.Repo, error) {
 	logrus.Infof("renaming repository from %s to %s", r.GetPreviousName(), r.GetName())
+
+	// capture context from gin
+	ctx := c.Request.Context()
+
 	// get the old name of the repo
 	prevOrg, prevRepo := util.SplitFullName(r.GetPreviousName())
 
@@ -851,7 +856,7 @@ func renameRepository(h *library.Hook, r *library.Repo, c *gin.Context, m *types
 	}
 
 	// get total number of builds associated with repository
-	t, err = database.FromContext(c).CountBuildsForRepo(dbR, nil)
+	t, err = database.FromContext(c).CountBuildsForRepo(ctx, dbR, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get build count for repo %s: %w", dbR.GetFullName(), err)
 	}
@@ -860,7 +865,7 @@ func renameRepository(h *library.Hook, r *library.Repo, c *gin.Context, m *types
 	page = 1
 	// capture all builds belonging to repo in database
 	for build := int64(0); build < t; build += 100 {
-		b, _, err := database.FromContext(c).ListBuildsForRepo(dbR, nil, time.Now().Unix(), 0, page, 100)
+		b, _, err := database.FromContext(c).ListBuildsForRepo(ctx, dbR, nil, time.Now().Unix(), 0, page, 100)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get build list for repo %s: %w", dbR.GetFullName(), err)
 		}
@@ -876,7 +881,7 @@ func renameRepository(h *library.Hook, r *library.Repo, c *gin.Context, m *types
 			fmt.Sprintf("%s/%s/%d", m.Vela.WebAddress, r.GetFullName(), build.GetNumber()),
 		)
 
-		_, err = database.FromContext(c).UpdateBuild(build)
+		_, err = database.FromContext(c).UpdateBuild(ctx, build)
 		if err != nil {
 			return nil, fmt.Errorf("unable to update build for repo %s: %w", dbR.GetFullName(), err)
 		}

--- a/cmd/vela-server/schedule.go
+++ b/cmd/vela-server/schedule.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -172,7 +173,7 @@ func processSchedule(s *library.Schedule, compiler compiler.Engine, database dat
 	}
 
 	// send API call to capture the number of pending or running builds for the repo
-	builds, err := database.CountBuildsForRepo(r, filters)
+	builds, err := database.CountBuildsForRepo(context.TODO(), r, filters)
 	if err != nil {
 		return fmt.Errorf("unable to get count of builds for repo %s: %w", r.GetFullName(), err)
 	}
@@ -350,7 +351,7 @@ func processSchedule(s *library.Schedule, compiler compiler.Engine, database dat
 		//   using the same Number and thus create a constraint
 		//   conflict; consider deleting the partially created
 		//   build object in the database
-		err = build.PlanBuild(database, p, b, r)
+		err = build.PlanBuild(context.TODO(), database, p, b, r)
 		if err != nil {
 			// check if the retry limit has been exceeded
 			if i < retryLimit-1 {
@@ -379,13 +380,14 @@ func processSchedule(s *library.Schedule, compiler compiler.Engine, database dat
 	}
 
 	// send API call to capture the triggered build
-	b, err = database.GetBuildForRepo(r, b.GetNumber())
+	b, err = database.GetBuildForRepo(context.TODO(), r, b.GetNumber())
 	if err != nil {
 		return fmt.Errorf("unable to get new build %s/%d: %w", r.GetFullName(), b.GetNumber(), err)
 	}
 
 	// publish the build to the queue
 	go build.PublishToQueue(
+		context.TODO(),
 		queue,
 		database,
 		p,

--- a/database/build/build.go
+++ b/database/build/build.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-vela/types/constants"
@@ -24,6 +25,8 @@ type (
 	engine struct {
 		// engine configuration settings used in build functions
 		config *config
+
+		ctx context.Context
 
 		// gorm.io/gorm database client used in build functions
 		//
@@ -65,13 +68,13 @@ func New(opts ...EngineOpt) (*engine, error) {
 	}
 
 	// create the builds table
-	err := e.CreateBuildTable(e.client.Config.Dialector.Name())
+	err := e.CreateBuildTable(e.ctx, e.client.Config.Dialector.Name())
 	if err != nil {
 		return nil, fmt.Errorf("unable to create %s table: %w", constants.TableBuild, err)
 	}
 
 	// create the indexes for the builds table
-	err = e.CreateBuildIndexes()
+	err = e.CreateBuildIndexes(e.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create indexes for %s table: %w", constants.TableBuild, err)
 	}

--- a/database/build/build_test.go
+++ b/database/build/build_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"database/sql/driver"
 	"reflect"
 	"testing"
@@ -67,6 +68,7 @@ func TestBuild_New(t *testing.T) {
 			want: &engine{
 				client: _postgres,
 				config: &config{SkipCreation: false},
+				ctx:    context.TODO(),
 				logger: logger,
 			},
 		},
@@ -79,6 +81,7 @@ func TestBuild_New(t *testing.T) {
 			want: &engine{
 				client: _sqlite,
 				config: &config{SkipCreation: false},
+				ctx:    context.TODO(),
 				logger: logger,
 			},
 		},
@@ -88,6 +91,7 @@ func TestBuild_New(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := New(
+				WithContext(context.TODO()),
 				WithClient(test.client),
 				WithLogger(test.logger),
 				WithSkipCreation(test.skipCreation),
@@ -140,6 +144,7 @@ func testPostgres(t *testing.T) (*engine, sqlmock.Sqlmock) {
 	}
 
 	_engine, err := New(
+		WithContext(context.TODO()),
 		WithClient(_postgres),
 		WithLogger(logrus.NewEntry(logrus.StandardLogger())),
 		WithSkipCreation(false),
@@ -162,6 +167,7 @@ func testSqlite(t *testing.T) *engine {
 	}
 
 	_engine, err := New(
+		WithContext(context.TODO()),
 		WithClient(_sqlite),
 		WithLogger(logrus.NewEntry(logrus.StandardLogger())),
 		WithSkipCreation(false),

--- a/database/build/clean.go
+++ b/database/build/clean.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"time"
 
 	"github.com/go-vela/types/constants"
@@ -14,7 +15,7 @@ import (
 )
 
 // CleanBuilds updates builds to an error with a provided message with a created timestamp prior to a defined moment.
-func (e *engine) CleanBuilds(msg string, before int64) (int64, error) {
+func (e *engine) CleanBuilds(ctx context.Context, msg string, before int64) (int64, error) {
 	logrus.Tracef("cleaning pending or running builds in the database created prior to %d", before)
 
 	b := new(library.Build)

--- a/database/build/clean_test.go
+++ b/database/build/clean_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -53,22 +54,22 @@ func TestBuild_Engine_CleanBuilds(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateBuild(_buildOne)
+	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateBuild(_buildTwo)
+	_, err = _sqlite.CreateBuild(context.TODO(), _buildTwo)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateBuild(_buildThree)
+	_, err = _sqlite.CreateBuild(context.TODO(), _buildThree)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateBuild(_buildFour)
+	_, err = _sqlite.CreateBuild(context.TODO(), _buildFour)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
@@ -97,7 +98,7 @@ func TestBuild_Engine_CleanBuilds(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CleanBuilds("msg", 3)
+			got, err := test.database.CleanBuilds(context.TODO(), "msg", 3)
 
 			if test.failure {
 				if err == nil {

--- a/database/build/count.go
+++ b/database/build/count.go
@@ -5,11 +5,13 @@
 package build
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 )
 
 // CountBuilds gets the count of all builds from the database.
-func (e *engine) CountBuilds() (int64, error) {
+func (e *engine) CountBuilds(ctx context.Context) (int64, error) {
 	e.logger.Tracef("getting count of all builds from the database")
 
 	// variable to store query results

--- a/database/build/count_deployment.go
+++ b/database/build/count_deployment.go
@@ -5,13 +5,15 @@
 package build
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/sirupsen/logrus"
 )
 
 // CountBuildsForDeployment gets the count of builds by deployment URL from the database.
-func (e *engine) CountBuildsForDeployment(d *library.Deployment, filters map[string]interface{}) (int64, error) {
+func (e *engine) CountBuildsForDeployment(ctx context.Context, d *library.Deployment, filters map[string]interface{}) (int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"deployment": d.GetURL(),
 	}).Tracef("getting count of builds for deployment %s from the database", d.GetURL())

--- a/database/build/count_deployment_test.go
+++ b/database/build/count_deployment_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -44,12 +45,12 @@ func TestBuild_Engine_CountBuildsForDeployment(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateBuild(_buildOne)
+	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateBuild(_buildTwo)
+	_, err = _sqlite.CreateBuild(context.TODO(), _buildTwo)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
@@ -80,7 +81,7 @@ func TestBuild_Engine_CountBuildsForDeployment(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CountBuildsForDeployment(_deployment, filters)
+			got, err := test.database.CountBuildsForDeployment(context.TODO(), _deployment, filters)
 
 			if test.failure {
 				if err == nil {

--- a/database/build/count_org.go
+++ b/database/build/count_org.go
@@ -5,12 +5,14 @@
 package build
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/sirupsen/logrus"
 )
 
 // CountBuildsForOrg gets the count of builds by org name from the database.
-func (e *engine) CountBuildsForOrg(org string, filters map[string]interface{}) (int64, error) {
+func (e *engine) CountBuildsForOrg(ctx context.Context, org string, filters map[string]interface{}) (int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org": org,
 	}).Tracef("getting count of builds for org %s from the database", org)

--- a/database/build/count_org_test.go
+++ b/database/build/count_org_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -67,12 +68,12 @@ func TestBuild_Engine_CountBuildsForOrg(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateBuild(_buildOne)
+	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateBuild(_buildTwo)
+	_, err = _sqlite.CreateBuild(context.TODO(), _buildTwo)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
@@ -137,7 +138,7 @@ func TestBuild_Engine_CountBuildsForOrg(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CountBuildsForOrg("foo", test.filters)
+			got, err := test.database.CountBuildsForOrg(context.TODO(), "foo", test.filters)
 
 			if test.failure {
 				if err == nil {

--- a/database/build/count_repo.go
+++ b/database/build/count_repo.go
@@ -5,13 +5,15 @@
 package build
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/sirupsen/logrus"
 )
 
 // CountBuildsForRepo gets the count of builds by repo ID from the database.
-func (e *engine) CountBuildsForRepo(r *library.Repo, filters map[string]interface{}) (int64, error) {
+func (e *engine) CountBuildsForRepo(ctx context.Context, r *library.Repo, filters map[string]interface{}) (int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),

--- a/database/build/count_repo_test.go
+++ b/database/build/count_repo_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -46,12 +47,12 @@ func TestBuild_Engine_CountBuildsForRepo(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateBuild(_buildOne)
+	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateBuild(_buildTwo)
+	_, err = _sqlite.CreateBuild(context.TODO(), _buildTwo)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
@@ -82,7 +83,7 @@ func TestBuild_Engine_CountBuildsForRepo(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CountBuildsForRepo(_repo, filters)
+			got, err := test.database.CountBuildsForRepo(context.TODO(), _repo, filters)
 
 			if test.failure {
 				if err == nil {

--- a/database/build/count_status.go
+++ b/database/build/count_status.go
@@ -5,11 +5,13 @@
 package build
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 )
 
 // CountBuildsForStatus gets the count of builds by status from the database.
-func (e *engine) CountBuildsForStatus(status string, filters map[string]interface{}) (int64, error) {
+func (e *engine) CountBuildsForStatus(ctx context.Context, status string, filters map[string]interface{}) (int64, error) {
 	e.logger.Tracef("getting count of builds for status %s from the database", status)
 
 	// variable to store query results

--- a/database/build/count_status_test.go
+++ b/database/build/count_status_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -39,12 +40,12 @@ func TestBuild_Engine_CountBuildsForStatus(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateBuild(_buildOne)
+	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateBuild(_buildTwo)
+	_, err = _sqlite.CreateBuild(context.TODO(), _buildTwo)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
@@ -75,7 +76,7 @@ func TestBuild_Engine_CountBuildsForStatus(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CountBuildsForStatus("running", filters)
+			got, err := test.database.CountBuildsForStatus(context.TODO(), "running", filters)
 
 			if test.failure {
 				if err == nil {

--- a/database/build/count_test.go
+++ b/database/build/count_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -37,12 +38,12 @@ func TestBuild_Engine_CountBuilds(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateBuild(_buildOne)
+	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateBuild(_buildTwo)
+	_, err = _sqlite.CreateBuild(context.TODO(), _buildTwo)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
@@ -71,7 +72,7 @@ func TestBuild_Engine_CountBuilds(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CountBuilds()
+			got, err := test.database.CountBuilds(context.TODO())
 
 			if test.failure {
 				if err == nil {

--- a/database/build/create.go
+++ b/database/build/create.go
@@ -6,6 +6,8 @@
 package build
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -13,7 +15,7 @@ import (
 )
 
 // CreateBuild creates a new build in the database.
-func (e *engine) CreateBuild(b *library.Build) (*library.Build, error) {
+func (e *engine) CreateBuild(ctx context.Context, b *library.Build) (*library.Build, error) {
 	e.logger.WithFields(logrus.Fields{
 		"build": b.GetNumber(),
 	}).Tracef("creating build %d in the database", b.GetNumber())

--- a/database/build/create_test.go
+++ b/database/build/create_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -56,7 +57,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CreateBuild(_build)
+			got, err := test.database.CreateBuild(context.TODO(), _build)
 
 			if test.failure {
 				if err == nil {

--- a/database/build/delete.go
+++ b/database/build/delete.go
@@ -5,6 +5,8 @@
 package build
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -12,7 +14,7 @@ import (
 )
 
 // DeleteBuild deletes an existing build from the database.
-func (e *engine) DeleteBuild(b *library.Build) error {
+func (e *engine) DeleteBuild(ctx context.Context, b *library.Build) error {
 	e.logger.WithFields(logrus.Fields{
 		"build": b.GetNumber(),
 	}).Tracef("deleting build %d from the database", b.GetNumber())

--- a/database/build/delete_test.go
+++ b/database/build/delete_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -29,7 +30,7 @@ func TestBuild_Engine_DeleteBuild(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateBuild(_build)
+	_, err := _sqlite.CreateBuild(context.TODO(), _build)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
@@ -55,7 +56,7 @@ func TestBuild_Engine_DeleteBuild(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err = test.database.DeleteBuild(_build)
+			err = test.database.DeleteBuild(context.TODO(), _build)
 
 			if test.failure {
 				if err == nil {

--- a/database/build/get.go
+++ b/database/build/get.go
@@ -5,13 +5,15 @@
 package build
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )
 
 // GetBuild gets a build by ID from the database.
-func (e *engine) GetBuild(id int64) (*library.Build, error) {
+func (e *engine) GetBuild(ctx context.Context, id int64) (*library.Build, error) {
 	e.logger.Tracef("getting build %d from the database", id)
 
 	// variable to store query results

--- a/database/build/get_repo.go
+++ b/database/build/get_repo.go
@@ -5,6 +5,8 @@
 package build
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -12,7 +14,7 @@ import (
 )
 
 // GetBuildForRepo gets a build by repo ID and number from the database.
-func (e *engine) GetBuildForRepo(r *library.Repo, number int) (*library.Build, error) {
+func (e *engine) GetBuildForRepo(ctx context.Context, r *library.Repo, number int) (*library.Build, error) {
 	e.logger.WithFields(logrus.Fields{
 		"build": number,
 		"org":   r.GetOrg(),

--- a/database/build/get_repo_test.go
+++ b/database/build/get_repo_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -43,7 +44,7 @@ func TestBuild_Engine_GetBuildForRepo(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateBuild(_build)
+	_, err := _sqlite.CreateBuild(context.TODO(), _build)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
@@ -72,7 +73,7 @@ func TestBuild_Engine_GetBuildForRepo(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.GetBuildForRepo(_repo, 1)
+			got, err := test.database.GetBuildForRepo(context.TODO(), _repo, 1)
 
 			if test.failure {
 				if err == nil {

--- a/database/build/get_test.go
+++ b/database/build/get_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -34,7 +35,7 @@ func TestBuild_Engine_GetBuild(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateBuild(_build)
+	_, err := _sqlite.CreateBuild(context.TODO(), _build)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
@@ -63,7 +64,7 @@ func TestBuild_Engine_GetBuild(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.GetBuild(1)
+			got, err := test.database.GetBuild(context.TODO(), 1)
 
 			if test.failure {
 				if err == nil {

--- a/database/build/index.go
+++ b/database/build/index.go
@@ -4,6 +4,8 @@
 
 package build
 
+import "context"
+
 const (
 	// CreateCreatedIndex represents a query to create an
 	// index on the builds table for the created column.
@@ -43,7 +45,7 @@ ON builds (status);
 )
 
 // CreateBuildIndexes creates the indexes for the builds table in the database.
-func (e *engine) CreateBuildIndexes() error {
+func (e *engine) CreateBuildIndexes(ctx context.Context) error {
 	e.logger.Tracef("creating indexes for builds table in the database")
 
 	// create the created column index for the builds table

--- a/database/build/index_test.go
+++ b/database/build/index_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -44,7 +45,7 @@ func TestBuild_Engine_CreateBuildIndexes(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.database.CreateBuildIndexes()
+			err := test.database.CreateBuildIndexes(context.TODO())
 
 			if test.failure {
 				if err == nil {

--- a/database/build/interface.go
+++ b/database/build/interface.go
@@ -5,6 +5,8 @@
 package build
 
 import (
+	"context"
+
 	"github.com/go-vela/types/library"
 )
 
@@ -18,46 +20,46 @@ type BuildInterface interface {
 	// https://en.wikipedia.org/wiki/Data_definition_language
 
 	// CreateBuildIndexes defines a function that creates the indexes for the builds table.
-	CreateBuildIndexes() error
+	CreateBuildIndexes(context.Context) error
 	// CreateBuildTable defines a function that creates the builds table.
-	CreateBuildTable(string) error
+	CreateBuildTable(context.Context, string) error
 
 	// Build Data Manipulation Language Functions
 	//
 	// https://en.wikipedia.org/wiki/Data_manipulation_language
 
 	// CleanBuilds defines a function that sets pending or running builds to error created before a given time.
-	CleanBuilds(string, int64) (int64, error)
+	CleanBuilds(context.Context, string, int64) (int64, error)
 	// CountBuilds defines a function that gets the count of all builds.
-	CountBuilds() (int64, error)
+	CountBuilds(context.Context) (int64, error)
 	// CountBuildsForDeployment defines a function that gets the count of builds by deployment url.
-	CountBuildsForDeployment(*library.Deployment, map[string]interface{}) (int64, error)
+	CountBuildsForDeployment(context.Context, *library.Deployment, map[string]interface{}) (int64, error)
 	// CountBuildsForOrg defines a function that gets the count of builds by org name.
-	CountBuildsForOrg(string, map[string]interface{}) (int64, error)
+	CountBuildsForOrg(context.Context, string, map[string]interface{}) (int64, error)
 	// CountBuildsForRepo defines a function that gets the count of builds by repo ID.
-	CountBuildsForRepo(*library.Repo, map[string]interface{}) (int64, error)
+	CountBuildsForRepo(context.Context, *library.Repo, map[string]interface{}) (int64, error)
 	// CountBuildsForStatus defines a function that gets the count of builds by status.
-	CountBuildsForStatus(string, map[string]interface{}) (int64, error)
+	CountBuildsForStatus(context.Context, string, map[string]interface{}) (int64, error)
 	// CreateBuild defines a function that creates a new build.
-	CreateBuild(*library.Build) (*library.Build, error)
+	CreateBuild(context.Context, *library.Build) (*library.Build, error)
 	// DeleteBuild defines a function that deletes an existing build.
-	DeleteBuild(*library.Build) error
+	DeleteBuild(context.Context, *library.Build) error
 	// GetBuild defines a function that gets a build by ID.
-	GetBuild(int64) (*library.Build, error)
+	GetBuild(context.Context, int64) (*library.Build, error)
 	// GetBuildForRepo defines a function that gets a build by repo ID and number.
-	GetBuildForRepo(*library.Repo, int) (*library.Build, error)
+	GetBuildForRepo(context.Context, *library.Repo, int) (*library.Build, error)
 	// LastBuildForRepo defines a function that gets the last build ran by repo ID and branch.
-	LastBuildForRepo(*library.Repo, string) (*library.Build, error)
+	LastBuildForRepo(context.Context, *library.Repo, string) (*library.Build, error)
 	// ListBuilds defines a function that gets a list of all builds.
-	ListBuilds() ([]*library.Build, error)
+	ListBuilds(context.Context) ([]*library.Build, error)
 	// ListBuildsForDeployment defines a function that gets a list of builds by deployment url.
-	ListBuildsForDeployment(*library.Deployment, map[string]interface{}, int, int) ([]*library.Build, int64, error)
+	ListBuildsForDeployment(context.Context, *library.Deployment, map[string]interface{}, int, int) ([]*library.Build, int64, error)
 	// ListBuildsForOrg defines a function that gets a list of builds by org name.
-	ListBuildsForOrg(string, map[string]interface{}, int, int) ([]*library.Build, int64, error)
+	ListBuildsForOrg(context.Context, string, map[string]interface{}, int, int) ([]*library.Build, int64, error)
 	// ListBuildsForRepo defines a function that gets a list of builds by repo ID.
-	ListBuildsForRepo(*library.Repo, map[string]interface{}, int64, int64, int, int) ([]*library.Build, int64, error)
+	ListBuildsForRepo(context.Context, *library.Repo, map[string]interface{}, int64, int64, int, int) ([]*library.Build, int64, error)
 	// ListPendingAndRunningBuilds defines a function that gets a list of pending and running builds.
-	ListPendingAndRunningBuilds(string) ([]*library.BuildQueue, error)
+	ListPendingAndRunningBuilds(context.Context, string) ([]*library.BuildQueue, error)
 	// UpdateBuild defines a function that updates an existing build.
-	UpdateBuild(*library.Build) (*library.Build, error)
+	UpdateBuild(context.Context, *library.Build) (*library.Build, error)
 }

--- a/database/build/last_repo.go
+++ b/database/build/last_repo.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"errors"
 
 	"github.com/go-vela/types/constants"
@@ -16,7 +17,7 @@ import (
 )
 
 // LastBuildForRepo gets the last build by repo ID and branch from the database.
-func (e *engine) LastBuildForRepo(r *library.Repo, branch string) (*library.Build, error) {
+func (e *engine) LastBuildForRepo(ctx context.Context, r *library.Repo, branch string) (*library.Build, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),

--- a/database/build/last_repo_test.go
+++ b/database/build/last_repo_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -44,7 +45,7 @@ func TestBuild_Engine_LastBuildForRepo(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateBuild(_build)
+	_, err := _sqlite.CreateBuild(context.TODO(), _build)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
@@ -73,7 +74,7 @@ func TestBuild_Engine_LastBuildForRepo(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.LastBuildForRepo(_repo, "master")
+			got, err := test.database.LastBuildForRepo(context.TODO(), _repo, "master")
 
 			if test.failure {
 				if err == nil {

--- a/database/build/list.go
+++ b/database/build/list.go
@@ -5,13 +5,15 @@
 package build
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )
 
 // ListBuilds gets a list of all builds from the database.
-func (e *engine) ListBuilds() ([]*library.Build, error) {
+func (e *engine) ListBuilds(ctx context.Context) ([]*library.Build, error) {
 	e.logger.Trace("listing all builds from the database")
 
 	// variables to store query results and return value
@@ -20,7 +22,7 @@ func (e *engine) ListBuilds() ([]*library.Build, error) {
 	builds := []*library.Build{}
 
 	// count the results
-	count, err := e.CountBuilds()
+	count, err := e.CountBuilds(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/database/build/list_deployment.go
+++ b/database/build/list_deployment.go
@@ -5,6 +5,8 @@
 package build
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -14,7 +16,7 @@ import (
 // ListBuildsForDeployment gets a list of builds by deployment url from the database.
 //
 //nolint:lll // ignore long line length due to variable names
-func (e *engine) ListBuildsForDeployment(d *library.Deployment, filters map[string]interface{}, page, perPage int) ([]*library.Build, int64, error) {
+func (e *engine) ListBuildsForDeployment(ctx context.Context, d *library.Deployment, filters map[string]interface{}, page, perPage int) ([]*library.Build, int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"deployment": d.GetURL(),
 	}).Tracef("listing builds for deployment %s from the database", d.GetURL())
@@ -25,7 +27,7 @@ func (e *engine) ListBuildsForDeployment(d *library.Deployment, filters map[stri
 	builds := []*library.Build{}
 
 	// count the results
-	count, err := e.CountBuildsForDeployment(d, filters)
+	count, err := e.CountBuildsForDeployment(context.TODO(), d, filters)
 	if err != nil {
 		return builds, 0, err
 	}

--- a/database/build/list_deployment_test.go
+++ b/database/build/list_deployment_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -54,12 +55,12 @@ func TestBuild_Engine_ListBuildsForDeployment(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateBuild(_buildOne)
+	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateBuild(_buildTwo)
+	_, err = _sqlite.CreateBuild(context.TODO(), _buildTwo)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
@@ -90,7 +91,7 @@ func TestBuild_Engine_ListBuildsForDeployment(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, _, err := test.database.ListBuildsForDeployment(_deployment, filters, 1, 10)
+			got, _, err := test.database.ListBuildsForDeployment(context.TODO(), _deployment, filters, 1, 10)
 
 			if test.failure {
 				if err == nil {

--- a/database/build/list_org.go
+++ b/database/build/list_org.go
@@ -5,6 +5,8 @@
 package build
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -14,7 +16,7 @@ import (
 // ListBuildsForOrg gets a list of builds by org name from the database.
 //
 //nolint:lll // ignore long line length due to variable names
-func (e *engine) ListBuildsForOrg(org string, filters map[string]interface{}, page, perPage int) ([]*library.Build, int64, error) {
+func (e *engine) ListBuildsForOrg(ctx context.Context, org string, filters map[string]interface{}, page, perPage int) ([]*library.Build, int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org": org,
 	}).Tracef("listing builds for org %s from the database", org)
@@ -25,7 +27,7 @@ func (e *engine) ListBuildsForOrg(org string, filters map[string]interface{}, pa
 	builds := []*library.Build{}
 
 	// count the results
-	count, err := e.CountBuildsForOrg(org, filters)
+	count, err := e.CountBuildsForOrg(ctx, org, filters)
 	if err != nil {
 		return builds, 0, err
 	}

--- a/database/build/list_org_test.go
+++ b/database/build/list_org_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -94,12 +95,12 @@ func TestBuild_Engine_ListBuildsForOrg(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateBuild(_buildOne)
+	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateBuild(_buildTwo)
+	_, err = _sqlite.CreateBuild(context.TODO(), _buildTwo)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
@@ -182,7 +183,7 @@ func TestBuild_Engine_ListBuildsForOrg(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, _, err := test.database.ListBuildsForOrg("foo", test.filters, 1, 10)
+			got, _, err := test.database.ListBuildsForOrg(context.TODO(), "foo", test.filters, 1, 10)
 
 			if test.failure {
 				if err == nil {

--- a/database/build/list_pending_running.go
+++ b/database/build/list_pending_running.go
@@ -5,13 +5,15 @@
 package build
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )
 
 // ListPendingAndRunningBuilds gets a list of all pending and running builds in the provided timeframe from the database.
-func (e *engine) ListPendingAndRunningBuilds(after string) ([]*library.BuildQueue, error) {
+func (e *engine) ListPendingAndRunningBuilds(ctx context.Context, after string) ([]*library.BuildQueue, error) {
 	e.logger.Trace("listing all pending and running builds from the database")
 
 	// variables to store query results and return value

--- a/database/build/list_pending_running_test.go
+++ b/database/build/list_pending_running_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -65,12 +66,12 @@ func TestBuild_Engine_ListPendingAndRunningBuilds(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateBuild(_buildOne)
+	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateBuild(_buildTwo)
+	_, err = _sqlite.CreateBuild(context.TODO(), _buildTwo)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
@@ -109,7 +110,7 @@ func TestBuild_Engine_ListPendingAndRunningBuilds(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.ListPendingAndRunningBuilds("0")
+			got, err := test.database.ListPendingAndRunningBuilds(context.TODO(), "0")
 
 			if test.failure {
 				if err == nil {

--- a/database/build/list_repo.go
+++ b/database/build/list_repo.go
@@ -5,6 +5,8 @@
 package build
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -14,7 +16,7 @@ import (
 // ListBuildsForRepo gets a list of builds by repo ID from the database.
 //
 //nolint:lll // ignore long line length due to variable names
-func (e *engine) ListBuildsForRepo(r *library.Repo, filters map[string]interface{}, before, after int64, page, perPage int) ([]*library.Build, int64, error) {
+func (e *engine) ListBuildsForRepo(ctx context.Context, r *library.Repo, filters map[string]interface{}, before, after int64, page, perPage int) ([]*library.Build, int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),
@@ -26,7 +28,7 @@ func (e *engine) ListBuildsForRepo(r *library.Repo, filters map[string]interface
 	builds := []*library.Build{}
 
 	// count the results
-	count, err := e.CountBuildsForRepo(r, filters)
+	count, err := e.CountBuildsForRepo(ctx, r, filters)
 	if err != nil {
 		return builds, 0, err
 	}

--- a/database/build/list_repo_test.go
+++ b/database/build/list_repo_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -59,12 +60,12 @@ func TestBuild_Engine_ListBuildsForRepo(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateBuild(_buildOne)
+	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateBuild(_buildTwo)
+	_, err = _sqlite.CreateBuild(context.TODO(), _buildTwo)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
@@ -95,7 +96,7 @@ func TestBuild_Engine_ListBuildsForRepo(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, _, err := test.database.ListBuildsForRepo(_repo, filters, time.Now().UTC().Unix(), 0, 1, 10)
+			got, _, err := test.database.ListBuildsForRepo(context.TODO(), _repo, filters, time.Now().UTC().Unix(), 0, 1, 10)
 
 			if test.failure {
 				if err == nil {

--- a/database/build/list_test.go
+++ b/database/build/list_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -47,12 +48,12 @@ func TestBuild_Engine_ListBuilds(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateBuild(_buildOne)
+	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateBuild(_buildTwo)
+	_, err = _sqlite.CreateBuild(context.TODO(), _buildTwo)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
@@ -81,7 +82,7 @@ func TestBuild_Engine_ListBuilds(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.ListBuilds()
+			got, err := test.database.ListBuilds(context.TODO())
 
 			if test.failure {
 				if err == nil {

--- a/database/build/opts.go
+++ b/database/build/opts.go
@@ -5,6 +5,8 @@
 package build
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
 
 	"gorm.io/gorm"
@@ -38,6 +40,15 @@ func WithSkipCreation(skipCreation bool) EngineOpt {
 	return func(e *engine) error {
 		// set to skip creating tables and indexes in the build engine
 		e.config.SkipCreation = skipCreation
+
+		return nil
+	}
+}
+
+// WithContext sets the context in the database engine for Builds.
+func WithContext(ctx context.Context) EngineOpt {
+	return func(e *engine) error {
+		e.ctx = ctx
 
 		return nil
 	}

--- a/database/build/table.go
+++ b/database/build/table.go
@@ -4,7 +4,11 @@
 
 package build
 
-import "github.com/go-vela/types/constants"
+import (
+	"context"
+
+	"github.com/go-vela/types/constants"
+)
 
 const (
 	// CreatePostgresTable represents a query to create the Postgres builds table.
@@ -91,7 +95,7 @@ builds (
 )
 
 // CreateBuildTable creates the builds table in the database.
-func (e *engine) CreateBuildTable(driver string) error {
+func (e *engine) CreateBuildTable(ctx context.Context, driver string) error {
 	e.logger.Tracef("creating builds table in the database")
 
 	// handle the driver provided to create the table

--- a/database/build/table_test.go
+++ b/database/build/table_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -41,7 +42,7 @@ func TestBuild_Engine_CreateBuildTable(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.database.CreateBuildTable(test.name)
+			err := test.database.CreateBuildTable(context.TODO(), test.name)
 
 			if test.failure {
 				if err == nil {

--- a/database/build/update.go
+++ b/database/build/update.go
@@ -6,6 +6,8 @@
 package build
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -13,7 +15,7 @@ import (
 )
 
 // UpdateBuild updates an existing build in the database.
-func (e *engine) UpdateBuild(b *library.Build) (*library.Build, error) {
+func (e *engine) UpdateBuild(ctx context.Context, b *library.Build) (*library.Build, error) {
 	e.logger.WithFields(logrus.Fields{
 		"build": b.GetNumber(),
 	}).Tracef("updating build %d in the database", b.GetNumber())

--- a/database/build/update_test.go
+++ b/database/build/update_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -32,7 +33,7 @@ WHERE "id" = $31`).
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateBuild(_build)
+	_, err := _sqlite.CreateBuild(context.TODO(), _build)
 	if err != nil {
 		t.Errorf("unable to create test build for sqlite: %v", err)
 	}
@@ -58,7 +59,7 @@ WHERE "id" = $31`).
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.UpdateBuild(_build)
+			got, err := test.database.UpdateBuild(context.TODO(), _build)
 
 			if test.failure {
 				if err == nil {

--- a/database/database.go
+++ b/database/database.go
@@ -5,6 +5,7 @@
 package database
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -54,6 +55,8 @@ type (
 		client *gorm.DB
 		// engine configuration settings used in database functions
 		config *config
+		// engine context used in database functions
+		ctx context.Context
 		// sirupsen/logrus logger used in database functions
 		logger *logrus.Entry
 
@@ -85,6 +88,7 @@ func New(opts ...EngineOpt) (Interface, error) {
 	e.client = new(gorm.DB)
 	e.config = new(config)
 	e.logger = new(logrus.Entry)
+	e.ctx = context.TODO()
 
 	// apply all provided configuration options
 	for _, opt := range opts {
@@ -143,7 +147,7 @@ func New(opts ...EngineOpt) (Interface, error) {
 	}
 
 	// create database agnostic engines for resources
-	err = e.NewResources()
+	err = e.NewResources(e.ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/database/integration_test.go
+++ b/database/integration_test.go
@@ -5,6 +5,7 @@
 package database
 
 import (
+	"context"
 	"os"
 	"reflect"
 	"strings"
@@ -186,7 +187,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 
 	// create the builds
 	for _, build := range resources.Builds {
-		_, err := db.CreateBuild(build)
+		_, err := db.CreateBuild(context.TODO(), build)
 		if err != nil {
 			t.Errorf("unable to create build %d: %v", build.GetID(), err)
 		}
@@ -194,7 +195,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	methods["CreateBuild"] = true
 
 	// count the builds
-	count, err := db.CountBuilds()
+	count, err := db.CountBuilds(context.TODO())
 	if err != nil {
 		t.Errorf("unable to count builds: %v", err)
 	}
@@ -204,7 +205,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	methods["CountBuilds"] = true
 
 	// count the builds for a deployment
-	count, err = db.CountBuildsForDeployment(resources.Deployments[0], nil)
+	count, err = db.CountBuildsForDeployment(context.TODO(), resources.Deployments[0], nil)
 	if err != nil {
 		t.Errorf("unable to count builds for deployment %d: %v", resources.Deployments[0].GetID(), err)
 	}
@@ -214,7 +215,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	methods["CountBuildsForDeployment"] = true
 
 	// count the builds for an org
-	count, err = db.CountBuildsForOrg(resources.Repos[0].GetOrg(), nil)
+	count, err = db.CountBuildsForOrg(context.TODO(), resources.Repos[0].GetOrg(), nil)
 	if err != nil {
 		t.Errorf("unable to count builds for org %s: %v", resources.Repos[0].GetOrg(), err)
 	}
@@ -224,7 +225,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	methods["CountBuildsForOrg"] = true
 
 	// count the builds for a repo
-	count, err = db.CountBuildsForRepo(resources.Repos[0], nil)
+	count, err = db.CountBuildsForRepo(context.TODO(), resources.Repos[0], nil)
 	if err != nil {
 		t.Errorf("unable to count builds for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
@@ -234,7 +235,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	methods["CountBuildsForRepo"] = true
 
 	// count the builds for a status
-	count, err = db.CountBuildsForStatus("running", nil)
+	count, err = db.CountBuildsForStatus(context.TODO(), "running", nil)
 	if err != nil {
 		t.Errorf("unable to count builds for status %s: %v", "running", err)
 	}
@@ -244,7 +245,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	methods["CountBuildsForStatus"] = true
 
 	// list the builds
-	list, err := db.ListBuilds()
+	list, err := db.ListBuilds(context.TODO())
 	if err != nil {
 		t.Errorf("unable to list builds: %v", err)
 	}
@@ -254,7 +255,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	methods["ListBuilds"] = true
 
 	// list the builds for a deployment
-	list, count, err = db.ListBuildsForDeployment(resources.Deployments[0], nil, 1, 10)
+	list, count, err = db.ListBuildsForDeployment(context.TODO(), resources.Deployments[0], nil, 1, 10)
 	if err != nil {
 		t.Errorf("unable to list builds for deployment %d: %v", resources.Deployments[0].GetID(), err)
 	}
@@ -267,7 +268,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	methods["ListBuildsForDeployment"] = true
 
 	// list the builds for an org
-	list, count, err = db.ListBuildsForOrg(resources.Repos[0].GetOrg(), nil, 1, 10)
+	list, count, err = db.ListBuildsForOrg(context.TODO(), resources.Repos[0].GetOrg(), nil, 1, 10)
 	if err != nil {
 		t.Errorf("unable to list builds for org %s: %v", resources.Repos[0].GetOrg(), err)
 	}
@@ -280,7 +281,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	methods["ListBuildsForOrg"] = true
 
 	// list the builds for a repo
-	list, count, err = db.ListBuildsForRepo(resources.Repos[0], nil, time.Now().UTC().Unix(), 0, 1, 10)
+	list, count, err = db.ListBuildsForRepo(context.TODO(), resources.Repos[0], nil, time.Now().UTC().Unix(), 0, 1, 10)
 	if err != nil {
 		t.Errorf("unable to list builds for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
@@ -293,7 +294,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	methods["ListBuildsForRepo"] = true
 
 	// list the pending and running builds
-	queueList, err := db.ListPendingAndRunningBuilds("0")
+	queueList, err := db.ListPendingAndRunningBuilds(context.TODO(), "0")
 	if err != nil {
 		t.Errorf("unable to list pending and running builds: %v", err)
 	}
@@ -303,7 +304,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	methods["ListPendingAndRunningBuilds"] = true
 
 	// lookup the last build by repo
-	got, err := db.LastBuildForRepo(resources.Repos[0], "main")
+	got, err := db.LastBuildForRepo(context.TODO(), resources.Repos[0], "main")
 	if err != nil {
 		t.Errorf("unable to get last build for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
@@ -315,7 +316,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	// lookup the builds by repo and number
 	for _, build := range resources.Builds {
 		repo := resources.Repos[build.GetRepoID()-1]
-		got, err = db.GetBuildForRepo(repo, build.GetNumber())
+		got, err = db.GetBuildForRepo(context.TODO(), repo, build.GetNumber())
 		if err != nil {
 			t.Errorf("unable to get build %d for repo %d: %v", build.GetID(), repo.GetID(), err)
 		}
@@ -326,7 +327,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	methods["GetBuildForRepo"] = true
 
 	// clean the builds
-	count, err = db.CleanBuilds("integration testing", 1563474090)
+	count, err = db.CleanBuilds(context.TODO(), "integration testing", 1563474090)
 	if err != nil {
 		t.Errorf("unable to clean builds: %v", err)
 	}
@@ -338,13 +339,13 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	// update the builds
 	for _, build := range resources.Builds {
 		build.SetStatus("success")
-		_, err = db.UpdateBuild(build)
+		_, err = db.UpdateBuild(context.TODO(), build)
 		if err != nil {
 			t.Errorf("unable to update build %d: %v", build.GetID(), err)
 		}
 
 		// lookup the build by ID
-		got, err = db.GetBuild(build.GetID())
+		got, err = db.GetBuild(context.TODO(), build.GetID())
 		if err != nil {
 			t.Errorf("unable to get build %d by ID: %v", build.GetID(), err)
 		}
@@ -357,7 +358,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 
 	// delete the builds
 	for _, build := range resources.Builds {
-		err = db.DeleteBuild(build)
+		err = db.DeleteBuild(context.TODO(), build)
 		if err != nil {
 			t.Errorf("unable to delete build %d: %v", build.GetID(), err)
 		}

--- a/database/resource.go
+++ b/database/resource.go
@@ -5,6 +5,8 @@
 package database
 
 import (
+	"context"
+
 	"github.com/go-vela/server/database/build"
 	"github.com/go-vela/server/database/hook"
 	"github.com/go-vela/server/database/log"
@@ -19,11 +21,12 @@ import (
 )
 
 // NewResources creates and returns the database agnostic engines for resources.
-func (e *engine) NewResources() error {
+func (e *engine) NewResources(ctx context.Context) error {
 	var err error
 
 	// create the database agnostic engine for builds
 	e.BuildInterface, err = build.New(
+		build.WithContext(e.ctx),
 		build.WithClient(e.client),
 		build.WithLogger(e.logger),
 		build.WithSkipCreation(e.config.SkipCreation),

--- a/database/resource_test.go
+++ b/database/resource_test.go
@@ -5,6 +5,7 @@
 package database
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -94,7 +95,7 @@ func TestDatabase_Engine_NewResources(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.database.NewResources()
+			err := test.database.NewResources(context.TODO())
 
 			if test.failure {
 				if err == nil {

--- a/router/middleware/build/build.go
+++ b/router/middleware/build/build.go
@@ -30,6 +30,7 @@ func Establish() gin.HandlerFunc {
 		o := org.Retrieve(c)
 		r := repo.Retrieve(c)
 		u := user.Retrieve(c)
+		ctx := c.Request.Context()
 
 		if r == nil {
 			retErr := fmt.Errorf("repo %s/%s not found", util.PathParameter(c, "org"), util.PathParameter(c, "repo"))
@@ -64,7 +65,7 @@ func Establish() gin.HandlerFunc {
 			"user":  u.GetName(),
 		}).Debugf("reading build %s/%d", r.GetFullName(), number)
 
-		b, err := database.FromContext(c).GetBuildForRepo(r, number)
+		b, err := database.FromContext(c).GetBuildForRepo(ctx, r, number)
 		if err != nil {
 			retErr := fmt.Errorf("unable to read build %s/%d: %w", r.GetFullName(), number, err)
 			util.HandleError(c, http.StatusNotFound, retErr)

--- a/router/middleware/build/build_test.go
+++ b/router/middleware/build/build_test.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -89,13 +90,13 @@ func TestBuild_Establish(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteBuild(want)
+		db.DeleteBuild(context.TODO(), want)
 		db.DeleteRepo(r)
 		db.Close()
 	}()
 
 	_, _ = db.CreateRepo(r)
-	_, _ = db.CreateBuild(want)
+	_, _ = db.CreateBuild(context.TODO(), want)
 
 	// setup context
 	gin.SetMode(gin.TestMode)

--- a/router/middleware/perm/perm_test.go
+++ b/router/middleware/perm/perm_test.go
@@ -5,6 +5,7 @@
 package perm
 
 import (
+	_context "context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -441,14 +442,16 @@ func TestPerm_MustBuildAccess(t *testing.T) {
 		t.Errorf("unable to create test database engine: %v", err)
 	}
 
+	ctx := _context.TODO()
+
 	defer func() {
-		db.DeleteBuild(b)
+		db.DeleteBuild(ctx, b)
 		db.DeleteRepo(r)
 		db.Close()
 	}()
 
 	_, _ = db.CreateRepo(r)
-	_, _ = db.CreateBuild(b)
+	_, _ = db.CreateBuild(ctx, b)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar/builds/1", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
@@ -524,6 +527,8 @@ func TestPerm_MustBuildAccess_PlatAdmin(t *testing.T) {
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
 
+	ctx := _context.TODO()
+
 	// setup database
 	db, err := database.NewTest()
 	if err != nil {
@@ -531,14 +536,14 @@ func TestPerm_MustBuildAccess_PlatAdmin(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteBuild(b)
+		db.DeleteBuild(ctx, b)
 		db.DeleteRepo(r)
 		db.DeleteUser(u)
 		db.Close()
 	}()
 
 	_, _ = db.CreateRepo(r)
-	_, _ = db.CreateBuild(b)
+	_, _ = db.CreateBuild(ctx, b)
 	_ = db.CreateUser(u)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar/builds/1", nil)
@@ -610,6 +615,8 @@ func TestPerm_MustBuildToken_WrongBuild(t *testing.T) {
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
 
+	ctx := _context.TODO()
+
 	// setup database
 	db, err := database.NewTest()
 	if err != nil {
@@ -617,13 +624,13 @@ func TestPerm_MustBuildToken_WrongBuild(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteBuild(b)
+		db.DeleteBuild(ctx, b)
 		db.DeleteRepo(r)
 		db.Close()
 	}()
 
 	_, _ = db.CreateRepo(r)
-	_, _ = db.CreateBuild(b)
+	_, _ = db.CreateBuild(ctx, b)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar/builds/1", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
@@ -694,6 +701,8 @@ func TestPerm_MustSecretAdmin_BuildToken_Repo(t *testing.T) {
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
 
+	ctx := _context.TODO()
+
 	// setup database
 	db, err := database.NewTest()
 	if err != nil {
@@ -701,13 +710,13 @@ func TestPerm_MustSecretAdmin_BuildToken_Repo(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteBuild(b)
+		db.DeleteBuild(ctx, b)
 		db.DeleteRepo(r)
 		db.Close()
 	}()
 
 	_, _ = db.CreateRepo(r)
-	_, _ = db.CreateBuild(b)
+	_, _ = db.CreateBuild(ctx, b)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/native/repo/foo/bar/baz", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
@@ -775,6 +784,8 @@ func TestPerm_MustSecretAdmin_BuildToken_Org(t *testing.T) {
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
 
+	ctx := _context.TODO()
+
 	// setup database
 	db, err := database.NewTest()
 	if err != nil {
@@ -782,13 +793,13 @@ func TestPerm_MustSecretAdmin_BuildToken_Org(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteBuild(b)
+		db.DeleteBuild(ctx, b)
 		db.DeleteRepo(r)
 		db.Close()
 	}()
 
 	_, _ = db.CreateRepo(r)
-	_, _ = db.CreateBuild(b)
+	_, _ = db.CreateBuild(ctx, b)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/native/org/foo/*/baz", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
@@ -856,6 +867,8 @@ func TestPerm_MustSecretAdmin_BuildToken_Shared(t *testing.T) {
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
 
+	ctx := _context.TODO()
+
 	// setup database
 	db, err := database.NewTest()
 	if err != nil {
@@ -863,13 +876,13 @@ func TestPerm_MustSecretAdmin_BuildToken_Shared(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteBuild(b)
+		db.DeleteBuild(ctx, b)
 		db.DeleteRepo(r)
 		db.Close()
 	}()
 
 	_, _ = db.CreateRepo(r)
-	_, _ = db.CreateBuild(b)
+	_, _ = db.CreateBuild(ctx, b)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/native/shared/foo/*/*", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
@@ -1819,6 +1832,8 @@ func TestPerm_MustRead_WorkerBuildToken(t *testing.T) {
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
 
+	ctx := _context.TODO()
+
 	// setup database
 	db, err := database.NewTest()
 	if err != nil {
@@ -1826,12 +1841,12 @@ func TestPerm_MustRead_WorkerBuildToken(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteBuild(b)
+		db.DeleteBuild(ctx, b)
 		db.DeleteRepo(r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateBuild(b)
+	_, _ = db.CreateBuild(ctx, b)
 	_, _ = db.CreateRepo(r)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar/builds/1", nil)

--- a/router/middleware/service/service_test.go
+++ b/router/middleware/service/service_test.go
@@ -5,6 +5,7 @@
 package service
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -78,14 +79,14 @@ func TestService_Establish(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteBuild(b)
+		db.DeleteBuild(context.TODO(), b)
 		db.DeleteRepo(r)
 		db.DeleteService(want)
 		db.Close()
 	}()
 
 	_, _ = db.CreateRepo(r)
-	_, _ = db.CreateBuild(b)
+	_, _ = db.CreateBuild(context.TODO(), b)
 	_ = db.CreateService(want)
 
 	// setup context
@@ -220,13 +221,13 @@ func TestService_Establish_NoServiceParameter(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteBuild(b)
+		db.DeleteBuild(context.TODO(), b)
 		db.DeleteRepo(r)
 		db.Close()
 	}()
 
 	_, _ = db.CreateRepo(r)
-	_, _ = db.CreateBuild(b)
+	_, _ = db.CreateBuild(context.TODO(), b)
 
 	// setup context
 	gin.SetMode(gin.TestMode)
@@ -276,13 +277,13 @@ func TestService_Establish_InvalidServiceParameter(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteBuild(b)
+		db.DeleteBuild(context.TODO(), b)
 		db.DeleteRepo(r)
 		db.Close()
 	}()
 
 	_, _ = db.CreateRepo(r)
-	_, _ = db.CreateBuild(b)
+	_, _ = db.CreateBuild(context.TODO(), b)
 
 	// setup context
 	gin.SetMode(gin.TestMode)
@@ -332,13 +333,13 @@ func TestService_Establish_NoService(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteBuild(b)
+		db.DeleteBuild(context.TODO(), b)
 		db.DeleteRepo(r)
 		db.Close()
 	}()
 
 	_, _ = db.CreateRepo(r)
-	_, _ = db.CreateBuild(b)
+	_, _ = db.CreateBuild(context.TODO(), b)
 
 	// setup context
 	gin.SetMode(gin.TestMode)

--- a/router/middleware/step/step_test.go
+++ b/router/middleware/step/step_test.go
@@ -5,6 +5,7 @@
 package step
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -80,14 +81,14 @@ func TestStep_Establish(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteBuild(b)
+		db.DeleteBuild(context.TODO(), b)
 		db.DeleteRepo(r)
 		db.DeleteStep(want)
 		db.Close()
 	}()
 
 	_, _ = db.CreateRepo(r)
-	_, _ = db.CreateBuild(b)
+	_, _ = db.CreateBuild(context.TODO(), b)
 	_ = db.CreateStep(want)
 
 	// setup context
@@ -222,13 +223,13 @@ func TestStep_Establish_NoStepParameter(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteBuild(b)
+		db.DeleteBuild(context.TODO(), b)
 		db.DeleteRepo(r)
 		db.Close()
 	}()
 
 	_, _ = db.CreateRepo(r)
-	_, _ = db.CreateBuild(b)
+	_, _ = db.CreateBuild(context.TODO(), b)
 
 	// setup context
 	gin.SetMode(gin.TestMode)
@@ -278,13 +279,13 @@ func TestStep_Establish_InvalidStepParameter(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteBuild(b)
+		db.DeleteBuild(context.TODO(), b)
 		db.DeleteRepo(r)
 		db.Close()
 	}()
 
 	_, _ = db.CreateRepo(r)
-	_, _ = db.CreateBuild(b)
+	_, _ = db.CreateBuild(context.TODO(), b)
 
 	// setup context
 	gin.SetMode(gin.TestMode)
@@ -334,13 +335,13 @@ func TestStep_Establish_NoStep(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteBuild(b)
+		db.DeleteBuild(context.TODO(), b)
 		db.DeleteRepo(r)
 		db.Close()
 	}()
 
 	_, _ = db.CreateRepo(r)
-	_, _ = db.CreateBuild(b)
+	_, _ = db.CreateBuild(context.TODO(), b)
 
 	// setup context
 	gin.SetMode(gin.TestMode)


### PR DESCRIPTION
continuing the efforts started in #898

this is prep to add support for OpenTelemetry tracing.

the reason being, otel can (for the most part) work out of the box if you pass around contexts properly.