### PR TITLE
chore: simplify queue env variable names

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       DATABASE_ENCRYPTION_KEY: 'C639A572E14D5075C526FDDD43E4ECF6'
       QUEUE_DRIVER: redis
       QUEUE_ADDR: 'redis://redis:6379'
+      QUEUE_PRIVATE_KEY: 'tCIevHOBq6DdN5SSBtteXUusjjd0fOqzk2eyi0DMq04NewmShNKQeUbbp3vkvIckb4pCxc+vxUo+mYf/vzOaSg=='
       SCM_DRIVER: github
       SCM_CONTEXT: 'continuous-integration/vela'
       SECRET_VAULT: 'true'
@@ -42,7 +43,6 @@ services:
       VELA_USER_ACCESS_TOKEN_DURATION: 60m
       VELA_DISABLE_WEBHOOK_VALIDATION: 'true'
       VELA_ENABLE_SECURE_COOKIE: 'false'
-      VELA_QUEUE_SIGNING_PRIVATE_KEY: 'tCIevHOBq6DdN5SSBtteXUusjjd0fOqzk2eyi0DMq04NewmShNKQeUbbp3vkvIckb4pCxc+vxUo+mYf/vzOaSg=='
       VELA_REPO_ALLOWLIST: '*'
       VELA_SCHEDULE_ALLOWLIST: '*'
     env_file:
@@ -70,6 +70,7 @@ services:
       EXECUTOR_DRIVER: linux
       QUEUE_DRIVER: redis
       QUEUE_ADDR: 'redis://redis:6379'
+      QUEUE_PUBLIC_KEY: 'DXsJkoTSkHlG26d75LyHJG+KQsXPr8VKPpmH/78zmko='
       VELA_BUILD_LIMIT: 1
       VELA_BUILD_TIMEOUT: 30m
       VELA_LOG_LEVEL: trace
@@ -79,7 +80,6 @@ services:
       VELA_SERVER_SECRET: 'zB7mrKDTZqNeNTD8z47yG4DHywspAh'
       WORKER_ADDR: 'http://worker:8080'
       WORKER_CHECK_IN: 5m
-      VELA_QUEUE_SIGNING_PUBLIC_KEY: 'DXsJkoTSkHlG26d75LyHJG+KQsXPr8VKPpmH/78zmko='
     restart: always
     ports:
       - '8081:8080'

--- a/queue/flags.go
+++ b/queue/flags.go
@@ -51,13 +51,13 @@ var Flags = []cli.Flag{
 		Value:    60 * time.Second,
 	},
 	&cli.StringFlag{
-		EnvVars:  []string{"VELA_QUEUE_SIGNING_PRIVATE_KEY"},
+		EnvVars:  []string{"QUEUE_PRIVATE_KEY"},
 		FilePath: "/vela/signing.key",
 		Name:     "queue.private-key",
 		Usage:    "set value of base64 encoded queue signing private key",
 	},
 	&cli.StringFlag{
-		EnvVars:  []string{"VELA_QUEUE_SIGNING_PUBLIC_KEY"},
+		EnvVars:  []string{"QUEUE_PUBLIC_KEY"},
 		FilePath: "/vela/signing.pub",
 		Name:     "queue.public-key",
 		Usage:    "set value of base64 encoded queue signing public key",


### PR DESCRIPTION
simplifying the naming based on verbosity feedback. 
lets do this before we release it. 