### PR TITLE
enhance: add context to Logs

### DIFF
--- a/api/build/plan.go
+++ b/api/build/plan.go
@@ -42,7 +42,7 @@ func PlanBuild(ctx context.Context, database database.Interface, p *pipeline.Bui
 	}
 
 	// plan all services for the build
-	services, err := service.PlanServices(database, p, b)
+	services, err := service.PlanServices(ctx, database, p, b)
 	if err != nil {
 		// clean up the objects from the pipeline in the database
 		CleanBuild(ctx, database, b, services, nil, err)
@@ -51,7 +51,7 @@ func PlanBuild(ctx context.Context, database database.Interface, p *pipeline.Bui
 	}
 
 	// plan all steps for the build
-	steps, err := step.PlanSteps(database, p, b)
+	steps, err := step.PlanSteps(ctx, database, p, b)
 	if err != nil {
 		// clean up the objects from the pipeline in the database
 		CleanBuild(ctx, database, b, services, steps, err)

--- a/api/log/create_service.go
+++ b/api/log/create_service.go
@@ -79,6 +79,7 @@ func CreateServiceLog(c *gin.Context) {
 	r := repo.Retrieve(c)
 	s := service.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%d/%d", r.GetFullName(), b.GetNumber(), s.GetNumber())
 
@@ -111,7 +112,7 @@ func CreateServiceLog(c *gin.Context) {
 	input.SetRepoID(r.GetID())
 
 	// send API call to create the logs
-	err = database.FromContext(c).CreateLog(input)
+	err = database.FromContext(c).CreateLog(ctx, input)
 	if err != nil {
 		retErr := fmt.Errorf("unable to create logs for service %s: %w", entry, err)
 

--- a/api/log/create_step.go
+++ b/api/log/create_step.go
@@ -79,6 +79,7 @@ func CreateStepLog(c *gin.Context) {
 	r := repo.Retrieve(c)
 	s := step.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%d/%d", r.GetFullName(), b.GetNumber(), s.GetNumber())
 
@@ -111,7 +112,7 @@ func CreateStepLog(c *gin.Context) {
 	input.SetRepoID(r.GetID())
 
 	// send API call to create the logs
-	err = database.FromContext(c).CreateLog(input)
+	err = database.FromContext(c).CreateLog(ctx, input)
 	if err != nil {
 		retErr := fmt.Errorf("unable to create logs for step %s: %w", entry, err)
 

--- a/api/log/delete_service.go
+++ b/api/log/delete_service.go
@@ -69,6 +69,7 @@ func DeleteServiceLog(c *gin.Context) {
 	r := repo.Retrieve(c)
 	s := service.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%d/%d", r.GetFullName(), b.GetNumber(), s.GetNumber())
 
@@ -84,7 +85,7 @@ func DeleteServiceLog(c *gin.Context) {
 	}).Infof("deleting logs for service %s", entry)
 
 	// send API call to capture the service logs
-	l, err := database.FromContext(c).GetLogForService(s)
+	l, err := database.FromContext(c).GetLogForService(ctx, s)
 	if err != nil {
 		retErr := fmt.Errorf("unable to get logs for service %s: %w", entry, err)
 
@@ -94,7 +95,7 @@ func DeleteServiceLog(c *gin.Context) {
 	}
 
 	// send API call to remove the log
-	err = database.FromContext(c).DeleteLog(l)
+	err = database.FromContext(c).DeleteLog(ctx, l)
 	if err != nil {
 		retErr := fmt.Errorf("unable to delete logs for service %s: %w", entry, err)
 

--- a/api/log/delete_step.go
+++ b/api/log/delete_step.go
@@ -69,6 +69,7 @@ func DeleteStepLog(c *gin.Context) {
 	r := repo.Retrieve(c)
 	s := step.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%d/%d", r.GetFullName(), b.GetNumber(), s.GetNumber())
 
@@ -84,7 +85,7 @@ func DeleteStepLog(c *gin.Context) {
 	}).Infof("deleting logs for step %s", entry)
 
 	// send API call to capture the step logs
-	l, err := database.FromContext(c).GetLogForStep(s)
+	l, err := database.FromContext(c).GetLogForStep(ctx, s)
 	if err != nil {
 		retErr := fmt.Errorf("unable to get logs for step %s: %w", entry, err)
 
@@ -94,7 +95,7 @@ func DeleteStepLog(c *gin.Context) {
 	}
 
 	// send API call to remove the log
-	err = database.FromContext(c).DeleteLog(l)
+	err = database.FromContext(c).DeleteLog(ctx, l)
 	if err != nil {
 		retErr := fmt.Errorf("unable to delete logs for step %s: %w", entry, err)
 

--- a/api/log/get_service.go
+++ b/api/log/get_service.go
@@ -69,6 +69,7 @@ func GetServiceLog(c *gin.Context) {
 	r := repo.Retrieve(c)
 	s := service.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%d/%d", r.GetFullName(), b.GetNumber(), s.GetNumber())
 
@@ -84,7 +85,7 @@ func GetServiceLog(c *gin.Context) {
 	}).Infof("reading logs for service %s", entry)
 
 	// send API call to capture the service logs
-	l, err := database.FromContext(c).GetLogForService(s)
+	l, err := database.FromContext(c).GetLogForService(ctx, s)
 	if err != nil {
 		retErr := fmt.Errorf("unable to get logs for service %s: %w", entry, err)
 

--- a/api/log/get_step.go
+++ b/api/log/get_step.go
@@ -70,6 +70,7 @@ func GetStepLog(c *gin.Context) {
 	r := repo.Retrieve(c)
 	s := step.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%d/%d", r.GetFullName(), b.GetNumber(), s.GetNumber())
 
@@ -85,7 +86,7 @@ func GetStepLog(c *gin.Context) {
 	}).Infof("reading logs for step %s", entry)
 
 	// send API call to capture the step logs
-	l, err := database.FromContext(c).GetLogForStep(s)
+	l, err := database.FromContext(c).GetLogForStep(ctx, s)
 	if err != nil {
 		retErr := fmt.Errorf("unable to get logs for step %s: %w", entry, err)
 

--- a/api/log/list_build.go
+++ b/api/log/list_build.go
@@ -76,6 +76,7 @@ func ListLogsForBuild(c *gin.Context) {
 	o := org.Retrieve(c)
 	r := repo.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%d", r.GetFullName(), b.GetNumber())
 
@@ -112,7 +113,7 @@ func ListLogsForBuild(c *gin.Context) {
 	perPage = util.MaxInt(1, util.MinInt(100, perPage))
 
 	// send API call to capture the list of logs for the build
-	l, t, err := database.FromContext(c).ListLogsForBuild(b, page, perPage)
+	l, t, err := database.FromContext(c).ListLogsForBuild(ctx, b, page, perPage)
 	if err != nil {
 		retErr := fmt.Errorf("unable to list logs for build %s: %w", entry, err)
 

--- a/api/log/update_service.go
+++ b/api/log/update_service.go
@@ -81,6 +81,7 @@ func UpdateServiceLog(c *gin.Context) {
 	r := repo.Retrieve(c)
 	s := service.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%d/%d", r.GetFullName(), b.GetNumber(), s.GetNumber())
 
@@ -96,7 +97,7 @@ func UpdateServiceLog(c *gin.Context) {
 	}).Infof("updating logs for service %s", entry)
 
 	// send API call to capture the service logs
-	l, err := database.FromContext(c).GetLogForService(s)
+	l, err := database.FromContext(c).GetLogForService(ctx, s)
 	if err != nil {
 		retErr := fmt.Errorf("unable to get logs for service %s: %w", entry, err)
 
@@ -124,7 +125,7 @@ func UpdateServiceLog(c *gin.Context) {
 	}
 
 	// send API call to update the log
-	err = database.FromContext(c).UpdateLog(l)
+	err = database.FromContext(c).UpdateLog(ctx, l)
 	if err != nil {
 		retErr := fmt.Errorf("unable to update logs for service %s: %w", entry, err)
 

--- a/api/log/update_step.go
+++ b/api/log/update_step.go
@@ -81,6 +81,7 @@ func UpdateStepLog(c *gin.Context) {
 	r := repo.Retrieve(c)
 	s := step.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%d/%d", r.GetFullName(), b.GetNumber(), s.GetNumber())
 
@@ -96,7 +97,7 @@ func UpdateStepLog(c *gin.Context) {
 	}).Infof("updating logs for step %s", entry)
 
 	// send API call to capture the step logs
-	l, err := database.FromContext(c).GetLogForStep(s)
+	l, err := database.FromContext(c).GetLogForStep(ctx, s)
 	if err != nil {
 		retErr := fmt.Errorf("unable to get logs for step %s: %w", entry, err)
 
@@ -124,7 +125,7 @@ func UpdateStepLog(c *gin.Context) {
 	}
 
 	// send API call to update the log
-	err = database.FromContext(c).UpdateLog(l)
+	err = database.FromContext(c).UpdateLog(ctx, l)
 	if err != nil {
 		retErr := fmt.Errorf("unable to update logs for step %s: %w", entry, err)
 

--- a/api/service/plan.go
+++ b/api/service/plan.go
@@ -5,6 +5,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -17,7 +18,7 @@ import (
 // PlanServices is a helper function to plan all services
 // in the build for execution. This creates the services
 // for the build in the configured backend.
-func PlanServices(database database.Interface, p *pipeline.Build, b *library.Build) ([]*library.Service, error) {
+func PlanServices(ctx context.Context, database database.Interface, p *pipeline.Build, b *library.Build) ([]*library.Service, error) {
 	// variable to store planned services
 	services := []*library.Service{}
 
@@ -55,7 +56,7 @@ func PlanServices(database database.Interface, p *pipeline.Build, b *library.Bui
 		l.SetData([]byte{})
 
 		// send API call to create the service logs
-		err = database.CreateLog(l)
+		err = database.CreateLog(ctx, l)
 		if err != nil {
 			return services, fmt.Errorf("unable to create service logs for service %s: %w", s.GetName(), err)
 		}

--- a/api/step/plan.go
+++ b/api/step/plan.go
@@ -5,6 +5,7 @@
 package step
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -17,7 +18,7 @@ import (
 // PlanSteps is a helper function to plan all steps
 // in the build for execution. This creates the steps
 // for the build in the configured backend.
-func PlanSteps(database database.Interface, p *pipeline.Build, b *library.Build) ([]*library.Step, error) {
+func PlanSteps(ctx context.Context, database database.Interface, p *pipeline.Build, b *library.Build) ([]*library.Step, error) {
 	// variable to store planned steps
 	steps := []*library.Step{}
 
@@ -26,7 +27,7 @@ func PlanSteps(database database.Interface, p *pipeline.Build, b *library.Build)
 		// iterate through all steps for each pipeline stage
 		for _, step := range stage.Steps {
 			// create the step object
-			s, err := planStep(database, b, step, stage.Name)
+			s, err := planStep(ctx, database, b, step, stage.Name)
 			if err != nil {
 				return steps, err
 			}
@@ -37,7 +38,7 @@ func PlanSteps(database database.Interface, p *pipeline.Build, b *library.Build)
 
 	// iterate through all pipeline steps
 	for _, step := range p.Steps {
-		s, err := planStep(database, b, step, "")
+		s, err := planStep(ctx, database, b, step, "")
 		if err != nil {
 			return steps, err
 		}
@@ -48,7 +49,7 @@ func PlanSteps(database database.Interface, p *pipeline.Build, b *library.Build)
 	return steps, nil
 }
 
-func planStep(database database.Interface, b *library.Build, c *pipeline.Container, stage string) (*library.Step, error) {
+func planStep(ctx context.Context, database database.Interface, b *library.Build, c *pipeline.Container, stage string) (*library.Step, error) {
 	// create the step object
 	s := new(library.Step)
 	s.SetBuildID(b.GetID())
@@ -82,7 +83,7 @@ func planStep(database database.Interface, b *library.Build, c *pipeline.Contain
 	l.SetData([]byte{})
 
 	// send API call to create the step logs
-	err = database.CreateLog(l)
+	err = database.CreateLog(ctx, l)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create logs for step %s: %w", s.GetName(), err)
 	}

--- a/database/integration_test.go
+++ b/database/integration_test.go
@@ -582,7 +582,7 @@ func testLogs(t *testing.T, db Interface, resources *Resources) {
 
 	// create the logs
 	for _, log := range resources.Logs {
-		err := db.CreateLog(log)
+		err := db.CreateLog(context.TODO(), log)
 		if err != nil {
 			t.Errorf("unable to create log %d: %v", log.GetID(), err)
 		}
@@ -590,7 +590,7 @@ func testLogs(t *testing.T, db Interface, resources *Resources) {
 	methods["CreateLog"] = true
 
 	// count the logs
-	count, err := db.CountLogs()
+	count, err := db.CountLogs(context.TODO())
 	if err != nil {
 		t.Errorf("unable to count logs: %v", err)
 	}
@@ -600,7 +600,7 @@ func testLogs(t *testing.T, db Interface, resources *Resources) {
 	methods["CountLogs"] = true
 
 	// count the logs for a build
-	count, err = db.CountLogsForBuild(resources.Builds[0])
+	count, err = db.CountLogsForBuild(context.TODO(), resources.Builds[0])
 	if err != nil {
 		t.Errorf("unable to count logs for build %d: %v", resources.Builds[0].GetID(), err)
 	}
@@ -610,7 +610,7 @@ func testLogs(t *testing.T, db Interface, resources *Resources) {
 	methods["CountLogsForBuild"] = true
 
 	// list the logs
-	list, err := db.ListLogs()
+	list, err := db.ListLogs(context.TODO())
 	if err != nil {
 		t.Errorf("unable to list logs: %v", err)
 	}
@@ -620,7 +620,7 @@ func testLogs(t *testing.T, db Interface, resources *Resources) {
 	methods["ListLogs"] = true
 
 	// list the logs for a build
-	list, count, err = db.ListLogsForBuild(resources.Builds[0], 1, 10)
+	list, count, err = db.ListLogsForBuild(context.TODO(), resources.Builds[0], 1, 10)
 	if err != nil {
 		t.Errorf("unable to list logs for build %d: %v", resources.Builds[0].GetID(), err)
 	}
@@ -635,7 +635,7 @@ func testLogs(t *testing.T, db Interface, resources *Resources) {
 	// lookup the logs by service
 	for _, log := range []*library.Log{resources.Logs[0], resources.Logs[1]} {
 		service := resources.Services[log.GetServiceID()-1]
-		got, err := db.GetLogForService(service)
+		got, err := db.GetLogForService(context.TODO(), service)
 		if err != nil {
 			t.Errorf("unable to get log %d for service %d: %v", log.GetID(), service.GetID(), err)
 		}
@@ -648,7 +648,7 @@ func testLogs(t *testing.T, db Interface, resources *Resources) {
 	// lookup the logs by service
 	for _, log := range []*library.Log{resources.Logs[2], resources.Logs[3]} {
 		step := resources.Steps[log.GetStepID()-1]
-		got, err := db.GetLogForStep(step)
+		got, err := db.GetLogForStep(context.TODO(), step)
 		if err != nil {
 			t.Errorf("unable to get log %d for step %d: %v", log.GetID(), step.GetID(), err)
 		}
@@ -661,13 +661,13 @@ func testLogs(t *testing.T, db Interface, resources *Resources) {
 	// update the logs
 	for _, log := range resources.Logs {
 		log.SetData([]byte("bar"))
-		err = db.UpdateLog(log)
+		err = db.UpdateLog(context.TODO(), log)
 		if err != nil {
 			t.Errorf("unable to update log %d: %v", log.GetID(), err)
 		}
 
 		// lookup the log by ID
-		got, err := db.GetLog(log.GetID())
+		got, err := db.GetLog(context.TODO(), log.GetID())
 		if err != nil {
 			t.Errorf("unable to get log %d by ID: %v", log.GetID(), err)
 		}
@@ -680,7 +680,7 @@ func testLogs(t *testing.T, db Interface, resources *Resources) {
 
 	// delete the logs
 	for _, log := range resources.Logs {
-		err = db.DeleteLog(log)
+		err = db.DeleteLog(context.TODO(), log)
 		if err != nil {
 			t.Errorf("unable to delete log %d: %v", log.GetID(), err)
 		}

--- a/database/log/count.go
+++ b/database/log/count.go
@@ -5,11 +5,13 @@
 package log
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 )
 
 // CountLogs gets the count of all logs from the database.
-func (e *engine) CountLogs() (int64, error) {
+func (e *engine) CountLogs(ctx context.Context) (int64, error) {
 	e.logger.Tracef("getting count of all logs from the database")
 
 	// variable to store query results

--- a/database/log/count_build.go
+++ b/database/log/count_build.go
@@ -5,12 +5,14 @@
 package log
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
 
 // CountLogsForBuild gets the count of logs by build ID from the database.
-func (e *engine) CountLogsForBuild(b *library.Build) (int64, error) {
+func (e *engine) CountLogsForBuild(ctx context.Context, b *library.Build) (int64, error) {
 	e.logger.Tracef("getting count of logs for build %d from the database", b.GetID())
 
 	// variable to store query results

--- a/database/log/count_build_test.go
+++ b/database/log/count_build_test.go
@@ -5,6 +5,7 @@
 package log
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -43,12 +44,12 @@ func TestLog_Engine_CountLogsForBuild(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	err := _sqlite.CreateLog(_service)
+	err := _sqlite.CreateLog(context.TODO(), _service)
 	if err != nil {
 		t.Errorf("unable to create test service log for sqlite: %v", err)
 	}
 
-	err = _sqlite.CreateLog(_step)
+	err = _sqlite.CreateLog(context.TODO(), _step)
 	if err != nil {
 		t.Errorf("unable to create test step log for sqlite: %v", err)
 	}
@@ -77,7 +78,7 @@ func TestLog_Engine_CountLogsForBuild(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CountLogsForBuild(_build)
+			got, err := test.database.CountLogsForBuild(context.TODO(), _build)
 
 			if test.failure {
 				if err == nil {

--- a/database/log/count_test.go
+++ b/database/log/count_test.go
@@ -5,6 +5,7 @@
 package log
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -37,12 +38,12 @@ func TestLog_Engine_CountLogs(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	err := _sqlite.CreateLog(_service)
+	err := _sqlite.CreateLog(context.TODO(), _service)
 	if err != nil {
 		t.Errorf("unable to create test service log for sqlite: %v", err)
 	}
 
-	err = _sqlite.CreateLog(_step)
+	err = _sqlite.CreateLog(context.TODO(), _step)
 	if err != nil {
 		t.Errorf("unable to create test step log for sqlite: %v", err)
 	}
@@ -71,7 +72,7 @@ func TestLog_Engine_CountLogs(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CountLogs()
+			got, err := test.database.CountLogs(context.TODO())
 
 			if test.failure {
 				if err == nil {

--- a/database/log/create.go
+++ b/database/log/create.go
@@ -6,6 +6,7 @@
 package log
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-vela/types/constants"
@@ -14,7 +15,7 @@ import (
 )
 
 // CreateLog creates a new log in the database.
-func (e *engine) CreateLog(l *library.Log) error {
+func (e *engine) CreateLog(ctx context.Context, l *library.Log) error {
 	// check what the log entry is for
 	switch {
 	case l.GetServiceID() > 0:

--- a/database/log/create_test.go
+++ b/database/log/create_test.go
@@ -5,6 +5,7 @@
 package log
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -73,7 +74,7 @@ VALUES ($1,$2,$3,$4,$5,$6) RETURNING "id"`).
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			for _, log := range test.logs {
-				err := test.database.CreateLog(log)
+				err := test.database.CreateLog(context.TODO(), log)
 
 				if test.failure {
 					if err == nil {

--- a/database/log/delete.go
+++ b/database/log/delete.go
@@ -5,13 +5,15 @@
 package log
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )
 
 // DeleteLog deletes an existing log from the database.
-func (e *engine) DeleteLog(l *library.Log) error {
+func (e *engine) DeleteLog(ctx context.Context, l *library.Log) error {
 	// check what the log entry is for
 	switch {
 	case l.GetServiceID() > 0:

--- a/database/log/delete_test.go
+++ b/database/log/delete_test.go
@@ -5,6 +5,7 @@
 package log
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -29,7 +30,7 @@ func TestLog_Engine_DeleteLog(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	err := _sqlite.CreateLog(_log)
+	err := _sqlite.CreateLog(context.TODO(), _log)
 	if err != nil {
 		t.Errorf("unable to create test log for sqlite: %v", err)
 	}
@@ -55,7 +56,7 @@ func TestLog_Engine_DeleteLog(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err = test.database.DeleteLog(_log)
+			err = test.database.DeleteLog(context.TODO(), _log)
 
 			if test.failure {
 				if err == nil {

--- a/database/log/get.go
+++ b/database/log/get.go
@@ -5,13 +5,15 @@
 package log
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )
 
 // GetLog gets a log by ID from the database.
-func (e *engine) GetLog(id int64) (*library.Log, error) {
+func (e *engine) GetLog(ctx context.Context, id int64) (*library.Log, error) {
 	e.logger.Tracef("getting log %d from the database", id)
 
 	// variable to store query results

--- a/database/log/get_service.go
+++ b/database/log/get_service.go
@@ -6,13 +6,15 @@
 package log
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )
 
 // GetLogForService gets a log by service ID from the database.
-func (e *engine) GetLogForService(s *library.Service) (*library.Log, error) {
+func (e *engine) GetLogForService(ctx context.Context, s *library.Service) (*library.Log, error) {
 	e.logger.Tracef("getting log for service %d for build %d from the database", s.GetID(), s.GetBuildID())
 
 	// variable to store query results

--- a/database/log/get_service_test.go
+++ b/database/log/get_service_test.go
@@ -5,6 +5,7 @@
 package log
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -42,7 +43,7 @@ func TestLog_Engine_GetLogForService(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	err := _sqlite.CreateLog(_log)
+	err := _sqlite.CreateLog(context.TODO(), _log)
 	if err != nil {
 		t.Errorf("unable to create test log for sqlite: %v", err)
 	}
@@ -71,7 +72,7 @@ func TestLog_Engine_GetLogForService(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.GetLogForService(_service)
+			got, err := test.database.GetLogForService(context.TODO(), _service)
 
 			if test.failure {
 				if err == nil {

--- a/database/log/get_step.go
+++ b/database/log/get_step.go
@@ -6,13 +6,15 @@
 package log
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )
 
 // GetLogForStep gets a log by step ID from the database.
-func (e *engine) GetLogForStep(s *library.Step) (*library.Log, error) {
+func (e *engine) GetLogForStep(ctx context.Context, s *library.Step) (*library.Log, error) {
 	e.logger.Tracef("getting log for step %d for build %d from the database", s.GetID(), s.GetBuildID())
 
 	// variable to store query results

--- a/database/log/get_step_test.go
+++ b/database/log/get_step_test.go
@@ -5,6 +5,7 @@
 package log
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -42,7 +43,7 @@ func TestLog_Engine_GetLogForStep(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	err := _sqlite.CreateLog(_log)
+	err := _sqlite.CreateLog(context.TODO(), _log)
 	if err != nil {
 		t.Errorf("unable to create test log for sqlite: %v", err)
 	}
@@ -71,7 +72,7 @@ func TestLog_Engine_GetLogForStep(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.GetLogForStep(_step)
+			got, err := test.database.GetLogForStep(context.TODO(), _step)
 
 			if test.failure {
 				if err == nil {

--- a/database/log/get_test.go
+++ b/database/log/get_test.go
@@ -5,6 +5,7 @@
 package log
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -35,7 +36,7 @@ func TestLog_Engine_GetLog(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	err := _sqlite.CreateLog(_log)
+	err := _sqlite.CreateLog(context.TODO(), _log)
 	if err != nil {
 		t.Errorf("unable to create test log for sqlite: %v", err)
 	}
@@ -64,7 +65,7 @@ func TestLog_Engine_GetLog(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.GetLog(1)
+			got, err := test.database.GetLog(context.TODO(), 1)
 
 			if test.failure {
 				if err == nil {

--- a/database/log/index.go
+++ b/database/log/index.go
@@ -4,6 +4,8 @@
 
 package log
 
+import "context"
+
 const (
 	// CreateBuildIDIndex represents a query to create an
 	// index on the logs table for the build_id column.
@@ -16,7 +18,7 @@ ON logs (build_id);
 )
 
 // CreateLogIndexes creates the indexes for the logs table in the database.
-func (e *engine) CreateLogIndexes() error {
+func (e *engine) CreateLogIndexes(ctx context.Context) error {
 	e.logger.Tracef("creating indexes for logs table in the database")
 
 	// create the build_id column index for the logs table

--- a/database/log/index_test.go
+++ b/database/log/index_test.go
@@ -5,6 +5,7 @@
 package log
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -41,7 +42,7 @@ func TestLog_Engine_CreateLogIndexes(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.database.CreateLogIndexes()
+			err := test.database.CreateLogIndexes(context.TODO())
 
 			if test.failure {
 				if err == nil {

--- a/database/log/interface.go
+++ b/database/log/interface.go
@@ -5,6 +5,8 @@
 package log
 
 import (
+	"context"
+
 	"github.com/go-vela/types/library"
 )
 
@@ -18,32 +20,32 @@ type LogInterface interface {
 	// https://en.wikipedia.org/wiki/Data_definition_language
 
 	// CreateLogIndexes defines a function that creates the indexes for the logs table.
-	CreateLogIndexes() error
+	CreateLogIndexes(context.Context) error
 	// CreateLogTable defines a function that creates the logs table.
-	CreateLogTable(string) error
+	CreateLogTable(context.Context, string) error
 
 	// Log Data Manipulation Language Functions
 	//
 	// https://en.wikipedia.org/wiki/Data_manipulation_language
 
 	// CountLogs defines a function that gets the count of all logs.
-	CountLogs() (int64, error)
+	CountLogs(context.Context) (int64, error)
 	// CountLogsForBuild defines a function that gets the count of logs by build ID.
-	CountLogsForBuild(*library.Build) (int64, error)
+	CountLogsForBuild(context.Context, *library.Build) (int64, error)
 	// CreateLog defines a function that creates a new log.
-	CreateLog(*library.Log) error
+	CreateLog(context.Context, *library.Log) error
 	// DeleteLog defines a function that deletes an existing log.
-	DeleteLog(*library.Log) error
+	DeleteLog(context.Context, *library.Log) error
 	// GetLog defines a function that gets a log by ID.
-	GetLog(int64) (*library.Log, error)
+	GetLog(context.Context, int64) (*library.Log, error)
 	// GetLogForService defines a function that gets a log by service ID.
-	GetLogForService(*library.Service) (*library.Log, error)
+	GetLogForService(context.Context, *library.Service) (*library.Log, error)
 	// GetLogForStep defines a function that gets a log by step ID.
-	GetLogForStep(*library.Step) (*library.Log, error)
+	GetLogForStep(context.Context, *library.Step) (*library.Log, error)
 	// ListLogs defines a function that gets a list of all logs.
-	ListLogs() ([]*library.Log, error)
+	ListLogs(context.Context) ([]*library.Log, error)
 	// ListLogsForBuild defines a function that gets a list of logs by build ID.
-	ListLogsForBuild(*library.Build, int, int) ([]*library.Log, int64, error)
+	ListLogsForBuild(context.Context, *library.Build, int, int) ([]*library.Log, int64, error)
 	// UpdateLog defines a function that updates an existing log.
-	UpdateLog(*library.Log) error
+	UpdateLog(context.Context, *library.Log) error
 }

--- a/database/log/list.go
+++ b/database/log/list.go
@@ -5,13 +5,15 @@
 package log
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )
 
 // ListLogs gets a list of all logs from the database.
-func (e *engine) ListLogs() ([]*library.Log, error) {
+func (e *engine) ListLogs(ctx context.Context) ([]*library.Log, error) {
 	e.logger.Trace("listing all logs from the database")
 
 	// variables to store query results and return value
@@ -20,7 +22,7 @@ func (e *engine) ListLogs() ([]*library.Log, error) {
 	logs := []*library.Log{}
 
 	// count the results
-	count, err := e.CountLogs()
+	count, err := e.CountLogs(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/database/log/list_build.go
+++ b/database/log/list_build.go
@@ -5,13 +5,15 @@
 package log
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )
 
 // ListLogsForBuild gets a list of logs by build ID from the database.
-func (e *engine) ListLogsForBuild(b *library.Build, page, perPage int) ([]*library.Log, int64, error) {
+func (e *engine) ListLogsForBuild(ctx context.Context, b *library.Build, page, perPage int) ([]*library.Log, int64, error) {
 	e.logger.Tracef("listing logs for build %d from the database", b.GetID())
 
 	// variables to store query results and return value
@@ -20,7 +22,7 @@ func (e *engine) ListLogsForBuild(b *library.Build, page, perPage int) ([]*libra
 	logs := []*library.Log{}
 
 	// count the results
-	count, err := e.CountLogsForBuild(b)
+	count, err := e.CountLogsForBuild(ctx, b)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/database/log/list_build_test.go
+++ b/database/log/list_build_test.go
@@ -5,6 +5,7 @@
 package log
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -54,12 +55,12 @@ func TestLog_Engine_ListLogsForBuild(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	err := _sqlite.CreateLog(_service)
+	err := _sqlite.CreateLog(context.TODO(), _service)
 	if err != nil {
 		t.Errorf("unable to create test service log for sqlite: %v", err)
 	}
 
-	err = _sqlite.CreateLog(_step)
+	err = _sqlite.CreateLog(context.TODO(), _step)
 	if err != nil {
 		t.Errorf("unable to create test step log for sqlite: %v", err)
 	}
@@ -88,7 +89,7 @@ func TestLog_Engine_ListLogsForBuild(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, _, err := test.database.ListLogsForBuild(_build, 1, 10)
+			got, _, err := test.database.ListLogsForBuild(context.TODO(), _build, 1, 10)
 
 			if test.failure {
 				if err == nil {

--- a/database/log/list_test.go
+++ b/database/log/list_test.go
@@ -5,6 +5,7 @@
 package log
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -48,12 +49,12 @@ func TestLog_Engine_ListLogs(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	err := _sqlite.CreateLog(_service)
+	err := _sqlite.CreateLog(context.TODO(), _service)
 	if err != nil {
 		t.Errorf("unable to create test service log for sqlite: %v", err)
 	}
 
-	err = _sqlite.CreateLog(_step)
+	err = _sqlite.CreateLog(context.TODO(), _step)
 	if err != nil {
 		t.Errorf("unable to create test step log for sqlite: %v", err)
 	}
@@ -82,7 +83,7 @@ func TestLog_Engine_ListLogs(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.ListLogs()
+			got, err := test.database.ListLogs(context.TODO())
 
 			if test.failure {
 				if err == nil {

--- a/database/log/log.go
+++ b/database/log/log.go
@@ -5,6 +5,7 @@
 package log
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-vela/types/constants"
@@ -26,6 +27,8 @@ type (
 	engine struct {
 		// engine configuration settings used in log functions
 		config *config
+
+		ctx context.Context
 
 		// gorm.io/gorm database client used in log functions
 		//
@@ -67,13 +70,13 @@ func New(opts ...EngineOpt) (*engine, error) {
 	}
 
 	// create the logs table
-	err := e.CreateLogTable(e.client.Config.Dialector.Name())
+	err := e.CreateLogTable(e.ctx, e.client.Config.Dialector.Name())
 	if err != nil {
 		return nil, fmt.Errorf("unable to create %s table: %w", constants.TableLog, err)
 	}
 
 	// create the indexes for the logs table
-	err = e.CreateLogIndexes()
+	err = e.CreateLogIndexes(e.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create indexes for %s table: %w", constants.TableLog, err)
 	}

--- a/database/log/opts.go
+++ b/database/log/opts.go
@@ -5,6 +5,8 @@
 package log
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
 
 	"gorm.io/gorm"
@@ -48,6 +50,15 @@ func WithSkipCreation(skipCreation bool) EngineOpt {
 	return func(e *engine) error {
 		// set to skip creating tables and indexes in the log engine
 		e.config.SkipCreation = skipCreation
+
+		return nil
+	}
+}
+
+// WithContext sets the context in the database engine for Logs.
+func WithContext(ctx context.Context) EngineOpt {
+	return func(e *engine) error {
+		e.ctx = ctx
 
 		return nil
 	}

--- a/database/log/opts_test.go
+++ b/database/log/opts_test.go
@@ -5,6 +5,7 @@
 package log
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -210,6 +211,55 @@ func TestLog_EngineOpt_WithSkipCreation(t *testing.T) {
 
 			if !reflect.DeepEqual(e.config.SkipCreation, test.want) {
 				t.Errorf("WithSkipCreation is %v, want %v", e.config.SkipCreation, test.want)
+			}
+		})
+	}
+}
+
+func TestLog_EngineOpt_WithContext(t *testing.T) {
+	// setup types
+	e := &engine{config: new(config)}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		name    string
+		ctx     context.Context
+		want    context.Context
+	}{
+		{
+			failure: false,
+			name:    "context set to TODO",
+			ctx:     context.TODO(),
+			want:    context.TODO(),
+		},
+		{
+			failure: false,
+			name:    "context set to nil",
+			ctx:     nil,
+			want:    nil,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := WithContext(test.ctx)(e)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithContext for %s should have returned err", test.name)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("WithContext returned err: %v", err)
+			}
+
+			if !reflect.DeepEqual(e.ctx, test.want) {
+				t.Errorf("WithContext is %v, want %v", e.ctx, test.want)
 			}
 		})
 	}

--- a/database/log/table.go
+++ b/database/log/table.go
@@ -5,6 +5,8 @@
 package log
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 )
 
@@ -43,7 +45,7 @@ logs (
 )
 
 // CreateLogTable creates the logs table in the database.
-func (e *engine) CreateLogTable(driver string) error {
+func (e *engine) CreateLogTable(ctx context.Context, driver string) error {
 	e.logger.Tracef("creating logs table in the database")
 
 	// handle the driver provided to create the table

--- a/database/log/table_test.go
+++ b/database/log/table_test.go
@@ -5,6 +5,7 @@
 package log
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -41,7 +42,7 @@ func TestLog_Engine_CreateLogTable(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.database.CreateLogTable(test.name)
+			err := test.database.CreateLogTable(context.TODO(), test.name)
 
 			if test.failure {
 				if err == nil {

--- a/database/log/update.go
+++ b/database/log/update.go
@@ -6,6 +6,7 @@
 package log
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-vela/types/constants"
@@ -14,7 +15,7 @@ import (
 )
 
 // UpdateLog updates an existing log in the database.
-func (e *engine) UpdateLog(l *library.Log) error {
+func (e *engine) UpdateLog(ctx context.Context, l *library.Log) error {
 	// check what the log entry is for
 	switch {
 	case l.GetServiceID() > 0:

--- a/database/log/update_test.go
+++ b/database/log/update_test.go
@@ -5,6 +5,7 @@
 package log
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -47,12 +48,12 @@ WHERE "id" = $6`).
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	err := _sqlite.CreateLog(_service)
+	err := _sqlite.CreateLog(context.TODO(), _service)
 	if err != nil {
 		t.Errorf("unable to create test service log for sqlite: %v", err)
 	}
 
-	err = _sqlite.CreateLog(_step)
+	err = _sqlite.CreateLog(context.TODO(), _step)
 	if err != nil {
 		t.Errorf("unable to create test step log for sqlite: %v", err)
 	}
@@ -82,7 +83,7 @@ WHERE "id" = $6`).
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			for _, log := range test.logs {
-				err = test.database.UpdateLog(log)
+				err = test.database.UpdateLog(context.TODO(), log)
 
 				if test.failure {
 					if err == nil {

--- a/database/resource.go
+++ b/database/resource.go
@@ -61,6 +61,7 @@ func (e *engine) NewResources(ctx context.Context) error {
 
 	// create the database agnostic engine for logs
 	e.LogInterface, err = log.New(
+		log.WithContext(e.ctx),
 		log.WithClient(e.client),
 		log.WithCompressionLevel(e.config.CompressionLevel),
 		log.WithLogger(e.logger),


### PR DESCRIPTION
continuing the efforts started in #898 #922 #923 #930 #937 #938 #941 #942

this is prep to add support for OpenTelemetry tracing.

the reason being, otel can (for the most part) work out of the box if you pass around contexts properly.