### PR TITLE
chore: add context to repos functions

### DIFF
--- a/api/admin/repo.go
+++ b/api/admin/repo.go
@@ -53,6 +53,9 @@ import (
 func UpdateRepo(c *gin.Context) {
 	logrus.Info("Admin: updating repo in database")
 
+	// capture middleware values
+	ctx := c.Request.Context()
+
 	// capture body from API request
 	input := new(library.Repo)
 
@@ -66,7 +69,7 @@ func UpdateRepo(c *gin.Context) {
 	}
 
 	// send API call to update the repo
-	r, err := database.FromContext(c).UpdateRepo(input)
+	r, err := database.FromContext(c).UpdateRepo(ctx, input)
 	if err != nil {
 		retErr := fmt.Errorf("unable to update repo %d: %w", input.GetID(), err)
 

--- a/api/build/create.go
+++ b/api/build/create.go
@@ -330,7 +330,7 @@ func CreateBuild(c *gin.Context) {
 	}
 
 	// send API call to update repo for ensuring counter is incremented
-	r, err = database.FromContext(c).UpdateRepo(r)
+	r, err = database.FromContext(c).UpdateRepo(ctx, r)
 	if err != nil {
 		retErr := fmt.Errorf("unable to create new build: failed to update repo %s: %w", r.GetFullName(), err)
 

--- a/api/build/get_id.go
+++ b/api/build/get_id.go
@@ -90,7 +90,7 @@ func GetBuildByID(c *gin.Context) {
 	}
 
 	// Get repo from database using repo ID field from build
-	r, err = database.FromContext(c).GetRepo(b.GetRepoID())
+	r, err = database.FromContext(c).GetRepo(ctx, b.GetRepoID())
 	if err != nil {
 		retErr := fmt.Errorf("unable to get repo: %w", err)
 

--- a/api/build/restart.go
+++ b/api/build/restart.go
@@ -321,7 +321,7 @@ func RestartBuild(c *gin.Context) {
 	}
 
 	// send API call to update repo for ensuring counter is incremented
-	r, err = database.FromContext(c).UpdateRepo(r)
+	r, err = database.FromContext(c).UpdateRepo(ctx, r)
 	if err != nil {
 		retErr := fmt.Errorf("unable to restart build: failed to update repo %s: %w", r.GetFullName(), err)
 		util.HandleError(c, http.StatusBadRequest, retErr)

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -261,7 +261,7 @@ func recordGauges(c *gin.Context) {
 	// repo_count
 	if q.RepoCount {
 		// send API call to capture the total number of repos
-		r, err := database.FromContext(c).CountRepos()
+		r, err := database.FromContext(c).CountRepos(ctx)
 		if err != nil {
 			logrus.Errorf("unable to get count of all repos: %v", err)
 		}

--- a/api/repo/chown.go
+++ b/api/repo/chown.go
@@ -54,6 +54,7 @@ func ChownRepo(c *gin.Context) {
 	o := org.Retrieve(c)
 	r := repo.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	// update engine logger with API metadata
 	//
@@ -68,7 +69,7 @@ func ChownRepo(c *gin.Context) {
 	r.SetUserID(u.GetID())
 
 	// send API call to update the repo
-	_, err := database.FromContext(c).UpdateRepo(r)
+	_, err := database.FromContext(c).UpdateRepo(ctx, r)
 	if err != nil {
 		retErr := fmt.Errorf("unable to change owner of repo %s to %s: %w", r.GetFullName(), u.GetName(), err)
 

--- a/api/repo/create.go
+++ b/api/repo/create.go
@@ -75,6 +75,7 @@ func CreateRepo(c *gin.Context) {
 	defaultTimeout := c.Value("defaultTimeout").(int64)
 	maxBuildLimit := c.Value("maxBuildLimit").(int64)
 	defaultRepoEvents := c.Value("defaultRepoEvents").([]string)
+	ctx := c.Request.Context()
 
 	// capture body from API request
 	input := new(library.Repo)
@@ -221,7 +222,7 @@ func CreateRepo(c *gin.Context) {
 	}
 
 	// send API call to capture the repo from the database
-	dbRepo, err := database.FromContext(c).GetRepoForOrg(r.GetOrg(), r.GetName())
+	dbRepo, err := database.FromContext(c).GetRepoForOrg(ctx, r.GetOrg(), r.GetName())
 	if err == nil && dbRepo.GetActive() {
 		retErr := fmt.Errorf("unable to activate repo: %s is already active", r.GetFullName())
 
@@ -283,7 +284,7 @@ func CreateRepo(c *gin.Context) {
 		dbRepo.SetActive(true)
 
 		// send API call to update the repo
-		r, err = database.FromContext(c).UpdateRepo(dbRepo)
+		r, err = database.FromContext(c).UpdateRepo(ctx, dbRepo)
 		if err != nil {
 			retErr := fmt.Errorf("unable to set repo %s to active: %w", dbRepo.GetFullName(), err)
 
@@ -293,7 +294,7 @@ func CreateRepo(c *gin.Context) {
 		}
 	} else {
 		// send API call to create the repo
-		r, err = database.FromContext(c).CreateRepo(r)
+		r, err = database.FromContext(c).CreateRepo(ctx, r)
 		if err != nil {
 			retErr := fmt.Errorf("unable to create new repo %s: %w", r.GetFullName(), err)
 

--- a/api/repo/delete.go
+++ b/api/repo/delete.go
@@ -59,6 +59,7 @@ func DeleteRepo(c *gin.Context) {
 	o := org.Retrieve(c)
 	r := repo.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	// update engine logger with API metadata
 	//
@@ -88,7 +89,7 @@ func DeleteRepo(c *gin.Context) {
 	// Mark the repo as inactive
 	r.SetActive(false)
 
-	_, err = database.FromContext(c).UpdateRepo(r)
+	_, err = database.FromContext(c).UpdateRepo(ctx, r)
 	if err != nil {
 		retErr := fmt.Errorf("unable to set repo %s to inactive: %w", r.GetFullName(), err)
 

--- a/api/repo/list.go
+++ b/api/repo/list.go
@@ -66,6 +66,7 @@ import (
 func ListRepos(c *gin.Context) {
 	// capture middleware values
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	// update engine logger with API metadata
 	//
@@ -108,7 +109,7 @@ func ListRepos(c *gin.Context) {
 	}
 
 	// send API call to capture the list of repos for the user
-	r, t, err := database.FromContext(c).ListReposForUser(u, sortBy, filters, page, perPage)
+	r, t, err := database.FromContext(c).ListReposForUser(ctx, u, sortBy, filters, page, perPage)
 	if err != nil {
 		retErr := fmt.Errorf("unable to get repos for user %s: %w", u.GetName(), err)
 

--- a/api/repo/list_org.go
+++ b/api/repo/list_org.go
@@ -88,6 +88,7 @@ func ListReposForOrg(c *gin.Context) {
 	// capture middleware values
 	o := org.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	// update engine logger with API metadata
 	//
@@ -141,7 +142,7 @@ func ListReposForOrg(c *gin.Context) {
 	}
 
 	// send API call to capture the list of repos for the org
-	r, t, err := database.FromContext(c).ListReposForOrg(o, sortBy, filters, page, perPage)
+	r, t, err := database.FromContext(c).ListReposForOrg(ctx, o, sortBy, filters, page, perPage)
 	if err != nil {
 		retErr := fmt.Errorf("unable to get repos for org %s: %w", o, err)
 

--- a/api/repo/repair.go
+++ b/api/repo/repair.go
@@ -55,6 +55,7 @@ func RepairRepo(c *gin.Context) {
 	o := org.Retrieve(c)
 	r := repo.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	// update engine logger with API metadata
 	//
@@ -122,7 +123,7 @@ func RepairRepo(c *gin.Context) {
 		r.SetActive(true)
 
 		// send API call to update the repo
-		_, err := database.FromContext(c).UpdateRepo(r)
+		_, err := database.FromContext(c).UpdateRepo(ctx, r)
 		if err != nil {
 			retErr := fmt.Errorf("unable to set repo %s to active: %w", r.GetFullName(), err)
 

--- a/api/repo/update.go
+++ b/api/repo/update.go
@@ -77,6 +77,7 @@ func UpdateRepo(c *gin.Context) {
 	r := repo.Retrieve(c)
 	u := user.Retrieve(c)
 	maxBuildLimit := c.Value("maxBuildLimit").(int64)
+	ctx := c.Request.Context()
 
 	// update engine logger with API metadata
 	//
@@ -295,7 +296,7 @@ func UpdateRepo(c *gin.Context) {
 	}
 
 	// send API call to update the repo
-	r, err = database.FromContext(c).UpdateRepo(r)
+	r, err = database.FromContext(c).UpdateRepo(ctx, r)
 	if err != nil {
 		retErr := fmt.Errorf("unable to update repo %s: %w", r.GetFullName(), err)
 

--- a/api/scm/sync.go
+++ b/api/scm/sync.go
@@ -59,6 +59,7 @@ func SyncRepo(c *gin.Context) {
 	o := org.Retrieve(c)
 	r := repo.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	// update engine logger with API metadata
 	//
@@ -80,7 +81,7 @@ func SyncRepo(c *gin.Context) {
 		r.SetActive(false)
 
 		// update repo in database
-		_, err := database.FromContext(c).UpdateRepo(r)
+		_, err := database.FromContext(c).UpdateRepo(ctx, r)
 		if err != nil {
 			retErr := fmt.Errorf("unable to update repo for org %s: %w", o, err)
 

--- a/api/scm/sync_org.go
+++ b/api/scm/sync_org.go
@@ -52,6 +52,7 @@ func SyncReposForOrg(c *gin.Context) {
 	// capture middleware values
 	o := org.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	// update engine logger with API metadata
 	//
@@ -79,7 +80,7 @@ func SyncReposForOrg(c *gin.Context) {
 	}
 
 	// send API call to capture the total number of repos for the org
-	t, err := database.FromContext(c).CountReposForOrg(o, map[string]interface{}{})
+	t, err := database.FromContext(c).CountReposForOrg(ctx, o, map[string]interface{}{})
 	if err != nil {
 		retErr := fmt.Errorf("unable to get repo count for org %s: %w", o, err)
 
@@ -92,7 +93,7 @@ func SyncReposForOrg(c *gin.Context) {
 	page := 0
 	// capture all repos belonging to a certain org in database
 	for orgRepos := int64(0); orgRepos < t; orgRepos += 100 {
-		r, _, err := database.FromContext(c).ListReposForOrg(o, "name", map[string]interface{}{}, page, 100)
+		r, _, err := database.FromContext(c).ListReposForOrg(ctx, o, "name", map[string]interface{}{}, page, 100)
 		if err != nil {
 			retErr := fmt.Errorf("unable to get repo count for org %s: %w", o, err)
 
@@ -113,7 +114,7 @@ func SyncReposForOrg(c *gin.Context) {
 		if err != nil {
 			repo.SetActive(false)
 
-			_, err := database.FromContext(c).UpdateRepo(repo)
+			_, err := database.FromContext(c).UpdateRepo(ctx, repo)
 			if err != nil {
 				retErr := fmt.Errorf("unable to update repo for org %s: %w", o, err)
 

--- a/api/user/get_source.go
+++ b/api/user/get_source.go
@@ -41,6 +41,7 @@ import (
 func GetSourceRepos(c *gin.Context) {
 	// capture middleware values
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	// update engine logger with API metadata
 	//
@@ -88,7 +89,7 @@ func GetSourceRepos(c *gin.Context) {
 
 		for page > 0 {
 			// send API call to capture the list of repos for the org
-			dbReposPart, _, err := database.FromContext(c).ListReposForOrg(org, "name", filters, page, 100)
+			dbReposPart, _, err := database.FromContext(c).ListReposForOrg(ctx, org, "name", filters, page, 100)
 			if err != nil {
 				retErr := fmt.Errorf("unable to get repos for org %s: %w", org, err)
 

--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -6,6 +6,7 @@ package webhook
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -135,7 +136,7 @@ func PostWebhook(c *gin.Context) {
 
 	// if event is repository event, handle separately and return
 	if strings.EqualFold(h.GetEvent(), constants.EventRepository) {
-		r, err = handleRepositoryEvent(c, m, h, r)
+		r, err = handleRepositoryEvent(ctx, c, m, h, r)
 		if err != nil {
 			util.HandleError(c, http.StatusInternalServerError, err)
 			return
@@ -184,7 +185,7 @@ func PostWebhook(c *gin.Context) {
 	}()
 
 	// send API call to capture parsed repo from webhook
-	repo, err := database.FromContext(c).GetRepoForOrg(r.GetOrg(), r.GetName())
+	repo, err := database.FromContext(c).GetRepoForOrg(ctx, r.GetOrg(), r.GetName())
 	if err != nil {
 		retErr := fmt.Errorf("%s: failed to get repo %s: %w", baseErr, r.GetFullName(), err)
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -445,7 +446,7 @@ func PostWebhook(c *gin.Context) {
 		}
 
 		// send API call to capture repo for the counter (grabbing repo again to ensure counter is correct)
-		repo, err = database.FromContext(c).GetRepoForOrg(repo.GetOrg(), repo.GetName())
+		repo, err = database.FromContext(c).GetRepoForOrg(ctx, repo.GetOrg(), repo.GetName())
 		if err != nil {
 			retErr := fmt.Errorf("%s: unable to get repo %s: %w", baseErr, r.GetFullName(), err)
 
@@ -621,7 +622,7 @@ func PostWebhook(c *gin.Context) {
 	} // end of retry loop
 
 	// send API call to update repo for ensuring counter is incremented
-	repo, err = database.FromContext(c).UpdateRepo(repo)
+	repo, err = database.FromContext(c).UpdateRepo(ctx, repo)
 	if err != nil {
 		retErr := fmt.Errorf("%s: failed to update repo %s: %w", baseErr, repo.GetFullName(), err)
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -689,7 +690,7 @@ func PostWebhook(c *gin.Context) {
 	)
 }
 
-func handleRepositoryEvent(c *gin.Context, m *types.Metadata, h *library.Hook, r *library.Repo) (*library.Repo, error) {
+func handleRepositoryEvent(ctx context.Context, c *gin.Context, m *types.Metadata, h *library.Hook, r *library.Repo) (*library.Repo, error) {
 	logrus.Debugf("webhook is repository event, making necessary updates to repo %s", r.GetFullName())
 
 	defer func() {
@@ -703,7 +704,7 @@ func handleRepositoryEvent(c *gin.Context, m *types.Metadata, h *library.Hook, r
 	switch h.GetEventAction() {
 	// if action is rename, go through rename routine
 	case constants.ActionRenamed, constants.ActionTransferred:
-		r, err := renameRepository(h, r, c, m)
+		r, err := renameRepository(ctx, h, r, c, m)
 		if err != nil {
 			h.SetStatus(constants.StatusFailure)
 			h.SetError(err.Error())
@@ -716,7 +717,7 @@ func handleRepositoryEvent(c *gin.Context, m *types.Metadata, h *library.Hook, r
 	case "archived", "unarchived", constants.ActionEdited:
 		logrus.Debugf("repository action %s for %s", h.GetEventAction(), r.GetFullName())
 		// send call to get repository from database
-		dbRepo, err := database.FromContext(c).GetRepoForOrg(r.GetOrg(), r.GetName())
+		dbRepo, err := database.FromContext(c).GetRepoForOrg(ctx, r.GetOrg(), r.GetName())
 		if err != nil {
 			retErr := fmt.Errorf("%s: failed to get repo %s: %w", baseErr, r.GetFullName(), err)
 
@@ -760,7 +761,7 @@ func handleRepositoryEvent(c *gin.Context, m *types.Metadata, h *library.Hook, r
 		}
 
 		// update repo object in the database after applying edits
-		dbRepo, err = database.FromContext(c).UpdateRepo(dbRepo)
+		dbRepo, err = database.FromContext(c).UpdateRepo(ctx, dbRepo)
 		if err != nil {
 			retErr := fmt.Errorf("%s: failed to update repo %s: %w", baseErr, r.GetFullName(), err)
 
@@ -781,17 +782,14 @@ func handleRepositoryEvent(c *gin.Context, m *types.Metadata, h *library.Hook, r
 // queries the database for the repo that matches that name and org, and updates
 // that repo to its new name in order to preserve it. It also updates the secrets
 // associated with that repo as well as build links for the UI.
-func renameRepository(h *library.Hook, r *library.Repo, c *gin.Context, m *types.Metadata) (*library.Repo, error) {
+func renameRepository(ctx context.Context, h *library.Hook, r *library.Repo, c *gin.Context, m *types.Metadata) (*library.Repo, error) {
 	logrus.Infof("renaming repository from %s to %s", r.GetPreviousName(), r.GetName())
-
-	// capture context from gin
-	ctx := c.Request.Context()
 
 	// get the old name of the repo
 	prevOrg, prevRepo := util.SplitFullName(r.GetPreviousName())
 
 	// get the repo from the database that matches the old name
-	dbR, err := database.FromContext(c).GetRepoForOrg(prevOrg, prevRepo)
+	dbR, err := database.FromContext(c).GetRepoForOrg(ctx, prevOrg, prevRepo)
 	if err != nil {
 		retErr := fmt.Errorf("%s: failed to get repo %s/%s from database", baseErr, prevOrg, prevRepo)
 		util.HandleError(c, http.StatusBadRequest, retErr)
@@ -896,7 +894,7 @@ func renameRepository(h *library.Hook, r *library.Repo, c *gin.Context, m *types
 	dbR.SetPreviousName(r.GetPreviousName())
 
 	// update the repo in the database
-	dbR, err = database.FromContext(c).UpdateRepo(dbR)
+	dbR, err = database.FromContext(c).UpdateRepo(ctx, dbR)
 	if err != nil {
 		retErr := fmt.Errorf("%s: failed to update repo %s/%s in database", baseErr, prevOrg, prevRepo)
 		util.HandleError(c, http.StatusBadRequest, retErr)

--- a/cmd/vela-server/schedule.go
+++ b/cmd/vela-server/schedule.go
@@ -138,7 +138,7 @@ func processSchedules(ctx context.Context, start time.Time, compiler compiler.En
 //nolint:funlen // ignore function length and number of statements
 func processSchedule(ctx context.Context, s *library.Schedule, compiler compiler.Engine, database database.Interface, metadata *types.Metadata, queue queue.Service, scm scm.Service) error {
 	// send API call to capture the repo for the schedule
-	r, err := database.GetRepo(s.GetRepoID())
+	r, err := database.GetRepo(ctx, s.GetRepoID())
 	if err != nil {
 		return fmt.Errorf("unable to fetch repo: %w", err)
 	}
@@ -249,7 +249,7 @@ func processSchedule(ctx context.Context, s *library.Schedule, compiler compiler
 		}
 
 		// send API call to capture repo for the counter (grabbing repo again to ensure counter is correct)
-		r, err = database.GetRepoForOrg(r.GetOrg(), r.GetName())
+		r, err = database.GetRepoForOrg(ctx, r.GetOrg(), r.GetName())
 		if err != nil {
 			err = fmt.Errorf("unable to get repo %s: %w", r.GetFullName(), err)
 
@@ -374,7 +374,7 @@ func processSchedule(ctx context.Context, s *library.Schedule, compiler compiler
 	} // end of retry loop
 
 	// send API call to update repo for ensuring counter is incremented
-	r, err = database.UpdateRepo(r)
+	r, err = database.UpdateRepo(ctx, r)
 	if err != nil {
 		return fmt.Errorf("unable to update repo %s: %w", r.GetFullName(), err)
 	}

--- a/database/integration_test.go
+++ b/database/integration_test.go
@@ -165,7 +165,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 
 	// create the repos for build related functions
 	for _, repo := range resources.Repos {
-		_, err := db.CreateRepo(repo)
+		_, err := db.CreateRepo(context.TODO(), repo)
 		if err != nil {
 			t.Errorf("unable to create repo %d: %v", repo.GetID(), err)
 		}
@@ -367,7 +367,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 
 	// delete the repos for build related functions
 	for _, repo := range resources.Repos {
-		err = db.DeleteRepo(repo)
+		err = db.DeleteRepo(context.TODO(), repo)
 		if err != nil {
 			t.Errorf("unable to delete repo %d: %v", repo.GetID(), err)
 		}
@@ -784,7 +784,7 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 
 	// create the repos
 	for _, repo := range resources.Repos {
-		_, err := db.CreateRepo(repo)
+		_, err := db.CreateRepo(context.TODO(), repo)
 		if err != nil {
 			t.Errorf("unable to create repo %d: %v", repo.GetID(), err)
 		}
@@ -792,7 +792,7 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 	methods["CreateRepo"] = true
 
 	// count the repos
-	count, err := db.CountRepos()
+	count, err := db.CountRepos(context.TODO())
 	if err != nil {
 		t.Errorf("unable to count repos: %v", err)
 	}
@@ -802,7 +802,7 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 	methods["CountRepos"] = true
 
 	// count the repos for an org
-	count, err = db.CountReposForOrg(resources.Repos[0].GetOrg(), nil)
+	count, err = db.CountReposForOrg(context.TODO(), resources.Repos[0].GetOrg(), nil)
 	if err != nil {
 		t.Errorf("unable to count repos for org %s: %v", resources.Repos[0].GetOrg(), err)
 	}
@@ -812,7 +812,7 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 	methods["CountReposForOrg"] = true
 
 	// count the repos for a user
-	count, err = db.CountReposForUser(resources.Users[0], nil)
+	count, err = db.CountReposForUser(context.TODO(), resources.Users[0], nil)
 	if err != nil {
 		t.Errorf("unable to count repos for user %d: %v", resources.Users[0].GetID(), err)
 	}
@@ -822,7 +822,7 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 	methods["CountReposForUser"] = true
 
 	// list the repos
-	list, err := db.ListRepos()
+	list, err := db.ListRepos(context.TODO())
 	if err != nil {
 		t.Errorf("unable to list repos: %v", err)
 	}
@@ -832,7 +832,7 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 	methods["ListRepos"] = true
 
 	// list the repos for an org
-	list, count, err = db.ListReposForOrg(resources.Repos[0].GetOrg(), "name", nil, 1, 10)
+	list, count, err = db.ListReposForOrg(context.TODO(), resources.Repos[0].GetOrg(), "name", nil, 1, 10)
 	if err != nil {
 		t.Errorf("unable to list repos for org %s: %v", resources.Repos[0].GetOrg(), err)
 	}
@@ -845,7 +845,7 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 	methods["ListReposForOrg"] = true
 
 	// list the repos for a user
-	list, count, err = db.ListReposForUser(resources.Users[0], "name", nil, 1, 10)
+	list, count, err = db.ListReposForUser(context.TODO(), resources.Users[0], "name", nil, 1, 10)
 	if err != nil {
 		t.Errorf("unable to list repos for user %d: %v", resources.Users[0].GetID(), err)
 	}
@@ -859,7 +859,7 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 
 	// lookup the repos by name
 	for _, repo := range resources.Repos {
-		got, err := db.GetRepoForOrg(repo.GetOrg(), repo.GetName())
+		got, err := db.GetRepoForOrg(context.TODO(), repo.GetOrg(), repo.GetName())
 		if err != nil {
 			t.Errorf("unable to get repo %d by org: %v", repo.GetID(), err)
 		}
@@ -872,13 +872,13 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 	// update the repos
 	for _, repo := range resources.Repos {
 		repo.SetActive(false)
-		_, err = db.UpdateRepo(repo)
+		_, err = db.UpdateRepo(context.TODO(), repo)
 		if err != nil {
 			t.Errorf("unable to update repo %d: %v", repo.GetID(), err)
 		}
 
 		// lookup the repo by ID
-		got, err := db.GetRepo(repo.GetID())
+		got, err := db.GetRepo(context.TODO(), repo.GetID())
 		if err != nil {
 			t.Errorf("unable to get repo %d by ID: %v", repo.GetID(), err)
 		}
@@ -891,7 +891,7 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 
 	// delete the repos
 	for _, repo := range resources.Repos {
-		err = db.DeleteRepo(repo)
+		err = db.DeleteRepo(context.TODO(), repo)
 		if err != nil {
 			t.Errorf("unable to delete repo %d: %v", repo.GetID(), err)
 		}

--- a/database/repo/count.go
+++ b/database/repo/count.go
@@ -5,11 +5,13 @@
 package repo
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 )
 
 // CountRepos gets the count of all repos from the database.
-func (e *engine) CountRepos() (int64, error) {
+func (e *engine) CountRepos(ctx context.Context) (int64, error) {
 	e.logger.Tracef("getting count of all repos from the database")
 
 	// variable to store query results

--- a/database/repo/count_org.go
+++ b/database/repo/count_org.go
@@ -5,12 +5,14 @@
 package repo
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/sirupsen/logrus"
 )
 
 // CountReposForOrg gets the count of repos by org name from the database.
-func (e *engine) CountReposForOrg(org string, filters map[string]interface{}) (int64, error) {
+func (e *engine) CountReposForOrg(ctx context.Context, org string, filters map[string]interface{}) (int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org": org,
 	}).Tracef("getting count of repos for org %s from the database", org)

--- a/database/repo/count_org_test.go
+++ b/database/repo/count_org_test.go
@@ -5,6 +5,7 @@
 package repo
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -43,12 +44,12 @@ func TestRepo_Engine_CountReposForOrg(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateRepo(_repoOne)
+	_, err := _sqlite.CreateRepo(context.TODO(), _repoOne)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateRepo(_repoTwo)
+	_, err = _sqlite.CreateRepo(context.TODO(), _repoTwo)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
@@ -79,7 +80,7 @@ func TestRepo_Engine_CountReposForOrg(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CountReposForOrg("foo", filters)
+			got, err := test.database.CountReposForOrg(context.TODO(), "foo", filters)
 
 			if test.failure {
 				if err == nil {

--- a/database/repo/count_test.go
+++ b/database/repo/count_test.go
@@ -5,6 +5,7 @@
 package repo
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -43,12 +44,12 @@ func TestRepo_Engine_CountRepos(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateRepo(_repoOne)
+	_, err := _sqlite.CreateRepo(context.TODO(), _repoOne)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateRepo(_repoTwo)
+	_, err = _sqlite.CreateRepo(context.TODO(), _repoTwo)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
@@ -77,7 +78,7 @@ func TestRepo_Engine_CountRepos(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CountRepos()
+			got, err := test.database.CountRepos(context.TODO())
 
 			if test.failure {
 				if err == nil {

--- a/database/repo/count_user.go
+++ b/database/repo/count_user.go
@@ -5,13 +5,15 @@
 package repo
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/sirupsen/logrus"
 )
 
 // CountReposForUser gets the count of repos by user ID from the database.
-func (e *engine) CountReposForUser(u *library.User, filters map[string]interface{}) (int64, error) {
+func (e *engine) CountReposForUser(ctx context.Context, u *library.User, filters map[string]interface{}) (int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"user": u.GetName(),
 	}).Tracef("getting count of repos for user %s from the database", u.GetName())

--- a/database/repo/count_user_test.go
+++ b/database/repo/count_user_test.go
@@ -5,6 +5,7 @@
 package repo
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -49,12 +50,12 @@ func TestRepo_Engine_CountReposForUser(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateRepo(_repoOne)
+	_, err := _sqlite.CreateRepo(context.TODO(), _repoOne)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateRepo(_repoTwo)
+	_, err = _sqlite.CreateRepo(context.TODO(), _repoTwo)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
@@ -85,7 +86,7 @@ func TestRepo_Engine_CountReposForUser(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CountReposForUser(_user, filters)
+			got, err := test.database.CountReposForUser(context.TODO(), _user, filters)
 
 			if test.failure {
 				if err == nil {

--- a/database/repo/create.go
+++ b/database/repo/create.go
@@ -6,6 +6,7 @@
 package repo
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-vela/types/constants"
@@ -15,7 +16,7 @@ import (
 )
 
 // CreateRepo creates a new repo in the database.
-func (e *engine) CreateRepo(r *library.Repo) (*library.Repo, error) {
+func (e *engine) CreateRepo(ctx context.Context, r *library.Repo) (*library.Repo, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),

--- a/database/repo/create_test.go
+++ b/database/repo/create_test.go
@@ -5,6 +5,7 @@
 package repo
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -62,7 +63,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CreateRepo(_repo)
+			got, err := test.database.CreateRepo(context.TODO(), _repo)
 
 			if test.failure {
 				if err == nil {

--- a/database/repo/delete.go
+++ b/database/repo/delete.go
@@ -5,6 +5,8 @@
 package repo
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -12,7 +14,7 @@ import (
 )
 
 // DeleteRepo deletes an existing repo from the database.
-func (e *engine) DeleteRepo(r *library.Repo) error {
+func (e *engine) DeleteRepo(ctx context.Context, r *library.Repo) error {
 	e.logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),

--- a/database/repo/delete_test.go
+++ b/database/repo/delete_test.go
@@ -5,6 +5,7 @@
 package repo
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -32,7 +33,7 @@ func TestRepo_Engine_DeleteRepo(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateRepo(_repo)
+	_, err := _sqlite.CreateRepo(context.TODO(), _repo)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
@@ -58,7 +59,7 @@ func TestRepo_Engine_DeleteRepo(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err = test.database.DeleteRepo(_repo)
+			err = test.database.DeleteRepo(context.TODO(), _repo)
 
 			if test.failure {
 				if err == nil {

--- a/database/repo/get.go
+++ b/database/repo/get.go
@@ -5,13 +5,15 @@
 package repo
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )
 
 // GetRepo gets a repo by ID from the database.
-func (e *engine) GetRepo(id int64) (*library.Repo, error) {
+func (e *engine) GetRepo(ctx context.Context, id int64) (*library.Repo, error) {
 	e.logger.Tracef("getting repo %d from the database", id)
 
 	// variable to store query results

--- a/database/repo/get_org.go
+++ b/database/repo/get_org.go
@@ -5,6 +5,8 @@
 package repo
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -12,7 +14,7 @@ import (
 )
 
 // GetRepoForOrg gets a repo by org and repo name from the database.
-func (e *engine) GetRepoForOrg(org, name string) (*library.Repo, error) {
+func (e *engine) GetRepoForOrg(ctx context.Context, org, name string) (*library.Repo, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org":  org,
 		"repo": name,

--- a/database/repo/get_org_test.go
+++ b/database/repo/get_org_test.go
@@ -5,6 +5,7 @@
 package repo
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -39,7 +40,7 @@ func TestRepo_Engine_GetRepoForOrg(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateRepo(_repo)
+	_, err := _sqlite.CreateRepo(context.TODO(), _repo)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
@@ -68,7 +69,7 @@ func TestRepo_Engine_GetRepoForOrg(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.GetRepoForOrg("foo", "bar")
+			got, err := test.database.GetRepoForOrg(context.TODO(), "foo", "bar")
 
 			if test.failure {
 				if err == nil {

--- a/database/repo/get_test.go
+++ b/database/repo/get_test.go
@@ -5,6 +5,7 @@
 package repo
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -39,7 +40,7 @@ func TestRepo_Engine_GetRepo(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateRepo(_repo)
+	_, err := _sqlite.CreateRepo(context.TODO(), _repo)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
@@ -68,7 +69,7 @@ func TestRepo_Engine_GetRepo(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.GetRepo(1)
+			got, err := test.database.GetRepo(context.TODO(), 1)
 
 			if test.failure {
 				if err == nil {

--- a/database/repo/index.go
+++ b/database/repo/index.go
@@ -4,6 +4,8 @@
 
 package repo
 
+import "context"
+
 const (
 	// CreateOrgNameIndex represents a query to create an
 	// index on the repos table for the org and name columns.
@@ -16,7 +18,7 @@ ON repos (org, name);
 )
 
 // CreateRepoIndexes creates the indexes for the repos table in the database.
-func (e *engine) CreateRepoIndexes() error {
+func (e *engine) CreateRepoIndexes(ctx context.Context) error {
 	e.logger.Tracef("creating indexes for repos table in the database")
 
 	// create the org and name columns index for the repos table

--- a/database/repo/index_test.go
+++ b/database/repo/index_test.go
@@ -5,6 +5,7 @@
 package repo
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -41,7 +42,7 @@ func TestRepo_Engine_CreateRepoIndexes(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.database.CreateRepoIndexes()
+			err := test.database.CreateRepoIndexes(context.TODO())
 
 			if test.failure {
 				if err == nil {

--- a/database/repo/interface.go
+++ b/database/repo/interface.go
@@ -5,6 +5,8 @@
 package repo
 
 import (
+	"context"
+
 	"github.com/go-vela/types/library"
 )
 
@@ -18,34 +20,34 @@ type RepoInterface interface {
 	// https://en.wikipedia.org/wiki/Data_definition_language
 
 	// CreateRepoIndexes defines a function that creates the indexes for the repos table.
-	CreateRepoIndexes() error
+	CreateRepoIndexes(context.Context) error
 	// CreateRepoTable defines a function that creates the repos table.
-	CreateRepoTable(string) error
+	CreateRepoTable(context.Context, string) error
 
 	// Repo Data Manipulation Language Functions
 	//
 	// https://en.wikipedia.org/wiki/Data_manipulation_language
 
 	// CountRepos defines a function that gets the count of all repos.
-	CountRepos() (int64, error)
+	CountRepos(context.Context) (int64, error)
 	// CountReposForOrg defines a function that gets the count of repos by org name.
-	CountReposForOrg(string, map[string]interface{}) (int64, error)
+	CountReposForOrg(context.Context, string, map[string]interface{}) (int64, error)
 	// CountReposForUser defines a function that gets the count of repos by user ID.
-	CountReposForUser(*library.User, map[string]interface{}) (int64, error)
+	CountReposForUser(context.Context, *library.User, map[string]interface{}) (int64, error)
 	// CreateRepo defines a function that creates a new repo.
-	CreateRepo(*library.Repo) (*library.Repo, error)
+	CreateRepo(context.Context, *library.Repo) (*library.Repo, error)
 	// DeleteRepo defines a function that deletes an existing repo.
-	DeleteRepo(*library.Repo) error
+	DeleteRepo(context.Context, *library.Repo) error
 	// GetRepo defines a function that gets a repo by ID.
-	GetRepo(int64) (*library.Repo, error)
+	GetRepo(context.Context, int64) (*library.Repo, error)
 	// GetRepoForOrg defines a function that gets a repo by org and repo name.
-	GetRepoForOrg(string, string) (*library.Repo, error)
+	GetRepoForOrg(context.Context, string, string) (*library.Repo, error)
 	// ListRepos defines a function that gets a list of all repos.
-	ListRepos() ([]*library.Repo, error)
+	ListRepos(context.Context) ([]*library.Repo, error)
 	// ListReposForOrg defines a function that gets a list of repos by org name.
-	ListReposForOrg(string, string, map[string]interface{}, int, int) ([]*library.Repo, int64, error)
+	ListReposForOrg(context.Context, string, string, map[string]interface{}, int, int) ([]*library.Repo, int64, error)
 	// ListReposForUser defines a function that gets a list of repos by user ID.
-	ListReposForUser(*library.User, string, map[string]interface{}, int, int) ([]*library.Repo, int64, error)
+	ListReposForUser(context.Context, *library.User, string, map[string]interface{}, int, int) ([]*library.Repo, int64, error)
 	// UpdateRepo defines a function that updates an existing repo.
-	UpdateRepo(*library.Repo) (*library.Repo, error)
+	UpdateRepo(context.Context, *library.Repo) (*library.Repo, error)
 }

--- a/database/repo/list.go
+++ b/database/repo/list.go
@@ -5,13 +5,15 @@
 package repo
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )
 
 // ListRepos gets a list of all repos from the database.
-func (e *engine) ListRepos() ([]*library.Repo, error) {
+func (e *engine) ListRepos(ctx context.Context) ([]*library.Repo, error) {
 	e.logger.Trace("listing all repos from the database")
 
 	// variables to store query results and return value
@@ -20,7 +22,7 @@ func (e *engine) ListRepos() ([]*library.Repo, error) {
 	repos := []*library.Repo{}
 
 	// count the results
-	count, err := e.CountRepos()
+	count, err := e.CountRepos(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/database/repo/list_org.go
+++ b/database/repo/list_org.go
@@ -5,6 +5,8 @@
 package repo
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -14,7 +16,7 @@ import (
 // ListReposForOrg gets a list of repos by org name from the database.
 //
 //nolint:lll // ignore long line length due to variable names
-func (e *engine) ListReposForOrg(org, sortBy string, filters map[string]interface{}, page, perPage int) ([]*library.Repo, int64, error) {
+func (e *engine) ListReposForOrg(ctx context.Context, org, sortBy string, filters map[string]interface{}, page, perPage int) ([]*library.Repo, int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org": org,
 	}).Tracef("listing repos for org %s from the database", org)
@@ -25,7 +27,7 @@ func (e *engine) ListReposForOrg(org, sortBy string, filters map[string]interfac
 	repos := []*library.Repo{}
 
 	// count the results
-	count, err := e.CountReposForOrg(org, filters)
+	count, err := e.CountReposForOrg(ctx, org, filters)
 	if err != nil {
 		return repos, 0, err
 	}

--- a/database/repo/list_org_test.go
+++ b/database/repo/list_org_test.go
@@ -5,6 +5,7 @@
 package repo
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -87,12 +88,12 @@ func TestRepo_Engine_ListReposForOrg(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateRepo(_repoOne)
+	_, err := _sqlite.CreateRepo(context.TODO(), _repoOne)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateRepo(_repoTwo)
+	_, err = _sqlite.CreateRepo(context.TODO(), _repoTwo)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
@@ -155,7 +156,7 @@ func TestRepo_Engine_ListReposForOrg(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, _, err := test.database.ListReposForOrg("foo", test.sort, filters, 1, 10)
+			got, _, err := test.database.ListReposForOrg(context.TODO(), "foo", test.sort, filters, 1, 10)
 
 			if test.failure {
 				if err == nil {

--- a/database/repo/list_test.go
+++ b/database/repo/list_test.go
@@ -5,6 +5,7 @@
 package repo
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -57,12 +58,12 @@ func TestRepo_Engine_ListRepos(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateRepo(_repoOne)
+	_, err := _sqlite.CreateRepo(context.TODO(), _repoOne)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateRepo(_repoTwo)
+	_, err = _sqlite.CreateRepo(context.TODO(), _repoTwo)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
@@ -91,7 +92,7 @@ func TestRepo_Engine_ListRepos(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.ListRepos()
+			got, err := test.database.ListRepos(context.TODO())
 
 			if test.failure {
 				if err == nil {

--- a/database/repo/list_user.go
+++ b/database/repo/list_user.go
@@ -5,6 +5,8 @@
 package repo
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -14,7 +16,7 @@ import (
 // ListReposForUser gets a list of repos by user ID from the database.
 //
 //nolint:lll // ignore long line length due to variable names
-func (e *engine) ListReposForUser(u *library.User, sortBy string, filters map[string]interface{}, page, perPage int) ([]*library.Repo, int64, error) {
+func (e *engine) ListReposForUser(ctx context.Context, u *library.User, sortBy string, filters map[string]interface{}, page, perPage int) ([]*library.Repo, int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"user": u.GetName(),
 	}).Tracef("listing repos for user %s from the database", u.GetName())
@@ -25,7 +27,7 @@ func (e *engine) ListReposForUser(u *library.User, sortBy string, filters map[st
 	repos := []*library.Repo{}
 
 	// count the results
-	count, err := e.CountReposForUser(u, filters)
+	count, err := e.CountReposForUser(ctx, u, filters)
 	if err != nil {
 		return repos, 0, err
 	}

--- a/database/repo/list_user_test.go
+++ b/database/repo/list_user_test.go
@@ -5,6 +5,7 @@
 package repo
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -92,12 +93,12 @@ func TestRepo_Engine_ListReposForUser(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateRepo(_repoOne)
+	_, err := _sqlite.CreateRepo(context.TODO(), _repoOne)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateRepo(_repoTwo)
+	_, err = _sqlite.CreateRepo(context.TODO(), _repoTwo)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
@@ -160,7 +161,7 @@ func TestRepo_Engine_ListReposForUser(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, _, err := test.database.ListReposForUser(_user, test.sort, filters, 1, 10)
+			got, _, err := test.database.ListReposForUser(context.TODO(), _user, test.sort, filters, 1, 10)
 
 			if test.failure {
 				if err == nil {

--- a/database/repo/opts.go
+++ b/database/repo/opts.go
@@ -5,6 +5,8 @@
 package repo
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
 
 	"gorm.io/gorm"
@@ -48,6 +50,15 @@ func WithSkipCreation(skipCreation bool) EngineOpt {
 	return func(e *engine) error {
 		// set to skip creating tables and indexes in the repo engine
 		e.config.SkipCreation = skipCreation
+
+		return nil
+	}
+}
+
+// WithContext sets the context in the database engine for Repos.
+func WithContext(ctx context.Context) EngineOpt {
+	return func(e *engine) error {
+		e.ctx = ctx
 
 		return nil
 	}

--- a/database/repo/opts_test.go
+++ b/database/repo/opts_test.go
@@ -5,6 +5,7 @@
 package repo
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -204,6 +205,55 @@ func TestRepo_EngineOpt_WithSkipCreation(t *testing.T) {
 
 			if !reflect.DeepEqual(e.config.SkipCreation, test.want) {
 				t.Errorf("WithSkipCreation is %v, want %v", e.config.SkipCreation, test.want)
+			}
+		})
+	}
+}
+
+func TestRepo_EngineOpt_WithContext(t *testing.T) {
+	// setup types
+	e := &engine{config: new(config)}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		name    string
+		ctx     context.Context
+		want    context.Context
+	}{
+		{
+			failure: false,
+			name:    "context set to TODO",
+			ctx:     context.TODO(),
+			want:    context.TODO(),
+		},
+		{
+			failure: false,
+			name:    "context set to nil",
+			ctx:     nil,
+			want:    nil,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := WithContext(test.ctx)(e)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithContext for %s should have returned err", test.name)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("WithContext returned err: %v", err)
+			}
+
+			if !reflect.DeepEqual(e.ctx, test.want) {
+				t.Errorf("WithContext is %v, want %v", e.ctx, test.want)
 			}
 		})
 	}

--- a/database/repo/repo.go
+++ b/database/repo/repo.go
@@ -5,6 +5,7 @@
 package repo
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-vela/types/constants"
@@ -26,6 +27,8 @@ type (
 	engine struct {
 		// engine configuration settings used in repo functions
 		config *config
+
+		ctx context.Context
 
 		// gorm.io/gorm database client used in repo functions
 		//
@@ -67,13 +70,13 @@ func New(opts ...EngineOpt) (*engine, error) {
 	}
 
 	// create the repos table
-	err := e.CreateRepoTable(e.client.Config.Dialector.Name())
+	err := e.CreateRepoTable(e.ctx, e.client.Config.Dialector.Name())
 	if err != nil {
 		return nil, fmt.Errorf("unable to create %s table: %w", constants.TableRepo, err)
 	}
 
 	// create the indexes for the repos table
-	err = e.CreateRepoIndexes()
+	err = e.CreateRepoIndexes(e.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create indexes for %s table: %w", constants.TableRepo, err)
 	}

--- a/database/repo/table.go
+++ b/database/repo/table.go
@@ -4,7 +4,11 @@
 
 package repo
 
-import "github.com/go-vela/types/constants"
+import (
+	"context"
+
+	"github.com/go-vela/types/constants"
+)
 
 const (
 	// CreatePostgresTable represents a query to create the Postgres repos table.
@@ -75,7 +79,7 @@ repos (
 )
 
 // CreateRepoTable creates the repos table in the database.
-func (e *engine) CreateRepoTable(driver string) error {
+func (e *engine) CreateRepoTable(ctx context.Context, driver string) error {
 	e.logger.Tracef("creating repos table in the database")
 
 	// handle the driver provided to create the table

--- a/database/repo/table_test.go
+++ b/database/repo/table_test.go
@@ -5,6 +5,7 @@
 package repo
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -41,7 +42,7 @@ func TestRepo_Engine_CreateRepoTable(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.database.CreateRepoTable(test.name)
+			err := test.database.CreateRepoTable(context.TODO(), test.name)
 
 			if test.failure {
 				if err == nil {

--- a/database/repo/update.go
+++ b/database/repo/update.go
@@ -6,6 +6,7 @@
 package repo
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-vela/types/constants"
@@ -15,7 +16,7 @@ import (
 )
 
 // UpdateRepo updates an existing repo in the database.
-func (e *engine) UpdateRepo(r *library.Repo) (*library.Repo, error) {
+func (e *engine) UpdateRepo(ctx context.Context, r *library.Repo) (*library.Repo, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),

--- a/database/repo/update_test.go
+++ b/database/repo/update_test.go
@@ -5,6 +5,7 @@
 package repo
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -38,7 +39,7 @@ WHERE "id" = $24`).
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateRepo(_repo)
+	_, err := _sqlite.CreateRepo(context.TODO(), _repo)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
@@ -64,7 +65,7 @@ WHERE "id" = $24`).
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.UpdateRepo(_repo)
+			got, err := test.database.UpdateRepo(context.TODO(), _repo)
 
 			if test.failure {
 				if err == nil {

--- a/database/resource.go
+++ b/database/resource.go
@@ -6,6 +6,7 @@ package database
 
 import (
 	"context"
+
 	"github.com/go-vela/server/database/build"
 	"github.com/go-vela/server/database/hook"
 	"github.com/go-vela/server/database/log"
@@ -68,6 +69,7 @@ func (e *engine) NewResources(ctx context.Context) error {
 
 	// create the database agnostic engine for repos
 	e.RepoInterface, err = repo.New(
+		repo.WithContext(e.ctx),
 		repo.WithClient(e.client),
 		repo.WithEncryptionKey(e.config.EncryptionKey),
 		repo.WithLogger(e.logger),

--- a/router/middleware/build/build_test.go
+++ b/router/middleware/build/build_test.go
@@ -91,11 +91,11 @@ func TestBuild_Establish(t *testing.T) {
 
 	defer func() {
 		db.DeleteBuild(context.TODO(), want)
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 	_, _ = db.CreateBuild(context.TODO(), want)
 
 	// setup context
@@ -173,11 +173,11 @@ func TestBuild_Establish_NoBuildParameter(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 
 	// setup context
 	gin.SetMode(gin.TestMode)
@@ -221,11 +221,11 @@ func TestBuild_Establish_InvalidBuildParameter(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 
 	// setup context
 	gin.SetMode(gin.TestMode)
@@ -269,11 +269,11 @@ func TestBuild_Establish_NoBuild(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 
 	// setup context
 	gin.SetMode(gin.TestMode)

--- a/router/middleware/org/org_test.go
+++ b/router/middleware/org/org_test.go
@@ -5,6 +5,7 @@
 package org
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -65,11 +66,11 @@ func TestOrg_Establish(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 
 	// setup context
 	gin.SetMode(gin.TestMode)

--- a/router/middleware/perm/perm_test.go
+++ b/router/middleware/perm/perm_test.go
@@ -446,11 +446,11 @@ func TestPerm_MustBuildAccess(t *testing.T) {
 
 	defer func() {
 		db.DeleteBuild(ctx, b)
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateBuild(ctx, b)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar/builds/1", nil)
@@ -537,12 +537,12 @@ func TestPerm_MustBuildAccess_PlatAdmin(t *testing.T) {
 
 	defer func() {
 		db.DeleteBuild(ctx, b)
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.DeleteUser(u)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateBuild(ctx, b)
 	_ = db.CreateUser(u)
 
@@ -625,11 +625,11 @@ func TestPerm_MustBuildToken_WrongBuild(t *testing.T) {
 
 	defer func() {
 		db.DeleteBuild(ctx, b)
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateBuild(ctx, b)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar/builds/1", nil)
@@ -711,11 +711,11 @@ func TestPerm_MustSecretAdmin_BuildToken_Repo(t *testing.T) {
 
 	defer func() {
 		db.DeleteBuild(ctx, b)
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateBuild(ctx, b)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/native/repo/foo/bar/baz", nil)
@@ -794,11 +794,11 @@ func TestPerm_MustSecretAdmin_BuildToken_Org(t *testing.T) {
 
 	defer func() {
 		db.DeleteBuild(ctx, b)
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateBuild(ctx, b)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/native/org/foo/*/baz", nil)
@@ -877,11 +877,11 @@ func TestPerm_MustSecretAdmin_BuildToken_Shared(t *testing.T) {
 
 	defer func() {
 		db.DeleteBuild(ctx, b)
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateBuild(ctx, b)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/native/shared/foo/*/*", nil)
@@ -957,12 +957,12 @@ func TestPerm_MustAdmin(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.DeleteUser(u)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_ = db.CreateUser(u)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
@@ -1055,12 +1055,12 @@ func TestPerm_MustAdmin_PlatAdmin(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.DeleteUser(u)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_ = db.CreateUser(u)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
@@ -1153,12 +1153,12 @@ func TestPerm_MustAdmin_NotAdmin(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.DeleteUser(u)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_ = db.CreateUser(u)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
@@ -1251,12 +1251,12 @@ func TestPerm_MustWrite(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.DeleteUser(u)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_ = db.CreateUser(u)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
@@ -1349,12 +1349,12 @@ func TestPerm_MustWrite_PlatAdmin(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.DeleteUser(u)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_ = db.CreateUser(u)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
@@ -1447,12 +1447,12 @@ func TestPerm_MustWrite_RepoAdmin(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.DeleteUser(u)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_ = db.CreateUser(u)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
@@ -1545,12 +1545,12 @@ func TestPerm_MustWrite_NotWrite(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.DeleteUser(u)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_ = db.CreateUser(u)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
@@ -1643,12 +1643,12 @@ func TestPerm_MustRead(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.DeleteUser(u)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_ = db.CreateUser(u)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
@@ -1741,12 +1741,12 @@ func TestPerm_MustRead_PlatAdmin(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.DeleteUser(u)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_ = db.CreateUser(u)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
@@ -1842,12 +1842,12 @@ func TestPerm_MustRead_WorkerBuildToken(t *testing.T) {
 
 	defer func() {
 		db.DeleteBuild(ctx, b)
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.Close()
 	}()
 
 	_, _ = db.CreateBuild(ctx, b)
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar/builds/1", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
@@ -1925,12 +1925,12 @@ func TestPerm_MustRead_RepoAdmin(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.DeleteUser(u)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_ = db.CreateUser(u)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
@@ -2023,12 +2023,12 @@ func TestPerm_MustRead_RepoWrite(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.DeleteUser(u)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_ = db.CreateUser(u)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
@@ -2121,12 +2121,12 @@ func TestPerm_MustRead_RepoPublic(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.DeleteUser(u)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_ = db.CreateUser(u)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
@@ -2219,12 +2219,12 @@ func TestPerm_MustRead_NotRead(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(_context.TODO(), r)
 		db.DeleteUser(u)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(_context.TODO(), r)
 	_ = db.CreateUser(u)
 
 	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)

--- a/router/middleware/pipeline/pipeline_test.go
+++ b/router/middleware/pipeline/pipeline_test.go
@@ -5,6 +5,7 @@
 package pipeline
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net/http"
@@ -103,11 +104,11 @@ func TestPipeline_Establish(t *testing.T) {
 
 	defer func() {
 		db.DeletePipeline(want)
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 	_, _ = db.CreatePipeline(want)
 
 	// setup context
@@ -185,11 +186,11 @@ func TestPipeline_Establish_NoPipelineParameter(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 
 	// setup context
 	gin.SetMode(gin.TestMode)
@@ -288,12 +289,12 @@ func TestPipeline_Establish_NoPipeline(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.DeleteUser(u)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 	_ = db.CreateUser(u)
 
 	// setup context

--- a/router/middleware/repo/repo.go
+++ b/router/middleware/repo/repo.go
@@ -27,6 +27,7 @@ func Establish() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		o := org.Retrieve(c)
 		u := user.Retrieve(c)
+		ctx := c.Request.Context()
 
 		rParam := util.PathParameter(c, "repo")
 		if len(rParam) == 0 {
@@ -45,7 +46,7 @@ func Establish() gin.HandlerFunc {
 			"user": u.GetName(),
 		}).Debugf("reading repo %s/%s", o, rParam)
 
-		r, err := database.FromContext(c).GetRepoForOrg(o, rParam)
+		r, err := database.FromContext(c).GetRepoForOrg(ctx, o, rParam)
 		if err != nil {
 			retErr := fmt.Errorf("unable to read repo %s/%s: %w", o, rParam, err)
 			util.HandleError(c, http.StatusNotFound, retErr)

--- a/router/middleware/repo/repo_test.go
+++ b/router/middleware/repo/repo_test.go
@@ -5,6 +5,7 @@
 package repo
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -72,11 +73,11 @@ func TestRepo_Establish(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(want)
+		db.DeleteRepo(context.TODO(), want)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(want)
+	_, _ = db.CreateRepo(context.TODO(), want)
 
 	// setup context
 	gin.SetMode(gin.TestMode)

--- a/router/middleware/service/service_test.go
+++ b/router/middleware/service/service_test.go
@@ -80,12 +80,12 @@ func TestService_Establish(t *testing.T) {
 
 	defer func() {
 		db.DeleteBuild(context.TODO(), b)
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.DeleteService(want)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 	_, _ = db.CreateBuild(context.TODO(), b)
 	_ = db.CreateService(want)
 
@@ -168,11 +168,11 @@ func TestService_Establish_NoBuild(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 
 	// setup context
 	gin.SetMode(gin.TestMode)
@@ -222,11 +222,11 @@ func TestService_Establish_NoServiceParameter(t *testing.T) {
 
 	defer func() {
 		db.DeleteBuild(context.TODO(), b)
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 	_, _ = db.CreateBuild(context.TODO(), b)
 
 	// setup context
@@ -278,11 +278,11 @@ func TestService_Establish_InvalidServiceParameter(t *testing.T) {
 
 	defer func() {
 		db.DeleteBuild(context.TODO(), b)
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 	_, _ = db.CreateBuild(context.TODO(), b)
 
 	// setup context
@@ -334,11 +334,11 @@ func TestService_Establish_NoService(t *testing.T) {
 
 	defer func() {
 		db.DeleteBuild(context.TODO(), b)
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 	_, _ = db.CreateBuild(context.TODO(), b)
 
 	// setup context

--- a/router/middleware/step/step_test.go
+++ b/router/middleware/step/step_test.go
@@ -82,12 +82,12 @@ func TestStep_Establish(t *testing.T) {
 
 	defer func() {
 		db.DeleteBuild(context.TODO(), b)
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.DeleteStep(want)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 	_, _ = db.CreateBuild(context.TODO(), b)
 	_ = db.CreateStep(want)
 
@@ -170,11 +170,11 @@ func TestStep_Establish_NoBuild(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 
 	// setup context
 	gin.SetMode(gin.TestMode)
@@ -224,11 +224,11 @@ func TestStep_Establish_NoStepParameter(t *testing.T) {
 
 	defer func() {
 		db.DeleteBuild(context.TODO(), b)
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 	_, _ = db.CreateBuild(context.TODO(), b)
 
 	// setup context
@@ -280,11 +280,11 @@ func TestStep_Establish_InvalidStepParameter(t *testing.T) {
 
 	defer func() {
 		db.DeleteBuild(context.TODO(), b)
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 	_, _ = db.CreateBuild(context.TODO(), b)
 
 	// setup context
@@ -336,11 +336,11 @@ func TestStep_Establish_NoStep(t *testing.T) {
 
 	defer func() {
 		db.DeleteBuild(context.TODO(), b)
-		db.DeleteRepo(r)
+		db.DeleteRepo(context.TODO(), r)
 		db.Close()
 	}()
 
-	_, _ = db.CreateRepo(r)
+	_, _ = db.CreateRepo(context.TODO(), r)
 	_, _ = db.CreateBuild(context.TODO(), b)
 
 	// setup context


### PR DESCRIPTION
continuing the efforts started in #898 #922 and #923 

this is prep to add support for OpenTelemetry tracing.

the reason being, otel can (for the most part) work out of the box if you pass around contexts properly.