### PR TITLE
fix: getting visbility to match on vela and SCM

### DIFF
--- a/api/repo/create.go
+++ b/api/repo/create.go
@@ -140,10 +140,8 @@ func CreateRepo(c *gin.Context) {
 	}
 
 	// set the visibility field based off the input provided
-	if len(input.GetVisibility()) == 0 {
-		// default visibility field to public
-		r.SetVisibility(constants.VisibilityPublic)
-	} else {
+	if len(input.GetVisibility()) > 0 {
+		// default visibility field to the input visibility
 		r.SetVisibility(input.GetVisibility())
 	}
 

--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -465,15 +465,24 @@ func (c *client) ListUserRepos(u *library.User) ([]*library.Repo, error) {
 
 // toLibraryRepo does a partial conversion of a github repo to a library repo.
 func toLibraryRepo(gr github.Repository) *library.Repo {
+	// setting the visbility to match the SCM visbility
+	var visibility string
+	if *gr.Private {
+		visibility = constants.VisibilityPrivate
+	} else {
+		visibility = constants.VisibilityPublic
+	}
+
 	return &library.Repo{
-		Org:      gr.GetOwner().Login,
-		Name:     gr.Name,
-		FullName: gr.FullName,
-		Link:     gr.HTMLURL,
-		Clone:    gr.CloneURL,
-		Branch:   gr.DefaultBranch,
-		Topics:   &gr.Topics,
-		Private:  gr.Private,
+		Org:        gr.GetOwner().Login,
+		Name:       gr.Name,
+		FullName:   gr.FullName,
+		Link:       gr.HTMLURL,
+		Clone:      gr.CloneURL,
+		Branch:     gr.DefaultBranch,
+		Topics:     &gr.Topics,
+		Private:    gr.Private,
+		Visibility: &visibility,
 	}
 }
 

--- a/scm/github/repo_test.go
+++ b/scm/github/repo_test.go
@@ -1028,6 +1028,7 @@ func TestGithub_GetRepo(t *testing.T) {
 	want.SetBranch("master")
 	want.SetPrivate(false)
 	want.SetTopics([]string{"octocat", "atom", "electron", "api"})
+	want.SetVisibility("public")
 
 	client, _ := NewTest(s.URL)
 
@@ -1191,6 +1192,7 @@ func TestGithub_ListUserRepos(t *testing.T) {
 	r.SetBranch("master")
 	r.SetPrivate(false)
 	r.SetTopics([]string{"octocat", "atom", "electron", "api"})
+	r.SetVisibility("public")
 
 	want := []*library.Repo{r}
 


### PR DESCRIPTION
Corresponds with issue "when enabling a private repo in scm, set it to private in vela as well" #784: 
[https://github.com/go-vela/community/issues/784]