### PR TITLE
enhance: use consistent variable aliases for queue signing keys

### DIFF
--- a/queue/flags.go
+++ b/queue/flags.go
@@ -51,13 +51,13 @@ var Flags = []cli.Flag{
 		Value:    60 * time.Second,
 	},
 	&cli.StringFlag{
-		EnvVars:  []string{"QUEUE_PRIVATE_KEY"},
+		EnvVars:  []string{"VELA_QUEUE_PRIVATE_KEY", "QUEUE_PRIVATE_KEY"},
 		FilePath: "/vela/signing.key",
 		Name:     "queue.private-key",
 		Usage:    "set value of base64 encoded queue signing private key",
 	},
 	&cli.StringFlag{
-		EnvVars:  []string{"QUEUE_PUBLIC_KEY"},
+		EnvVars:  []string{"VELA_QUEUE_PUBLIC_KEY", "QUEUE_PUBLIC_KEY"},
 		FilePath: "/vela/signing.pub",
 		Name:     "queue.public-key",
 		Usage:    "set value of base64 encoded queue signing public key",


### PR DESCRIPTION
i thought i included these variables in my last tweak PR but apparently not. i noticed while writing the docs.