### PR TITLE
enhance(queue): adjust pop to allow channels as argument

### DIFF
--- a/queue/redis/pop.go
+++ b/queue/redis/pop.go
@@ -15,13 +15,23 @@ import (
 )
 
 // Pop grabs an item from the specified channel off the queue.
-func (c *client) Pop(ctx context.Context) (*types.Item, error) {
+func (c *client) Pop(ctx context.Context, routes []string) (*types.Item, error) {
 	c.Logger.Tracef("popping item from queue %s", c.config.Channels)
+
+	// define channels to pop from
+	var channels []string
+
+	// if routes were supplied, use those
+	if len(routes) > 0 {
+		channels = routes
+	} else {
+		channels = c.config.Channels
+	}
 
 	// build a redis queue command to pop an item from queue
 	//
 	// https://pkg.go.dev/github.com/go-redis/redis?tab=doc#Client.BLPop
-	popCmd := c.Redis.BLPop(ctx, c.config.Timeout, c.config.Channels...)
+	popCmd := c.Redis.BLPop(ctx, c.config.Timeout, channels...)
 
 	// blocking call to pop item from queue
 	//

--- a/queue/service.go
+++ b/queue/service.go
@@ -26,7 +26,7 @@ type Service interface {
 
 	// Pop defines a function that grabs an
 	// item off the queue.
-	Pop(context.Context) (*types.Item, error)
+	Pop(context.Context, []string) (*types.Item, error)
 
 	// Push defines a function that publishes an
 	// item to the specified route in the queue.


### PR DESCRIPTION
This is some groundwork for allowing platform admins to live update routes for workers.

Changing the `Pop` method to accept an optional channels argument gives the worker the ability to leverage the DB record of its routes when listening to the queue rather than what was configured on start up.

There is a question on whether or not this change makes start-up routes obsolete. Admins could use the API to supply routes rather than put them in the container environment. However, since the server leverages `QUEUE_ROUTES` to validate routes prior to publishing, removal of that flag is not an option. The deprecation would be better explained in docs rather than in code.