### PR TITLE
fix(webhook): keep parent and build number synced

### DIFF
--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -342,9 +342,6 @@ func PostWebhook(c *gin.Context) {
 	logrus.Debugf("updating build number to %d", repo.GetCounter())
 	b.SetNumber(repo.GetCounter())
 
-	logrus.Debugf("updating parent number to %d", b.GetNumber())
-	b.SetParent(b.GetNumber())
-
 	logrus.Debug("updating status to pending")
 	b.SetStatus(constants.StatusPending)
 
@@ -475,7 +472,6 @@ func PostWebhook(c *gin.Context) {
 		inc := repo.GetCounter() + 1
 		repo.SetCounter(inc)
 		b.SetNumber(inc)
-		b.SetParent(inc)
 
 		// populate the build link if a web address is provided
 		if len(m.Vela.WebAddress) > 0 {

--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -362,6 +362,7 @@ func PostWebhook(c *gin.Context) {
 		}
 
 		b.SetCommit(commit)
+		b.SetBranch(strings.ReplaceAll(branch, "refs/heads/", ""))
 		b.SetBaseRef(baseref)
 		b.SetHeadRef(headref)
 	}

--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -467,8 +467,7 @@ func PostWebhook(c *gin.Context) {
 		repo.SetTopics(r.GetTopics())
 		repo.SetBranch(r.GetBranch())
 
-		// parent and build number should stay synced and only diverge when a build
-		// is restarted, which is handled in the restart handler
+		// update the build numbers based off repo counter
 		inc := repo.GetCounter() + 1
 		repo.SetCounter(inc)
 		b.SetNumber(inc)

--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -362,7 +362,6 @@ func PostWebhook(c *gin.Context) {
 		}
 
 		b.SetCommit(commit)
-		b.SetBranch(strings.Replace(branch, "refs/heads/", "", -1))
 		b.SetBaseRef(baseref)
 		b.SetHeadRef(headref)
 	}

--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -470,19 +470,12 @@ func PostWebhook(c *gin.Context) {
 		repo.SetTopics(r.GetTopics())
 		repo.SetBranch(r.GetBranch())
 
-		// set the parent equal to the current repo counter
-		b.SetParent(repo.GetCounter())
-
-		// check if the parent is set to 0
-		if b.GetParent() == 0 {
-			// parent should be "1" if it's the first build ran
-			b.SetParent(1)
-		}
-
-		// update the build numbers based off repo counter
+		// parent and build number should stay synced and only diverge when a build
+		// is restarted, which is handled in the restart handler
 		inc := repo.GetCounter() + 1
 		repo.SetCounter(inc)
 		b.SetNumber(inc)
+		b.SetParent(inc)
 
 		// populate the build link if a web address is provided
 		if len(m.Vela.WebAddress) > 0 {


### PR DESCRIPTION
currently, new builds always produce build objects that have their `parent` field referencing the previous build (-1) - the exception is the very first build for which `parent` and `number` are the same value (1).

afaik, there's no reason for this and the only time these two should diverge (at least, currently) is if a build was restarted. in that case `parent` should reference the build number that was restarted. that currently works as described.

in other words, it currently looks like every build (except the very first one) is a restart of the previous build.

this change will remove the setting of the parent field on regular builds. for restarts it will continue to work as before and set the parent appropriately.