### PR TITLE
enhance: add context to Secrets

### DIFF
--- a/api/admin/secret.go
+++ b/api/admin/secret.go
@@ -53,6 +53,9 @@ import (
 func UpdateSecret(c *gin.Context) {
 	logrus.Info("Admin: updating secret in database")
 
+	// capture middleware values
+	ctx := c.Request.Context()
+
 	// capture body from API request
 	input := new(library.Secret)
 
@@ -66,7 +69,7 @@ func UpdateSecret(c *gin.Context) {
 	}
 
 	// send API call to update the secret
-	s, err := database.FromContext(c).UpdateSecret(input)
+	s, err := database.FromContext(c).UpdateSecret(ctx, input)
 	if err != nil {
 		retErr := fmt.Errorf("unable to update secret %d: %w", input.GetID(), err)
 

--- a/api/secret/create.go
+++ b/api/secret/create.go
@@ -86,6 +86,7 @@ func CreateSecret(c *gin.Context) {
 	t := util.PathParameter(c, "type")
 	o := util.PathParameter(c, "org")
 	n := util.PathParameter(c, "name")
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%s/%s", t, o, n)
 
@@ -229,7 +230,7 @@ func CreateSecret(c *gin.Context) {
 	}
 
 	// send API call to create the secret
-	s, err := secret.FromContext(c, e).Create(t, o, n, input)
+	s, err := secret.FromContext(c, e).Create(ctx, t, o, n, input)
 	if err != nil {
 		retErr := fmt.Errorf("unable to create secret %s for %s service: %w", entry, e, err)
 

--- a/api/secret/delete.go
+++ b/api/secret/delete.go
@@ -76,6 +76,7 @@ func DeleteSecret(c *gin.Context) {
 	o := util.PathParameter(c, "org")
 	n := util.PathParameter(c, "name")
 	s := strings.TrimPrefix(util.PathParameter(c, "secret"), "/")
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%s/%s/%s", t, o, n, s)
 
@@ -108,7 +109,7 @@ func DeleteSecret(c *gin.Context) {
 	logrus.WithFields(fields).Infof("deleting secret %s from %s service", entry, e)
 
 	// send API call to remove the secret
-	err := secret.FromContext(c, e).Delete(t, o, n, s)
+	err := secret.FromContext(c, e).Delete(ctx, t, o, n, s)
 	if err != nil {
 		retErr := fmt.Errorf("unable to delete secret %s from %s service: %w", entry, e, err)
 

--- a/api/secret/get.go
+++ b/api/secret/get.go
@@ -78,6 +78,7 @@ func GetSecret(c *gin.Context) {
 	o := util.PathParameter(c, "org")
 	n := util.PathParameter(c, "name")
 	s := strings.TrimPrefix(util.PathParameter(c, "secret"), "/")
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%s/%s/%s", t, o, n, s)
 
@@ -110,7 +111,7 @@ func GetSecret(c *gin.Context) {
 	logrus.WithFields(fields).Infof("reading secret %s from %s service", entry, e)
 
 	// send API call to capture the secret
-	secret, err := secret.FromContext(c, e).Get(t, o, n, s)
+	secret, err := secret.FromContext(c, e).Get(ctx, t, o, n, s)
 	if err != nil {
 		retErr := fmt.Errorf("unable to get secret %s from %s service: %w", entry, e, err)
 

--- a/api/secret/list.go
+++ b/api/secret/list.go
@@ -99,6 +99,7 @@ func ListSecrets(c *gin.Context) {
 	t := util.PathParameter(c, "type")
 	o := util.PathParameter(c, "org")
 	n := util.PathParameter(c, "name")
+	ctx := c.Request.Context()
 
 	var teams []string
 	// get list of user's teams if type is shared secret and team is '*'
@@ -164,7 +165,7 @@ func ListSecrets(c *gin.Context) {
 	}
 
 	// send API call to capture the total number of secrets
-	total, err := secret.FromContext(c, e).Count(t, o, n, teams)
+	total, err := secret.FromContext(c, e).Count(ctx, t, o, n, teams)
 	if err != nil {
 		retErr := fmt.Errorf("unable to get secret count for %s from %s service: %w", entry, e, err)
 
@@ -177,7 +178,7 @@ func ListSecrets(c *gin.Context) {
 	perPage = util.MaxInt(1, util.MinInt(100, perPage))
 
 	// send API call to capture the list of secrets
-	s, err := secret.FromContext(c, e).List(t, o, n, page, perPage, teams)
+	s, err := secret.FromContext(c, e).List(ctx, t, o, n, page, perPage, teams)
 	if err != nil {
 		retErr := fmt.Errorf("unable to list secrets for %s from %s service: %w", entry, e, err)
 

--- a/api/secret/update.go
+++ b/api/secret/update.go
@@ -88,6 +88,7 @@ func UpdateSecret(c *gin.Context) {
 	o := util.PathParameter(c, "org")
 	n := util.PathParameter(c, "name")
 	s := strings.TrimPrefix(util.PathParameter(c, "secret"), "/")
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%s/%s/%s", t, o, n, s)
 
@@ -161,7 +162,7 @@ func UpdateSecret(c *gin.Context) {
 	}
 
 	// send API call to update the secret
-	secret, err := secret.FromContext(c, e).Update(t, o, n, input)
+	secret, err := secret.FromContext(c, e).Update(ctx, t, o, n, input)
 	if err != nil {
 		retErr := fmt.Errorf("unable to update secret %s for %s service: %w", entry, e, err)
 

--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -816,7 +816,7 @@ func renameRepository(ctx context.Context, h *library.Hook, r *library.Repo, c *
 	}
 
 	// get total number of secrets associated with repository
-	t, err := database.FromContext(c).CountSecretsForRepo(dbR, map[string]interface{}{})
+	t, err := database.FromContext(c).CountSecretsForRepo(ctx, dbR, map[string]interface{}{})
 	if err != nil {
 		return nil, fmt.Errorf("unable to get secret count for repo %s/%s: %w", prevOrg, prevRepo, err)
 	}
@@ -825,7 +825,7 @@ func renameRepository(ctx context.Context, h *library.Hook, r *library.Repo, c *
 	page := 1
 	// capture all secrets belonging to certain repo in database
 	for repoSecrets := int64(0); repoSecrets < t; repoSecrets += 100 {
-		s, _, err := database.FromContext(c).ListSecretsForRepo(dbR, map[string]interface{}{}, page, 100)
+		s, _, err := database.FromContext(c).ListSecretsForRepo(ctx, dbR, map[string]interface{}{}, page, 100)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get secret list for repo %s/%s: %w", prevOrg, prevRepo, err)
 		}
@@ -840,7 +840,7 @@ func renameRepository(ctx context.Context, h *library.Hook, r *library.Repo, c *
 		secret.SetOrg(r.GetOrg())
 		secret.SetRepo(r.GetName())
 
-		_, err = database.FromContext(c).UpdateSecret(secret)
+		_, err = database.FromContext(c).UpdateSecret(ctx, secret)
 		if err != nil {
 			return nil, fmt.Errorf("unable to update secret for repo %s/%s: %w", prevOrg, prevRepo, err)
 		}

--- a/database/integration_test.go
+++ b/database/integration_test.go
@@ -1104,7 +1104,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 
 	// create the secrets
 	for _, secret := range resources.Secrets {
-		_, err := db.CreateSecret(secret)
+		_, err := db.CreateSecret(context.TODO(), secret)
 		if err != nil {
 			t.Errorf("unable to create secret %d: %v", secret.GetID(), err)
 		}
@@ -1112,7 +1112,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 	methods["CreateSecret"] = true
 
 	// count the secrets
-	count, err := db.CountSecrets()
+	count, err := db.CountSecrets(context.TODO())
 	if err != nil {
 		t.Errorf("unable to count secrets: %v", err)
 	}
@@ -1125,7 +1125,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 		switch secret.GetType() {
 		case constants.SecretOrg:
 			// count the secrets for an org
-			count, err = db.CountSecretsForOrg(secret.GetOrg(), nil)
+			count, err = db.CountSecretsForOrg(context.TODO(), secret.GetOrg(), nil)
 			if err != nil {
 				t.Errorf("unable to count secrets for org %s: %v", secret.GetOrg(), err)
 			}
@@ -1135,7 +1135,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			methods["CountSecretsForOrg"] = true
 		case constants.SecretRepo:
 			// count the secrets for a repo
-			count, err = db.CountSecretsForRepo(resources.Repos[0], nil)
+			count, err = db.CountSecretsForRepo(context.TODO(), resources.Repos[0], nil)
 			if err != nil {
 				t.Errorf("unable to count secrets for repo %d: %v", resources.Repos[0].GetID(), err)
 			}
@@ -1145,7 +1145,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			methods["CountSecretsForRepo"] = true
 		case constants.SecretShared:
 			// count the secrets for a team
-			count, err = db.CountSecretsForTeam(secret.GetOrg(), secret.GetTeam(), nil)
+			count, err = db.CountSecretsForTeam(context.TODO(), secret.GetOrg(), secret.GetTeam(), nil)
 			if err != nil {
 				t.Errorf("unable to count secrets for team %s: %v", secret.GetTeam(), err)
 			}
@@ -1155,7 +1155,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			methods["CountSecretsForTeam"] = true
 
 			// count the secrets for a list of teams
-			count, err = db.CountSecretsForTeams(secret.GetOrg(), []string{secret.GetTeam()}, nil)
+			count, err = db.CountSecretsForTeams(context.TODO(), secret.GetOrg(), []string{secret.GetTeam()}, nil)
 			if err != nil {
 				t.Errorf("unable to count secrets for teams %s: %v", []string{secret.GetTeam()}, err)
 			}
@@ -1169,7 +1169,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 	}
 
 	// list the secrets
-	list, err := db.ListSecrets()
+	list, err := db.ListSecrets(context.TODO())
 	if err != nil {
 		t.Errorf("unable to list secrets: %v", err)
 	}
@@ -1182,7 +1182,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 		switch secret.GetType() {
 		case constants.SecretOrg:
 			// list the secrets for an org
-			list, count, err = db.ListSecretsForOrg(secret.GetOrg(), nil, 1, 10)
+			list, count, err = db.ListSecretsForOrg(context.TODO(), secret.GetOrg(), nil, 1, 10)
 			if err != nil {
 				t.Errorf("unable to list secrets for org %s: %v", secret.GetOrg(), err)
 			}
@@ -1195,7 +1195,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			methods["ListSecretsForOrg"] = true
 		case constants.SecretRepo:
 			// list the secrets for a repo
-			list, count, err = db.ListSecretsForRepo(resources.Repos[0], nil, 1, 10)
+			list, count, err = db.ListSecretsForRepo(context.TODO(), resources.Repos[0], nil, 1, 10)
 			if err != nil {
 				t.Errorf("unable to list secrets for repo %d: %v", resources.Repos[0].GetID(), err)
 			}
@@ -1208,7 +1208,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			methods["ListSecretsForRepo"] = true
 		case constants.SecretShared:
 			// list the secrets for a team
-			list, count, err = db.ListSecretsForTeam(secret.GetOrg(), secret.GetTeam(), nil, 1, 10)
+			list, count, err = db.ListSecretsForTeam(context.TODO(), secret.GetOrg(), secret.GetTeam(), nil, 1, 10)
 			if err != nil {
 				t.Errorf("unable to list secrets for team %s: %v", secret.GetTeam(), err)
 			}
@@ -1221,7 +1221,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			methods["ListSecretsForTeam"] = true
 
 			// list the secrets for a list of teams
-			list, count, err = db.ListSecretsForTeams(secret.GetOrg(), []string{secret.GetTeam()}, nil, 1, 10)
+			list, count, err = db.ListSecretsForTeams(context.TODO(), secret.GetOrg(), []string{secret.GetTeam()}, nil, 1, 10)
 			if err != nil {
 				t.Errorf("unable to list secrets for teams %s: %v", []string{secret.GetTeam()}, err)
 			}
@@ -1241,7 +1241,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 		switch secret.GetType() {
 		case constants.SecretOrg:
 			// lookup the secret by org
-			got, err := db.GetSecretForOrg(secret.GetOrg(), secret.GetName())
+			got, err := db.GetSecretForOrg(context.TODO(), secret.GetOrg(), secret.GetName())
 			if err != nil {
 				t.Errorf("unable to get secret %d for org %s: %v", secret.GetID(), secret.GetOrg(), err)
 			}
@@ -1251,7 +1251,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			methods["GetSecretForOrg"] = true
 		case constants.SecretRepo:
 			// lookup the secret by repo
-			got, err := db.GetSecretForRepo(secret.GetName(), resources.Repos[0])
+			got, err := db.GetSecretForRepo(context.TODO(), secret.GetName(), resources.Repos[0])
 			if err != nil {
 				t.Errorf("unable to get secret %d for repo %d: %v", secret.GetID(), resources.Repos[0].GetID(), err)
 			}
@@ -1261,7 +1261,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			methods["GetSecretForRepo"] = true
 		case constants.SecretShared:
 			// lookup the secret by team
-			got, err := db.GetSecretForTeam(secret.GetOrg(), secret.GetTeam(), secret.GetName())
+			got, err := db.GetSecretForTeam(context.TODO(), secret.GetOrg(), secret.GetTeam(), secret.GetName())
 			if err != nil {
 				t.Errorf("unable to get secret %d for team %s: %v", secret.GetID(), secret.GetTeam(), err)
 			}
@@ -1277,7 +1277,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 	// update the secrets
 	for _, secret := range resources.Secrets {
 		secret.SetUpdatedAt(time.Now().UTC().Unix())
-		got, err := db.UpdateSecret(secret)
+		got, err := db.UpdateSecret(context.TODO(), secret)
 		if err != nil {
 			t.Errorf("unable to update secret %d: %v", secret.GetID(), err)
 		}
@@ -1291,7 +1291,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 
 	// delete the secrets
 	for _, secret := range resources.Secrets {
-		err = db.DeleteSecret(secret)
+		err = db.DeleteSecret(context.TODO(), secret)
 		if err != nil {
 			t.Errorf("unable to delete secret %d: %v", secret.GetID(), err)
 		}

--- a/database/resource.go
+++ b/database/resource.go
@@ -109,6 +109,7 @@ func (e *engine) NewResources(ctx context.Context) error {
 	//
 	// https://pkg.go.dev/github.com/go-vela/server/database/secret#New
 	e.SecretInterface, err = secret.New(
+		secret.WithContext(e.ctx),
 		secret.WithClient(e.client),
 		secret.WithEncryptionKey(e.config.EncryptionKey),
 		secret.WithLogger(e.logger),

--- a/database/secret/count.go
+++ b/database/secret/count.go
@@ -5,11 +5,13 @@
 package secret
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 )
 
 // CountSecrets gets the count of all secrets from the database.
-func (e *engine) CountSecrets() (int64, error) {
+func (e *engine) CountSecrets(ctx context.Context) (int64, error) {
 	e.logger.Tracef("getting count of all secrets from the database")
 
 	// variable to store query results

--- a/database/secret/count_org.go
+++ b/database/secret/count_org.go
@@ -5,12 +5,14 @@
 package secret
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/sirupsen/logrus"
 )
 
 // CountSecretsForOrg gets the count of secrets by org name from the database.
-func (e *engine) CountSecretsForOrg(org string, filters map[string]interface{}) (int64, error) {
+func (e *engine) CountSecretsForOrg(ctx context.Context, org string, filters map[string]interface{}) (int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org":  org,
 		"type": constants.SecretOrg,

--- a/database/secret/count_org_test.go
+++ b/database/secret/count_org_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -51,12 +52,12 @@ func TestSecret_Engine_CountSecretsForOrg(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateSecret(_secretOne)
+	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateSecret(_secretTwo)
+	_, err = _sqlite.CreateSecret(context.TODO(), _secretTwo)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
@@ -87,7 +88,7 @@ func TestSecret_Engine_CountSecretsForOrg(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CountSecretsForOrg("foo", filters)
+			got, err := test.database.CountSecretsForOrg(context.TODO(), "foo", filters)
 
 			if test.failure {
 				if err == nil {

--- a/database/secret/count_repo.go
+++ b/database/secret/count_repo.go
@@ -5,13 +5,15 @@
 package secret
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/sirupsen/logrus"
 )
 
 // CountSecretsForRepo gets the count of secrets by org and repo name from the database.
-func (e *engine) CountSecretsForRepo(r *library.Repo, filters map[string]interface{}) (int64, error) {
+func (e *engine) CountSecretsForRepo(ctx context.Context, r *library.Repo, filters map[string]interface{}) (int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),

--- a/database/secret/count_repo_test.go
+++ b/database/secret/count_repo_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -62,12 +63,12 @@ func TestSecret_Engine_CountSecretsForRepo(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateSecret(_secretOne)
+	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateSecret(_secretTwo)
+	_, err = _sqlite.CreateSecret(context.TODO(), _secretTwo)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
@@ -98,7 +99,7 @@ func TestSecret_Engine_CountSecretsForRepo(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CountSecretsForRepo(_repo, filters)
+			got, err := test.database.CountSecretsForRepo(context.TODO(), _repo, filters)
 
 			if test.failure {
 				if err == nil {

--- a/database/secret/count_team.go
+++ b/database/secret/count_team.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"strings"
 
 	"github.com/go-vela/types/constants"
@@ -12,7 +13,7 @@ import (
 )
 
 // CountSecretsForTeam gets the count of secrets by org and team name from the database.
-func (e *engine) CountSecretsForTeam(org, team string, filters map[string]interface{}) (int64, error) {
+func (e *engine) CountSecretsForTeam(ctx context.Context, org, team string, filters map[string]interface{}) (int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org":  org,
 		"team": team,
@@ -36,7 +37,7 @@ func (e *engine) CountSecretsForTeam(org, team string, filters map[string]interf
 }
 
 // CountSecretsForTeams gets the count of secrets by teams within an org from the database.
-func (e *engine) CountSecretsForTeams(org string, teams []string, filters map[string]interface{}) (int64, error) {
+func (e *engine) CountSecretsForTeams(ctx context.Context, org string, teams []string, filters map[string]interface{}) (int64, error) {
 	// lower case team names for not case-sensitive values from the SCM i.e. GitHub
 	//
 	// iterate through the list of teams provided

--- a/database/secret/count_team_test.go
+++ b/database/secret/count_team_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -52,12 +53,12 @@ func TestSecret_Engine_CountSecretsForTeam(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateSecret(_secretOne)
+	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateSecret(_secretTwo)
+	_, err = _sqlite.CreateSecret(context.TODO(), _secretTwo)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
@@ -88,7 +89,7 @@ func TestSecret_Engine_CountSecretsForTeam(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CountSecretsForTeam("foo", "bar", filters)
+			got, err := test.database.CountSecretsForTeam(context.TODO(), "foo", "bar", filters)
 
 			if test.failure {
 				if err == nil {
@@ -158,12 +159,12 @@ func TestSecret_Engine_CountSecretsForTeams(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateSecret(_secretOne)
+	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateSecret(_secretTwo)
+	_, err = _sqlite.CreateSecret(context.TODO(), _secretTwo)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
@@ -194,7 +195,7 @@ func TestSecret_Engine_CountSecretsForTeams(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CountSecretsForTeams("foo", []string{"foo", "bar"}, filters)
+			got, err := test.database.CountSecretsForTeams(context.TODO(), "foo", []string{"foo", "bar"}, filters)
 
 			if test.failure {
 				if err == nil {

--- a/database/secret/count_test.go
+++ b/database/secret/count_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -49,12 +50,12 @@ func TestSecret_Engine_CountSecrets(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateSecret(_secretOne)
+	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateSecret(_secretTwo)
+	_, err = _sqlite.CreateSecret(context.TODO(), _secretTwo)
 	if err != nil {
 		t.Errorf("unable to create test repo for sqlite: %v", err)
 	}
@@ -83,7 +84,7 @@ func TestSecret_Engine_CountSecrets(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CountSecrets()
+			got, err := test.database.CountSecrets(context.TODO())
 
 			if test.failure {
 				if err == nil {

--- a/database/secret/create.go
+++ b/database/secret/create.go
@@ -6,6 +6,7 @@
 package secret
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-vela/types/constants"
@@ -15,7 +16,7 @@ import (
 )
 
 // CreateSecret creates a new secret in the database.
-func (e *engine) CreateSecret(s *library.Secret) (*library.Secret, error) {
+func (e *engine) CreateSecret(ctx context.Context, s *library.Secret) (*library.Secret, error) {
 	// handle the secret based off the type
 	switch s.GetType() {
 	case constants.SecretShared:

--- a/database/secret/create_test.go
+++ b/database/secret/create_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -128,7 +129,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14) RETURNING "id"`).
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.CreateSecret(test.secret)
+			got, err := test.database.CreateSecret(context.TODO(), test.secret)
 
 			if test.failure {
 				if err == nil {

--- a/database/secret/delete.go
+++ b/database/secret/delete.go
@@ -5,6 +5,8 @@
 package secret
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -12,7 +14,7 @@ import (
 )
 
 // DeleteSecret deletes an existing secret from the database.
-func (e *engine) DeleteSecret(s *library.Secret) error {
+func (e *engine) DeleteSecret(ctx context.Context, s *library.Secret) error {
 	// handle the secret based off the type
 	//
 	//nolint:dupl // ignore similar code with update.go

--- a/database/secret/delete_test.go
+++ b/database/secret/delete_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -70,17 +71,17 @@ func TestSecret_Engine_DeleteSecret(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateSecret(_secretRepo)
+	_, err := _sqlite.CreateSecret(context.TODO(), _secretRepo)
 	if err != nil {
 		t.Errorf("unable to create test repo secret for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateSecret(_secretOrg)
+	_, err = _sqlite.CreateSecret(context.TODO(), _secretOrg)
 	if err != nil {
 		t.Errorf("unable to create test org secret for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateSecret(_secretShared)
+	_, err = _sqlite.CreateSecret(context.TODO(), _secretShared)
 	if err != nil {
 		t.Errorf("unable to create test shared secret for sqlite: %v", err)
 	}
@@ -133,7 +134,7 @@ func TestSecret_Engine_DeleteSecret(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err = test.database.DeleteSecret(test.secret)
+			err = test.database.DeleteSecret(context.TODO(), test.secret)
 
 			if test.failure {
 				if err == nil {

--- a/database/secret/get.go
+++ b/database/secret/get.go
@@ -5,13 +5,15 @@
 package secret
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )
 
 // GetSecret gets a secret by ID from the database.
-func (e *engine) GetSecret(id int64) (*library.Secret, error) {
+func (e *engine) GetSecret(ctx context.Context, id int64) (*library.Secret, error) {
 	e.logger.Tracef("getting secret %d from the database", id)
 
 	// variable to store query results

--- a/database/secret/get_org.go
+++ b/database/secret/get_org.go
@@ -5,6 +5,8 @@
 package secret
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -12,7 +14,7 @@ import (
 )
 
 // GetSecretForOrg gets a secret by org name from the database.
-func (e *engine) GetSecretForOrg(org, name string) (*library.Secret, error) {
+func (e *engine) GetSecretForOrg(ctx context.Context, org, name string) (*library.Secret, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org":    org,
 		"secret": name,

--- a/database/secret/get_org_test.go
+++ b/database/secret/get_org_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -42,7 +43,7 @@ func TestSecret_Engine_GetSecretForOrg(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateSecret(_secret)
+	_, err := _sqlite.CreateSecret(context.TODO(), _secret)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
@@ -71,7 +72,7 @@ func TestSecret_Engine_GetSecretForOrg(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.GetSecretForOrg("foo", "baz")
+			got, err := test.database.GetSecretForOrg(context.TODO(), "foo", "baz")
 
 			if test.failure {
 				if err == nil {

--- a/database/secret/get_repo.go
+++ b/database/secret/get_repo.go
@@ -5,6 +5,8 @@
 package secret
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -12,7 +14,7 @@ import (
 )
 
 // GetSecretForRepo gets a secret by org and repo name from the database.
-func (e *engine) GetSecretForRepo(name string, r *library.Repo) (*library.Secret, error) {
+func (e *engine) GetSecretForRepo(ctx context.Context, name string, r *library.Repo) (*library.Secret, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org":    r.GetOrg(),
 		"repo":   r.GetName(),

--- a/database/secret/get_repo_test.go
+++ b/database/secret/get_repo_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -52,7 +53,7 @@ func TestSecret_Engine_GetSecretForRepo(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateSecret(_secret)
+	_, err := _sqlite.CreateSecret(context.TODO(), _secret)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
@@ -81,7 +82,7 @@ func TestSecret_Engine_GetSecretForRepo(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.GetSecretForRepo("baz", _repo)
+			got, err := test.database.GetSecretForRepo(context.TODO(), "baz", _repo)
 
 			if test.failure {
 				if err == nil {

--- a/database/secret/get_team.go
+++ b/database/secret/get_team.go
@@ -5,6 +5,8 @@
 package secret
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -12,7 +14,7 @@ import (
 )
 
 // GetSecretForTeam gets a secret by org and team name from the database.
-func (e *engine) GetSecretForTeam(org, team, name string) (*library.Secret, error) {
+func (e *engine) GetSecretForTeam(ctx context.Context, org, team, name string) (*library.Secret, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org":    org,
 		"team":   team,

--- a/database/secret/get_team_test.go
+++ b/database/secret/get_team_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -42,7 +43,7 @@ func TestSecret_Engine_GetSecretForTeam(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateSecret(_secret)
+	_, err := _sqlite.CreateSecret(context.TODO(), _secret)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
@@ -71,7 +72,7 @@ func TestSecret_Engine_GetSecretForTeam(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.GetSecretForTeam("foo", "bar", "baz")
+			got, err := test.database.GetSecretForTeam(context.TODO(), "foo", "bar", "baz")
 
 			if test.failure {
 				if err == nil {

--- a/database/secret/get_test.go
+++ b/database/secret/get_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -40,7 +41,7 @@ func TestSecret_Engine_GetSecret(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateSecret(_secret)
+	_, err := _sqlite.CreateSecret(context.TODO(), _secret)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
@@ -69,7 +70,7 @@ func TestSecret_Engine_GetSecret(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.GetSecret(1)
+			got, err := test.database.GetSecret(context.TODO(), 1)
 
 			if test.failure {
 				if err == nil {

--- a/database/secret/index.go
+++ b/database/secret/index.go
@@ -4,6 +4,8 @@
 
 package secret
 
+import "context"
+
 const (
 	// CreateTypeOrgRepo represents a query to create an
 	// index on the secrets table for the type, org and repo columns.
@@ -32,7 +34,7 @@ ON secrets (type, org);
 )
 
 // CreateSecretIndexes creates the indexes for the secrets table in the database.
-func (e *engine) CreateSecretIndexes() error {
+func (e *engine) CreateSecretIndexes(ctx context.Context) error {
 	e.logger.Tracef("creating indexes for secrets table in the database")
 
 	// create the type, org and repo columns index for the secrets table

--- a/database/secret/index_test.go
+++ b/database/secret/index_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -43,7 +44,7 @@ func TestSecret_Engine_CreateSecretIndexes(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.database.CreateSecretIndexes()
+			err := test.database.CreateSecretIndexes(context.TODO())
 
 			if test.failure {
 				if err == nil {

--- a/database/secret/interface.go
+++ b/database/secret/interface.go
@@ -5,6 +5,8 @@
 package secret
 
 import (
+	"context"
+
 	"github.com/go-vela/types/library"
 )
 
@@ -18,46 +20,46 @@ type SecretInterface interface {
 	// https://en.wikipedia.org/wiki/Data_definition_language
 
 	// CreateSecretIndexes defines a function that creates the indexes for the secrets table.
-	CreateSecretIndexes() error
+	CreateSecretIndexes(context.Context) error
 	// CreateSecretTable defines a function that creates the secrets table.
-	CreateSecretTable(string) error
+	CreateSecretTable(context.Context, string) error
 
 	// Secret Data Manipulation Language Functions
 	//
 	// https://en.wikipedia.org/wiki/Data_manipulation_language
 
 	// CountSecrets defines a function that gets the count of all secrets.
-	CountSecrets() (int64, error)
+	CountSecrets(context.Context) (int64, error)
 	// CountSecretsForOrg defines a function that gets the count of secrets by org name.
-	CountSecretsForOrg(string, map[string]interface{}) (int64, error)
+	CountSecretsForOrg(context.Context, string, map[string]interface{}) (int64, error)
 	// CountSecretsForRepo defines a function that gets the count of secrets by org and repo name.
-	CountSecretsForRepo(*library.Repo, map[string]interface{}) (int64, error)
+	CountSecretsForRepo(context.Context, *library.Repo, map[string]interface{}) (int64, error)
 	// CountSecretsForTeam defines a function that gets the count of secrets by org and team name.
-	CountSecretsForTeam(string, string, map[string]interface{}) (int64, error)
+	CountSecretsForTeam(context.Context, string, string, map[string]interface{}) (int64, error)
 	// CountSecretsForTeams defines a function that gets the count of secrets by teams within an org.
-	CountSecretsForTeams(string, []string, map[string]interface{}) (int64, error)
+	CountSecretsForTeams(context.Context, string, []string, map[string]interface{}) (int64, error)
 	// CreateSecret defines a function that creates a new secret.
-	CreateSecret(*library.Secret) (*library.Secret, error)
+	CreateSecret(context.Context, *library.Secret) (*library.Secret, error)
 	// DeleteSecret defines a function that deletes an existing secret.
-	DeleteSecret(*library.Secret) error
+	DeleteSecret(context.Context, *library.Secret) error
 	// GetSecret defines a function that gets a secret by ID.
-	GetSecret(int64) (*library.Secret, error)
+	GetSecret(context.Context, int64) (*library.Secret, error)
 	// GetSecretForOrg defines a function that gets a secret by org name.
-	GetSecretForOrg(string, string) (*library.Secret, error)
+	GetSecretForOrg(context.Context, string, string) (*library.Secret, error)
 	// GetSecretForRepo defines a function that gets a secret by org and repo name.
-	GetSecretForRepo(string, *library.Repo) (*library.Secret, error)
+	GetSecretForRepo(context.Context, string, *library.Repo) (*library.Secret, error)
 	// GetSecretForTeam defines a function that gets a secret by org and team name.
-	GetSecretForTeam(string, string, string) (*library.Secret, error)
+	GetSecretForTeam(context.Context, string, string, string) (*library.Secret, error)
 	// ListSecrets defines a function that gets a list of all secrets.
-	ListSecrets() ([]*library.Secret, error)
+	ListSecrets(context.Context) ([]*library.Secret, error)
 	// ListSecretsForOrg defines a function that gets a list of secrets by org name.
-	ListSecretsForOrg(string, map[string]interface{}, int, int) ([]*library.Secret, int64, error)
+	ListSecretsForOrg(context.Context, string, map[string]interface{}, int, int) ([]*library.Secret, int64, error)
 	// ListSecretsForRepo defines a function that gets a list of secrets by org and repo name.
-	ListSecretsForRepo(*library.Repo, map[string]interface{}, int, int) ([]*library.Secret, int64, error)
+	ListSecretsForRepo(context.Context, *library.Repo, map[string]interface{}, int, int) ([]*library.Secret, int64, error)
 	// ListSecretsForTeam defines a function that gets a list of secrets by org and team name.
-	ListSecretsForTeam(string, string, map[string]interface{}, int, int) ([]*library.Secret, int64, error)
+	ListSecretsForTeam(context.Context, string, string, map[string]interface{}, int, int) ([]*library.Secret, int64, error)
 	// ListSecretsForTeams defines a function that gets a list of secrets by teams within an org.
-	ListSecretsForTeams(string, []string, map[string]interface{}, int, int) ([]*library.Secret, int64, error)
+	ListSecretsForTeams(context.Context, string, []string, map[string]interface{}, int, int) ([]*library.Secret, int64, error)
 	// UpdateSecret defines a function that updates an existing secret.
-	UpdateSecret(*library.Secret) (*library.Secret, error)
+	UpdateSecret(context.Context, *library.Secret) (*library.Secret, error)
 }

--- a/database/secret/list.go
+++ b/database/secret/list.go
@@ -5,13 +5,15 @@
 package secret
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )
 
 // ListSecrets gets a list of all secrets from the database.
-func (e *engine) ListSecrets() ([]*library.Secret, error) {
+func (e *engine) ListSecrets(ctx context.Context) ([]*library.Secret, error) {
 	e.logger.Trace("listing all secrets from the database")
 
 	// variables to store query results and return value
@@ -20,7 +22,7 @@ func (e *engine) ListSecrets() ([]*library.Secret, error) {
 	secrets := []*library.Secret{}
 
 	// count the results
-	count, err := e.CountSecrets()
+	count, err := e.CountSecrets(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/database/secret/list_org.go
+++ b/database/secret/list_org.go
@@ -5,6 +5,8 @@
 package secret
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -14,7 +16,7 @@ import (
 // ListSecretsForOrg gets a list of secrets by org name from the database.
 //
 //nolint:lll // ignore long line length due to variable names
-func (e *engine) ListSecretsForOrg(org string, filters map[string]interface{}, page, perPage int) ([]*library.Secret, int64, error) {
+func (e *engine) ListSecretsForOrg(ctx context.Context, org string, filters map[string]interface{}, page, perPage int) ([]*library.Secret, int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org":  org,
 		"type": constants.SecretOrg,
@@ -26,7 +28,7 @@ func (e *engine) ListSecretsForOrg(org string, filters map[string]interface{}, p
 	secrets := []*library.Secret{}
 
 	// count the results
-	count, err := e.CountSecretsForOrg(org, filters)
+	count, err := e.CountSecretsForOrg(ctx, org, filters)
 	if err != nil {
 		return secrets, 0, err
 	}

--- a/database/secret/list_org_test.go
+++ b/database/secret/list_org_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -62,12 +63,12 @@ func TestSecret_Engine_ListSecretsForOrg(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateSecret(_secretOne)
+	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateSecret(_secretTwo)
+	_, err = _sqlite.CreateSecret(context.TODO(), _secretTwo)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
@@ -98,7 +99,7 @@ func TestSecret_Engine_ListSecretsForOrg(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, _, err := test.database.ListSecretsForOrg("foo", filters, 1, 10)
+			got, _, err := test.database.ListSecretsForOrg(context.TODO(), "foo", filters, 1, 10)
 
 			if test.failure {
 				if err == nil {

--- a/database/secret/list_repo.go
+++ b/database/secret/list_repo.go
@@ -5,6 +5,8 @@
 package secret
 
 import (
+	"context"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
@@ -14,7 +16,7 @@ import (
 // ListSecretsForRepo gets a list of secrets by org name from the database.
 //
 //nolint:lll // ignore long line length due to variable names
-func (e *engine) ListSecretsForRepo(r *library.Repo, filters map[string]interface{}, page, perPage int) ([]*library.Secret, int64, error) {
+func (e *engine) ListSecretsForRepo(ctx context.Context, r *library.Repo, filters map[string]interface{}, page, perPage int) ([]*library.Secret, int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),
@@ -27,7 +29,7 @@ func (e *engine) ListSecretsForRepo(r *library.Repo, filters map[string]interfac
 	secrets := []*library.Secret{}
 
 	// count the results
-	count, err := e.CountSecretsForRepo(r, filters)
+	count, err := e.CountSecretsForRepo(ctx, r, filters)
 	if err != nil {
 		return secrets, 0, err
 	}

--- a/database/secret/list_repo_test.go
+++ b/database/secret/list_repo_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -73,12 +74,12 @@ func TestSecret_Engine_ListSecretsForRepo(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateSecret(_secretOne)
+	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateSecret(_secretTwo)
+	_, err = _sqlite.CreateSecret(context.TODO(), _secretTwo)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
@@ -109,7 +110,7 @@ func TestSecret_Engine_ListSecretsForRepo(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, _, err := test.database.ListSecretsForRepo(_repo, filters, 1, 10)
+			got, _, err := test.database.ListSecretsForRepo(context.TODO(), _repo, filters, 1, 10)
 
 			if test.failure {
 				if err == nil {

--- a/database/secret/list_team.go
+++ b/database/secret/list_team.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"strings"
 
 	"github.com/go-vela/types/constants"
@@ -16,7 +17,7 @@ import (
 // ListSecretsForTeam gets a list of secrets by org and team name from the database.
 //
 //nolint:lll // ignore long line length due to variable names
-func (e *engine) ListSecretsForTeam(org, team string, filters map[string]interface{}, page, perPage int) ([]*library.Secret, int64, error) {
+func (e *engine) ListSecretsForTeam(ctx context.Context, org, team string, filters map[string]interface{}, page, perPage int) ([]*library.Secret, int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org":  org,
 		"team": team,
@@ -29,7 +30,7 @@ func (e *engine) ListSecretsForTeam(org, team string, filters map[string]interfa
 	secrets := []*library.Secret{}
 
 	// count the results
-	count, err := e.CountSecretsForTeam(org, team, filters)
+	count, err := e.CountSecretsForTeam(ctx, org, team, filters)
 	if err != nil {
 		return secrets, 0, err
 	}
@@ -86,7 +87,7 @@ func (e *engine) ListSecretsForTeam(org, team string, filters map[string]interfa
 }
 
 // ListSecretsForTeams gets a list of secrets by teams within an org from the database.
-func (e *engine) ListSecretsForTeams(org string, teams []string, filters map[string]interface{}, page, perPage int) ([]*library.Secret, int64, error) {
+func (e *engine) ListSecretsForTeams(ctx context.Context, org string, teams []string, filters map[string]interface{}, page, perPage int) ([]*library.Secret, int64, error) {
 	// iterate through the list of teams provided
 	for index, team := range teams {
 		// ensure the team name is lower case
@@ -105,7 +106,7 @@ func (e *engine) ListSecretsForTeams(org string, teams []string, filters map[str
 	secrets := []*library.Secret{}
 
 	// count the results
-	count, err := e.CountSecretsForTeams(org, teams, filters)
+	count, err := e.CountSecretsForTeams(ctx, org, teams, filters)
 	if err != nil {
 		return secrets, 0, err
 	}

--- a/database/secret/list_team_test.go
+++ b/database/secret/list_team_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -63,12 +64,12 @@ func TestSecret_Engine_ListSecretsForTeam(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateSecret(_secretOne)
+	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateSecret(_secretTwo)
+	_, err = _sqlite.CreateSecret(context.TODO(), _secretTwo)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
@@ -99,7 +100,7 @@ func TestSecret_Engine_ListSecretsForTeam(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, _, err := test.database.ListSecretsForTeam("foo", "bar", filters, 1, 10)
+			got, _, err := test.database.ListSecretsForTeam(context.TODO(), "foo", "bar", filters, 1, 10)
 
 			if test.failure {
 				if err == nil {
@@ -169,12 +170,12 @@ func TestSecret_Engine_ListSecretsForTeams(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateSecret(_secretOne)
+	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateSecret(_secretTwo)
+	_, err = _sqlite.CreateSecret(context.TODO(), _secretTwo)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
@@ -205,7 +206,7 @@ func TestSecret_Engine_ListSecretsForTeams(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, _, err := test.database.ListSecretsForTeams("foo", []string{"foo", "bar"}, filters, 1, 10)
+			got, _, err := test.database.ListSecretsForTeams(context.TODO(), "foo", []string{"foo", "bar"}, filters, 1, 10)
 
 			if test.failure {
 				if err == nil {

--- a/database/secret/list_test.go
+++ b/database/secret/list_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -59,12 +60,12 @@ func TestSecret_Engine_ListSecrets(t *testing.T) {
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateSecret(_secretOne)
+	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateSecret(_secretTwo)
+	_, err = _sqlite.CreateSecret(context.TODO(), _secretTwo)
 	if err != nil {
 		t.Errorf("unable to create test secret for sqlite: %v", err)
 	}
@@ -93,7 +94,7 @@ func TestSecret_Engine_ListSecrets(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.ListSecrets()
+			got, err := test.database.ListSecrets(context.TODO())
 
 			if test.failure {
 				if err == nil {

--- a/database/secret/opts.go
+++ b/database/secret/opts.go
@@ -5,6 +5,8 @@
 package secret
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
 
 	"gorm.io/gorm"
@@ -48,6 +50,15 @@ func WithSkipCreation(skipCreation bool) EngineOpt {
 	return func(e *engine) error {
 		// set to skip creating tables and indexes in the secret engine
 		e.config.SkipCreation = skipCreation
+
+		return nil
+	}
+}
+
+// WithContext sets the context in the database engine for Secrets.
+func WithContext(ctx context.Context) EngineOpt {
+	return func(e *engine) error {
+		e.ctx = ctx
 
 		return nil
 	}

--- a/database/secret/opts_test.go
+++ b/database/secret/opts_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -204,6 +205,55 @@ func TestSecret_EngineOpt_WithSkipCreation(t *testing.T) {
 
 			if !reflect.DeepEqual(e.config.SkipCreation, test.want) {
 				t.Errorf("WithSkipCreation is %v, want %v", e.config.SkipCreation, test.want)
+			}
+		})
+	}
+}
+
+func TestSecret_EngineOpt_WithContext(t *testing.T) {
+	// setup types
+	e := &engine{config: new(config)}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		name    string
+		ctx     context.Context
+		want    context.Context
+	}{
+		{
+			failure: false,
+			name:    "context set to TODO",
+			ctx:     context.TODO(),
+			want:    context.TODO(),
+		},
+		{
+			failure: false,
+			name:    "context set to nil",
+			ctx:     nil,
+			want:    nil,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := WithContext(test.ctx)(e)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithContext for %s should have returned err", test.name)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("WithContext returned err: %v", err)
+			}
+
+			if !reflect.DeepEqual(e.ctx, test.want) {
+				t.Errorf("WithContext is %v, want %v", e.ctx, test.want)
 			}
 		})
 	}

--- a/database/secret/secret.go
+++ b/database/secret/secret.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-vela/types/constants"
@@ -26,6 +27,8 @@ type (
 	engine struct {
 		// engine configuration settings used in secret functions
 		config *config
+
+		ctx context.Context
 
 		// gorm.io/gorm database client used in secret functions
 		//
@@ -67,13 +70,13 @@ func New(opts ...EngineOpt) (*engine, error) {
 	}
 
 	// create the secrets table
-	err := e.CreateSecretTable(e.client.Config.Dialector.Name())
+	err := e.CreateSecretTable(e.ctx, e.client.Config.Dialector.Name())
 	if err != nil {
 		return nil, fmt.Errorf("unable to create %s table: %w", constants.TableSecret, err)
 	}
 
 	// create the indexes for the secrets table
-	err = e.CreateSecretIndexes()
+	err = e.CreateSecretIndexes(e.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create indexes for %s table: %w", constants.TableSecret, err)
 	}

--- a/database/secret/table.go
+++ b/database/secret/table.go
@@ -4,7 +4,11 @@
 
 package secret
 
-import "github.com/go-vela/types/constants"
+import (
+	"context"
+
+	"github.com/go-vela/types/constants"
+)
 
 const (
 	// CreatePostgresTable represents a query to create the Postgres secrets table.
@@ -57,7 +61,7 @@ secrets (
 )
 
 // CreateSecretTable creates the secrets table in the database.
-func (e *engine) CreateSecretTable(driver string) error {
+func (e *engine) CreateSecretTable(ctx context.Context, driver string) error {
 	e.logger.Tracef("creating secrets table in the database")
 
 	// handle the driver provided to create the table

--- a/database/secret/table_test.go
+++ b/database/secret/table_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -41,7 +42,7 @@ func TestSecret_Engine_CreateSecretTable(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.database.CreateSecretTable(test.name)
+			err := test.database.CreateSecretTable(context.TODO(), test.name)
 
 			if test.failure {
 				if err == nil {

--- a/database/secret/update.go
+++ b/database/secret/update.go
@@ -6,6 +6,7 @@
 package secret
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-vela/types/constants"
@@ -15,7 +16,7 @@ import (
 )
 
 // UpdateSecret updates an existing secret in the database.
-func (e *engine) UpdateSecret(s *library.Secret) (*library.Secret, error) {
+func (e *engine) UpdateSecret(ctx context.Context, s *library.Secret) (*library.Secret, error) {
 	// handle the secret based off the type
 	switch s.GetType() {
 	case constants.SecretShared:

--- a/database/secret/update_test.go
+++ b/database/secret/update_test.go
@@ -5,6 +5,7 @@
 package secret
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -77,17 +78,17 @@ WHERE "id" = $14`).
 	_sqlite := testSqlite(t)
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
-	_, err := _sqlite.CreateSecret(_secretRepo)
+	_, err := _sqlite.CreateSecret(context.TODO(), _secretRepo)
 	if err != nil {
 		t.Errorf("unable to create test repo secret for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateSecret(_secretOrg)
+	_, err = _sqlite.CreateSecret(context.TODO(), _secretOrg)
 	if err != nil {
 		t.Errorf("unable to create test org secret for sqlite: %v", err)
 	}
 
-	_, err = _sqlite.CreateSecret(_secretShared)
+	_, err = _sqlite.CreateSecret(context.TODO(), _secretShared)
 	if err != nil {
 		t.Errorf("unable to create test shared secret for sqlite: %v", err)
 	}
@@ -140,7 +141,7 @@ WHERE "id" = $14`).
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.UpdateSecret(test.secret)
+			got, err := test.database.UpdateSecret(context.TODO(), test.secret)
 			got.SetUpdatedAt(test.secret.GetUpdatedAt())
 
 			if test.failure {

--- a/secret/native/count.go
+++ b/secret/native/count.go
@@ -5,6 +5,7 @@
 package native
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-vela/types/constants"
@@ -13,7 +14,7 @@ import (
 )
 
 // Count counts a list of secrets.
-func (c *client) Count(sType, org, name string, teams []string) (int64, error) {
+func (c *client) Count(ctx context.Context, sType, org, name string, teams []string) (int64, error) {
 	// handle the secret based off the type
 	switch sType {
 	case constants.SecretOrg:
@@ -23,7 +24,7 @@ func (c *client) Count(sType, org, name string, teams []string) (int64, error) {
 		}).Tracef("counting native %s secrets for %s", sType, org)
 
 		// capture the count of org secrets from the native service
-		return c.Database.CountSecretsForOrg(org, nil)
+		return c.Database.CountSecretsForOrg(ctx, org, nil)
 	case constants.SecretRepo:
 		c.Logger.WithFields(logrus.Fields{
 			"org":  org,
@@ -38,7 +39,7 @@ func (c *client) Count(sType, org, name string, teams []string) (int64, error) {
 		r.SetFullName(fmt.Sprintf("%s/%s", org, name))
 
 		// capture the count of repo secrets from the native service
-		return c.Database.CountSecretsForRepo(r, nil)
+		return c.Database.CountSecretsForRepo(ctx, r, nil)
 	case constants.SecretShared:
 		// check if we should capture secrets for multiple teams
 		if name == "*" {
@@ -49,7 +50,7 @@ func (c *client) Count(sType, org, name string, teams []string) (int64, error) {
 			}).Tracef("counting native %s secrets for teams %s in org %s", sType, teams, org)
 
 			// capture the count of shared secrets for multiple teams from the native service
-			return c.Database.CountSecretsForTeams(org, teams, nil)
+			return c.Database.CountSecretsForTeams(ctx, org, teams, nil)
 		}
 
 		c.Logger.WithFields(logrus.Fields{
@@ -59,7 +60,7 @@ func (c *client) Count(sType, org, name string, teams []string) (int64, error) {
 		}).Tracef("counting native %s secrets for %s/%s", sType, org, name)
 
 		// capture the count of shared secrets from the native service
-		return c.Database.CountSecretsForTeam(org, name, nil)
+		return c.Database.CountSecretsForTeam(ctx, org, name, nil)
 	default:
 		return 0, fmt.Errorf("invalid secret type: %s", sType)
 	}

--- a/secret/native/count_test.go
+++ b/secret/native/count_test.go
@@ -5,6 +5,7 @@
 package native
 
 import (
+	"context"
 	"testing"
 
 	"github.com/go-vela/server/database"
@@ -34,11 +35,11 @@ func TestNative_Count(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteSecret(sec)
+		db.DeleteSecret(context.TODO(), sec)
 		db.Close()
 	}()
 
-	_, _ = db.CreateSecret(sec)
+	_, _ = db.CreateSecret(context.TODO(), sec)
 
 	// run test
 	s, err := New(
@@ -48,7 +49,7 @@ func TestNative_Count(t *testing.T) {
 		t.Errorf("New returned err: %v", err)
 	}
 
-	got, err := s.Count("repo", "foo", "bar", []string{})
+	got, err := s.Count(context.TODO(), "repo", "foo", "bar", []string{})
 	if err != nil {
 		t.Errorf("Count returned err: %v", err)
 	}
@@ -74,7 +75,7 @@ func TestNative_Count_Empty(t *testing.T) {
 		t.Errorf("New returned err: %v", err)
 	}
 
-	got, err := s.Count("repo", "foo", "bar", []string{})
+	got, err := s.Count(context.TODO(), "repo", "foo", "bar", []string{})
 	if err != nil {
 		t.Errorf("Count returned err: %v", err)
 	}

--- a/secret/native/create.go
+++ b/secret/native/create.go
@@ -5,6 +5,7 @@
 package native
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-vela/types/constants"
@@ -13,7 +14,7 @@ import (
 )
 
 // Create creates a new secret.
-func (c *client) Create(sType, org, name string, s *library.Secret) (*library.Secret, error) {
+func (c *client) Create(ctx context.Context, sType, org, name string, s *library.Secret) (*library.Secret, error) {
 	// handle the secret based off the type
 	switch sType {
 	case constants.SecretOrg:
@@ -24,7 +25,7 @@ func (c *client) Create(sType, org, name string, s *library.Secret) (*library.Se
 		}).Tracef("creating native %s secret %s for %s", sType, s.GetName(), org)
 
 		// create the org secret in the native service
-		return c.Database.CreateSecret(s)
+		return c.Database.CreateSecret(ctx, s)
 	case constants.SecretRepo:
 		c.Logger.WithFields(logrus.Fields{
 			"org":    org,
@@ -34,7 +35,7 @@ func (c *client) Create(sType, org, name string, s *library.Secret) (*library.Se
 		}).Tracef("creating native %s secret %s for %s/%s", sType, s.GetName(), org, name)
 
 		// create the repo secret in the native service
-		return c.Database.CreateSecret(s)
+		return c.Database.CreateSecret(ctx, s)
 	case constants.SecretShared:
 		c.Logger.WithFields(logrus.Fields{
 			"org":    org,
@@ -44,7 +45,7 @@ func (c *client) Create(sType, org, name string, s *library.Secret) (*library.Se
 		}).Tracef("creating native %s secret %s for %s/%s", sType, s.GetName(), org, name)
 
 		// create the shared secret in the native service
-		return c.Database.CreateSecret(s)
+		return c.Database.CreateSecret(ctx, s)
 	default:
 		return nil, fmt.Errorf("invalid secret type: %s", sType)
 	}

--- a/secret/native/create_test.go
+++ b/secret/native/create_test.go
@@ -5,6 +5,7 @@
 package native
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -37,7 +38,7 @@ func TestNative_Create_Org(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteSecret(want)
+		db.DeleteSecret(context.TODO(), want)
 		db.Close()
 	}()
 
@@ -49,7 +50,7 @@ func TestNative_Create_Org(t *testing.T) {
 		t.Errorf("New returned err: %v", err)
 	}
 
-	got, err := s.Create("org", "foo", "*", want)
+	got, err := s.Create(context.TODO(), "org", "foo", "*", want)
 	if err != nil {
 		t.Errorf("Create returned err: %v", err)
 	}
@@ -84,7 +85,7 @@ func TestNative_Create_Repo(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteSecret(want)
+		db.DeleteSecret(context.TODO(), want)
 		db.Close()
 	}()
 
@@ -96,7 +97,7 @@ func TestNative_Create_Repo(t *testing.T) {
 		t.Errorf("New returned err: %v", err)
 	}
 
-	got, err := s.Create("repo", "foo", "bar", want)
+	got, err := s.Create(context.TODO(), "repo", "foo", "bar", want)
 	if err != nil {
 		t.Errorf("Create returned err: %v", err)
 	}
@@ -131,7 +132,7 @@ func TestNative_Create_Shared(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteSecret(want)
+		db.DeleteSecret(context.TODO(), want)
 		db.Close()
 	}()
 
@@ -143,7 +144,7 @@ func TestNative_Create_Shared(t *testing.T) {
 		t.Errorf("New returned err: %v", err)
 	}
 
-	got, err := s.Create("shared", "foo", "bar", want)
+	got, err := s.Create(context.TODO(), "shared", "foo", "bar", want)
 	if err != nil {
 		t.Errorf("Create returned err: %v", err)
 	}
@@ -178,7 +179,7 @@ func TestNative_Create_Invalid(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteSecret(sec)
+		db.DeleteSecret(context.TODO(), sec)
 		db.Close()
 	}()
 
@@ -190,7 +191,7 @@ func TestNative_Create_Invalid(t *testing.T) {
 		t.Errorf("New returned err: %v", err)
 	}
 
-	_, err = s.Create("invalid", "foo", "bar", sec)
+	_, err = s.Create(context.TODO(), "invalid", "foo", "bar", sec)
 	if err == nil {
 		t.Errorf("Create should have returned err")
 	}

--- a/secret/native/delete.go
+++ b/secret/native/delete.go
@@ -5,6 +5,7 @@
 package native
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-vela/types/constants"
@@ -12,9 +13,9 @@ import (
 )
 
 // Delete deletes a secret.
-func (c *client) Delete(sType, org, name, path string) error {
+func (c *client) Delete(ctx context.Context, sType, org, name, path string) error {
 	// capture the secret from the native service
-	s, err := c.Get(sType, org, name, path)
+	s, err := c.Get(ctx, sType, org, name, path)
 	if err != nil {
 		return err
 	}
@@ -29,7 +30,7 @@ func (c *client) Delete(sType, org, name, path string) error {
 		}).Tracef("deleting native %s secret %s for %s", sType, path, org)
 
 		// delete the org secret from the native service
-		return c.Database.DeleteSecret(s)
+		return c.Database.DeleteSecret(ctx, s)
 	case constants.SecretRepo:
 		c.Logger.WithFields(logrus.Fields{
 			"org":    org,
@@ -39,7 +40,7 @@ func (c *client) Delete(sType, org, name, path string) error {
 		}).Tracef("deleting native %s secret %s for %s/%s", sType, path, org, name)
 
 		// delete the repo secret from the native service
-		return c.Database.DeleteSecret(s)
+		return c.Database.DeleteSecret(ctx, s)
 	case constants.SecretShared:
 		c.Logger.WithFields(logrus.Fields{
 			"org":    org,
@@ -49,7 +50,7 @@ func (c *client) Delete(sType, org, name, path string) error {
 		}).Tracef("deleting native %s secret %s for %s/%s", sType, path, org, name)
 
 		// delete the shared secret from the native service
-		return c.Database.DeleteSecret(s)
+		return c.Database.DeleteSecret(ctx, s)
 	default:
 		return fmt.Errorf("invalid secret type: %s", sType)
 	}

--- a/secret/native/delete_test.go
+++ b/secret/native/delete_test.go
@@ -5,6 +5,7 @@
 package native
 
 import (
+	"context"
 	"testing"
 
 	"github.com/go-vela/server/database"
@@ -34,11 +35,11 @@ func TestNative_Delete(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteSecret(sec)
+		db.DeleteSecret(context.TODO(), sec)
 		db.Close()
 	}()
 
-	_, _ = db.CreateSecret(sec)
+	_, _ = db.CreateSecret(context.TODO(), sec)
 
 	// run test
 	s, err := New(
@@ -48,7 +49,7 @@ func TestNative_Delete(t *testing.T) {
 		t.Errorf("New returned err: %v", err)
 	}
 
-	err = s.Delete("repo", "foo", "bar", "baz")
+	err = s.Delete(context.TODO(), "repo", "foo", "bar", "baz")
 	if err != nil {
 		t.Errorf("Delete returned err: %v", err)
 	}
@@ -70,7 +71,7 @@ func TestNative_Delete_Invalid(t *testing.T) {
 		t.Errorf("New returned err: %v", err)
 	}
 
-	err = s.Delete("repo", "foo", "bar", "foob")
+	err = s.Delete(context.TODO(), "repo", "foo", "bar", "foob")
 	if err == nil {
 		t.Errorf("Delete should have returned err")
 	}

--- a/secret/native/get.go
+++ b/secret/native/get.go
@@ -5,6 +5,7 @@
 package native
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-vela/types/constants"
@@ -13,7 +14,7 @@ import (
 )
 
 // Get captures a secret.
-func (c *client) Get(sType, org, name, path string) (*library.Secret, error) {
+func (c *client) Get(ctx context.Context, sType, org, name, path string) (*library.Secret, error) {
 	// handle the secret based off the type
 	switch sType {
 	case constants.SecretOrg:
@@ -24,7 +25,7 @@ func (c *client) Get(sType, org, name, path string) (*library.Secret, error) {
 		}).Tracef("getting native %s secret %s for %s", sType, path, org)
 
 		// capture the org secret from the native service
-		return c.Database.GetSecretForOrg(org, path)
+		return c.Database.GetSecretForOrg(ctx, org, path)
 	case constants.SecretRepo:
 		c.Logger.WithFields(logrus.Fields{
 			"org":    org,
@@ -40,7 +41,7 @@ func (c *client) Get(sType, org, name, path string) (*library.Secret, error) {
 		r.SetFullName(fmt.Sprintf("%s/%s", org, name))
 
 		// capture the repo secret from the native service
-		return c.Database.GetSecretForRepo(path, r)
+		return c.Database.GetSecretForRepo(ctx, path, r)
 	case constants.SecretShared:
 		c.Logger.WithFields(logrus.Fields{
 			"org":    org,
@@ -50,7 +51,7 @@ func (c *client) Get(sType, org, name, path string) (*library.Secret, error) {
 		}).Tracef("getting native %s secret %s for %s/%s", sType, path, org, name)
 
 		// capture the shared secret from the native service
-		return c.Database.GetSecretForTeam(org, name, path)
+		return c.Database.GetSecretForTeam(ctx, org, name, path)
 	default:
 		return nil, fmt.Errorf("invalid secret type: %s", sType)
 	}

--- a/secret/native/get_test.go
+++ b/secret/native/get_test.go
@@ -5,6 +5,7 @@
 package native
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -38,7 +39,7 @@ func TestNative_Get(t *testing.T) {
 	defer db.Close()
 
 	defer func() {
-		db.DeleteSecret(want)
+		db.DeleteSecret(context.TODO(), want)
 		db.Close()
 	}()
 
@@ -50,9 +51,9 @@ func TestNative_Get(t *testing.T) {
 		t.Errorf("New returned err: %v", err)
 	}
 
-	_, _ = s.Create("repo", "foo", "bar", want)
+	_, _ = s.Create(context.TODO(), "repo", "foo", "bar", want)
 
-	got, err := s.Get("repo", "foo", "bar", "baz")
+	got, err := s.Get(context.TODO(), "repo", "foo", "bar", "baz")
 	if err != nil {
 		t.Errorf("Get returned err: %v", err)
 	}
@@ -78,7 +79,7 @@ func TestNative_Get_Invalid(t *testing.T) {
 		t.Errorf("New returned err: %v", err)
 	}
 
-	got, err := s.Get("repo", "foo", "bar", "foob")
+	got, err := s.Get(context.TODO(), "repo", "foo", "bar", "foob")
 	if err == nil {
 		t.Errorf("Get should have returned err")
 	}

--- a/secret/native/list.go
+++ b/secret/native/list.go
@@ -5,6 +5,7 @@
 package native
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-vela/types/constants"
@@ -13,7 +14,7 @@ import (
 )
 
 // List captures a list of secrets.
-func (c *client) List(sType, org, name string, page, perPage int, teams []string) ([]*library.Secret, error) {
+func (c *client) List(ctx context.Context, sType, org, name string, page, perPage int, teams []string) ([]*library.Secret, error) {
 	// handle the secret based off the type
 	switch sType {
 	case constants.SecretOrg:
@@ -23,7 +24,7 @@ func (c *client) List(sType, org, name string, page, perPage int, teams []string
 		}).Tracef("listing native %s secrets for %s", sType, org)
 
 		// capture the list of org secrets from the native service
-		secrets, _, err := c.Database.ListSecretsForOrg(org, nil, page, perPage)
+		secrets, _, err := c.Database.ListSecretsForOrg(ctx, org, nil, page, perPage)
 		if err != nil {
 			return nil, err
 		}
@@ -43,7 +44,7 @@ func (c *client) List(sType, org, name string, page, perPage int, teams []string
 		r.SetFullName(fmt.Sprintf("%s/%s", org, name))
 
 		// capture the list of repo secrets from the native service
-		secrets, _, err := c.Database.ListSecretsForRepo(r, nil, page, perPage)
+		secrets, _, err := c.Database.ListSecretsForRepo(ctx, r, nil, page, perPage)
 		if err != nil {
 			return nil, err
 		}
@@ -59,7 +60,7 @@ func (c *client) List(sType, org, name string, page, perPage int, teams []string
 			}).Tracef("listing native %s secrets for teams %s in org %s", sType, teams, org)
 
 			// capture the list of shared secrets for multiple teams from the native service
-			secrets, _, err := c.Database.ListSecretsForTeams(org, teams, nil, page, perPage)
+			secrets, _, err := c.Database.ListSecretsForTeams(ctx, org, teams, nil, page, perPage)
 			if err != nil {
 				return nil, err
 			}
@@ -74,7 +75,7 @@ func (c *client) List(sType, org, name string, page, perPage int, teams []string
 		}).Tracef("listing native %s secrets for %s/%s", sType, org, name)
 
 		// capture the list of shared secrets from the native service
-		secrets, _, err := c.Database.ListSecretsForTeam(org, name, nil, page, perPage)
+		secrets, _, err := c.Database.ListSecretsForTeam(ctx, org, name, nil, page, perPage)
 		if err != nil {
 			return nil, err
 		}

--- a/secret/native/list_test.go
+++ b/secret/native/list_test.go
@@ -5,6 +5,7 @@
 package native
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -55,8 +56,8 @@ func TestNative_List(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteSecret(sOne)
-		db.DeleteSecret(sTwo)
+		db.DeleteSecret(context.TODO(), sOne)
+		db.DeleteSecret(context.TODO(), sTwo)
 		db.Close()
 	}()
 
@@ -68,11 +69,11 @@ func TestNative_List(t *testing.T) {
 		t.Errorf("New returned err: %v", err)
 	}
 
-	_, _ = s.Create("repo", "foo", "bar", sOne)
+	_, _ = s.Create(context.TODO(), "repo", "foo", "bar", sOne)
 
-	_, _ = s.Create("repo", "foo", "bar", sTwo)
+	_, _ = s.Create(context.TODO(), "repo", "foo", "bar", sTwo)
 
-	got, err := s.List("repo", "foo", "bar", 1, 10, []string{})
+	got, err := s.List(context.TODO(), "repo", "foo", "bar", 1, 10, []string{})
 	if err != nil {
 		t.Errorf("List returned err: %v", err)
 	}
@@ -98,7 +99,7 @@ func TestNative_List_Empty(t *testing.T) {
 		t.Errorf("New returned err: %v", err)
 	}
 
-	got, err := s.List("repo", "foo", "bar", 1, 10, []string{})
+	got, err := s.List(context.TODO(), "repo", "foo", "bar", 1, 10, []string{})
 	if err != nil {
 		t.Errorf("List returned err: %v", err)
 	}

--- a/secret/native/update.go
+++ b/secret/native/update.go
@@ -5,6 +5,7 @@
 package native
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-vela/types/constants"
@@ -13,9 +14,9 @@ import (
 )
 
 // Update updates an existing secret.
-func (c *client) Update(sType, org, name string, s *library.Secret) (*library.Secret, error) {
+func (c *client) Update(ctx context.Context, sType, org, name string, s *library.Secret) (*library.Secret, error) {
 	// capture the secret from the native service
-	secret, err := c.Get(sType, org, name, s.GetName())
+	secret, err := c.Get(ctx, sType, org, name, s.GetName())
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +57,7 @@ func (c *client) Update(sType, org, name string, s *library.Secret) (*library.Se
 		}).Tracef("updating native %s secret %s for %s", sType, s.GetName(), org)
 
 		// update the org secret in the native service
-		return c.Database.UpdateSecret(secret)
+		return c.Database.UpdateSecret(ctx, secret)
 	case constants.SecretRepo:
 		c.Logger.WithFields(logrus.Fields{
 			"org":    org,
@@ -66,7 +67,7 @@ func (c *client) Update(sType, org, name string, s *library.Secret) (*library.Se
 		}).Tracef("updating native %s secret %s for %s/%s", sType, s.GetName(), org, name)
 
 		// update the repo secret in the native service
-		return c.Database.UpdateSecret(secret)
+		return c.Database.UpdateSecret(ctx, secret)
 	case constants.SecretShared:
 		c.Logger.WithFields(logrus.Fields{
 			"org":    org,
@@ -76,7 +77,7 @@ func (c *client) Update(sType, org, name string, s *library.Secret) (*library.Se
 		}).Tracef("updating native %s secret %s for %s/%s", sType, s.GetName(), org, name)
 
 		// update the shared secret in the native service
-		return c.Database.UpdateSecret(secret)
+		return c.Database.UpdateSecret(ctx, secret)
 	default:
 		return nil, fmt.Errorf("invalid secret type: %s", sType)
 	}

--- a/secret/native/update_test.go
+++ b/secret/native/update_test.go
@@ -5,6 +5,7 @@
 package native
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -54,11 +55,11 @@ func TestNative_Update(t *testing.T) {
 	}
 
 	defer func() {
-		db.DeleteSecret(original)
+		db.DeleteSecret(context.TODO(), original)
 		db.Close()
 	}()
 
-	_, _ = db.CreateSecret(original)
+	_, _ = db.CreateSecret(context.TODO(), original)
 
 	// run test
 	s, err := New(
@@ -68,7 +69,7 @@ func TestNative_Update(t *testing.T) {
 		t.Errorf("New returned err: %v", err)
 	}
 
-	got, err := s.Update("repo", "foo", "bar", want)
+	got, err := s.Update(context.TODO(), "repo", "foo", "bar", want)
 	if err != nil {
 		t.Errorf("Update returned err: %v", err)
 	}
@@ -99,7 +100,7 @@ func TestNative_Update_Invalid(t *testing.T) {
 		t.Errorf("New returned err: %v", err)
 	}
 
-	_, err = s.Update("repo", "foo", "bar", sec)
+	_, err = s.Update(context.TODO(), "repo", "foo", "bar", sec)
 	if err == nil {
 		t.Errorf("Update should have returned err")
 	}

--- a/secret/service.go
+++ b/secret/service.go
@@ -4,7 +4,11 @@
 
 package secret
 
-import "github.com/go-vela/types/library"
+import (
+	"context"
+
+	"github.com/go-vela/types/library"
+)
 
 // Service represents the interface for Vela integrating
 // with the different supported secret providers.
@@ -16,17 +20,17 @@ type Service interface {
 	Driver() string
 
 	// Get defines a function that captures a secret.
-	Get(string, string, string, string) (*library.Secret, error)
+	Get(context.Context, string, string, string, string) (*library.Secret, error)
 	// List defines a function that captures a list of secrets.
-	List(string, string, string, int, int, []string) ([]*library.Secret, error)
+	List(context.Context, string, string, string, int, int, []string) ([]*library.Secret, error)
 	// Count defines a function that counts a list of secrets.
-	Count(string, string, string, []string) (int64, error)
+	Count(context.Context, string, string, string, []string) (int64, error)
 	// Create defines a function that creates a new secret.
-	Create(string, string, string, *library.Secret) (*library.Secret, error)
+	Create(context.Context, string, string, string, *library.Secret) (*library.Secret, error)
 	// Update defines a function that updates an existing secret.
-	Update(string, string, string, *library.Secret) (*library.Secret, error)
+	Update(context.Context, string, string, string, *library.Secret) (*library.Secret, error)
 	// Delete defines a function that deletes a secret.
-	Delete(string, string, string, string) error
+	Delete(context.Context, string, string, string, string) error
 
 	// TODO: Add convert functions to interface?
 }

--- a/secret/vault/count.go
+++ b/secret/vault/count.go
@@ -5,6 +5,7 @@
 package vault
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -15,7 +16,7 @@ import (
 )
 
 // Count counts a list of secrets.
-func (c *client) Count(sType, org, name string, _ []string) (i int64, err error) {
+func (c *client) Count(ctx context.Context, sType, org, name string, _ []string) (i int64, err error) {
 	// create log fields from secret metadata
 	fields := logrus.Fields{
 		"org":  org,

--- a/secret/vault/count_test.go
+++ b/secret/vault/count_test.go
@@ -5,6 +5,7 @@
 package vault
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -88,7 +89,7 @@ func TestVault_Count_Org(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			got, err := s.Count("org", "foo", "*", []string{})
+			got, err := s.Count(context.TODO(), "org", "foo", "*", []string{})
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Count returned %v, want %v", resp.Code, http.StatusOK)
@@ -181,7 +182,7 @@ func TestVault_Count_Repo(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			got, err := s.Count("repo", "foo", "bar", []string{})
+			got, err := s.Count(context.TODO(), "repo", "foo", "bar", []string{})
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Count returned %v, want %v", resp.Code, http.StatusOK)
@@ -274,7 +275,7 @@ func TestVault_Count_Shared(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			got, err := s.Count("shared", "foo", "bar", []string{})
+			got, err := s.Count(context.TODO(), "shared", "foo", "bar", []string{})
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("List returned %v, want %v", resp.Code, http.StatusOK)
@@ -325,7 +326,7 @@ func TestVault_Count_InvalidType(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			got, err := s.Count("invalid", "foo", "bar", []string{})
+			got, err := s.Count(context.TODO(), "invalid", "foo", "bar", []string{})
 			if err == nil {
 				t.Errorf("Count should have returned err")
 			}
@@ -371,7 +372,7 @@ func TestVault_Count_ClosedServer(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			got, err := s.Count("repo", "foo", "bar", []string{})
+			got, err := s.Count(context.TODO(), "repo", "foo", "bar", []string{})
 			if err == nil {
 				t.Errorf("Count should have returned err")
 			}
@@ -441,7 +442,7 @@ func TestVault_Count_EmptyList(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			got, err := s.Count("repo", "foo", "bar", []string{})
+			got, err := s.Count(context.TODO(), "repo", "foo", "bar", []string{})
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Count returned %v, want %v", resp.Code, http.StatusOK)
@@ -516,7 +517,7 @@ func TestVault_Count_InvalidList(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			got, err := s.Count("repo", "foo", "bar", []string{})
+			got, err := s.Count(context.TODO(), "repo", "foo", "bar", []string{})
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Count returned %v, want %v", resp.Code, http.StatusOK)

--- a/secret/vault/create.go
+++ b/secret/vault/create.go
@@ -5,6 +5,7 @@
 package vault
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -16,7 +17,7 @@ import (
 )
 
 // Create creates a new secret.
-func (c *client) Create(sType, org, name string, s *library.Secret) (*library.Secret, error) {
+func (c *client) Create(ctx context.Context, sType, org, name string, s *library.Secret) (*library.Secret, error) {
 	// create log fields from secret metadata
 	fields := logrus.Fields{
 		"org":    org,

--- a/secret/vault/create_test.go
+++ b/secret/vault/create_test.go
@@ -5,6 +5,7 @@
 package vault
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -82,7 +83,7 @@ func TestVault_Create_Org(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
-			got, err := s.Create("org", "foo", "*", sec)
+			got, err := s.Create(context.TODO(), "org", "foo", "*", sec)
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Create returned %v, want %v", resp.Code, http.StatusOK)
@@ -167,7 +168,7 @@ func TestVault_Create_Repo(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			got, err := s.Create("repo", "foo", "bar", sec)
+			got, err := s.Create(context.TODO(), "repo", "foo", "bar", sec)
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Create returned %v, want %v", resp.Code, http.StatusOK)
@@ -252,7 +253,7 @@ func TestVault_Create_Shared(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			got, err := s.Create("shared", "foo", "bar", sec)
+			got, err := s.Create(context.TODO(), "shared", "foo", "bar", sec)
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Create returned %v, want %v", resp.Code, http.StatusOK)
@@ -333,7 +334,7 @@ func TestVault_Create_InvalidSecret(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			_, err = s.Create("repo", "foo", "bar", sec)
+			_, err = s.Create(context.TODO(), "repo", "foo", "bar", sec)
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Create returned %v, want %v", resp.Code, http.StatusOK)
@@ -392,7 +393,7 @@ func TestVault_Create_InvalidType(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			_, err = s.Create("invalid", "foo", "bar", sec)
+			_, err = s.Create(context.TODO(), "invalid", "foo", "bar", sec)
 			if err == nil {
 				t.Errorf("Create should have returned err")
 			}
@@ -446,7 +447,7 @@ func TestVault_Create_ClosedServer(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			_, err = s.Create("repo", "foo", "bar", sec)
+			_, err = s.Create(context.TODO(), "repo", "foo", "bar", sec)
 			if err == nil {
 				t.Errorf("Create should have returned err")
 			}

--- a/secret/vault/delete.go
+++ b/secret/vault/delete.go
@@ -5,6 +5,7 @@
 package vault
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -14,7 +15,7 @@ import (
 )
 
 // Delete deletes a secret.
-func (c *client) Delete(sType, org, name, path string) error {
+func (c *client) Delete(ctx context.Context, sType, org, name, path string) error {
 	// create log fields from secret metadata
 	fields := logrus.Fields{
 		"org":    org,

--- a/secret/vault/delete_test.go
+++ b/secret/vault/delete_test.go
@@ -5,6 +5,7 @@
 package vault
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -65,7 +66,7 @@ func TestVault_Delete_Org(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			err = s.Delete("org", "foo", "bar", "foob")
+			err = s.Delete(context.TODO(), "org", "foo", "bar", "foob")
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Delete returned %v, want %v", resp.Code, http.StatusOK)
@@ -130,7 +131,7 @@ func TestVault_Delete_Repo(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			err = s.Delete("repo", "foo", "bar", "foob")
+			err = s.Delete(context.TODO(), "repo", "foo", "bar", "foob")
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Delete returned %v, want %v", resp.Code, http.StatusOK)
@@ -195,7 +196,7 @@ func TestVault_Delete_Shared(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			err = s.Delete("shared", "foo", "bar", "foob")
+			err = s.Delete(context.TODO(), "shared", "foo", "bar", "foob")
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Delete returned %v, want %v", resp.Code, http.StatusOK)
@@ -242,7 +243,7 @@ func TestVault_Delete_InvalidType(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			err = s.Delete("invalid", "foo", "bar", "foob")
+			err = s.Delete(context.TODO(), "invalid", "foo", "bar", "foob")
 			if err == nil {
 				t.Errorf("Delete should have returned err")
 			}
@@ -284,7 +285,7 @@ func TestVault_Delete_ClosedServer(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			err = s.Delete("repo", "foo", "bar", "foob")
+			err = s.Delete(context.TODO(), "repo", "foo", "bar", "foob")
 			if err == nil {
 				t.Errorf("Delete should have returned err")
 			}

--- a/secret/vault/get.go
+++ b/secret/vault/get.go
@@ -5,6 +5,7 @@
 package vault
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -16,7 +17,7 @@ import (
 )
 
 // Get captures a secret.
-func (c *client) Get(sType, org, name, path string) (s *library.Secret, err error) {
+func (c *client) Get(ctx context.Context, sType, org, name, path string) (s *library.Secret, err error) {
 	// create log fields from secret metadata
 	fields := logrus.Fields{
 		"org":    org,

--- a/secret/vault/get_test.go
+++ b/secret/vault/get_test.go
@@ -5,6 +5,7 @@
 package vault
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -82,7 +83,7 @@ func TestVault_Get_Org(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
-			got, err := s.Get("org", "foo", "bar", "baz")
+			got, err := s.Get(context.TODO(), "org", "foo", "bar", "baz")
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Get returned %v, want %v", resp.Code, http.StatusOK)
@@ -166,7 +167,7 @@ func TestVault_Get_Repo(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
-			got, err := s.Get("repo", "foo", "bar", "baz")
+			got, err := s.Get(context.TODO(), "repo", "foo", "bar", "baz")
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Get returned %v, want %v", resp.Code, http.StatusOK)
@@ -250,7 +251,7 @@ func TestVault_Get_Shared(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
-			got, err := s.Get("shared", "foo", "bar", "baz")
+			got, err := s.Get(context.TODO(), "shared", "foo", "bar", "baz")
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Get returned %v, want %v", resp.Code, http.StatusOK)
@@ -300,7 +301,7 @@ func TestVault_Get_InvalidType(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
-			got, err := s.Get("invalid", "foo", "bar", "foob")
+			got, err := s.Get(context.TODO(), "invalid", "foo", "bar", "foob")
 			if err == nil {
 				t.Errorf("Get should have returned err")
 			}
@@ -345,7 +346,7 @@ func TestVault_Get_ClosedServer(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
-			got, err := s.Get("repo", "foo", "bar", "foob")
+			got, err := s.Get(context.TODO(), "repo", "foo", "bar", "foob")
 			if err == nil {
 				t.Errorf("Get should have returned err")
 			}

--- a/secret/vault/list.go
+++ b/secret/vault/list.go
@@ -5,6 +5,7 @@
 package vault
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -20,7 +21,7 @@ import (
 // We drop page and perPage as we are always returning all results.
 // Vault API doesn't seem to support pagination. Might result in undesired
 // behavior for fetching Vault secrets in paginated manner.
-func (c *client) List(sType, org, name string, _, _ int, _ []string) ([]*library.Secret, error) {
+func (c *client) List(ctx context.Context, sType, org, name string, _, _ int, _ []string) ([]*library.Secret, error) {
 	// create log fields from secret metadata
 	fields := logrus.Fields{
 		"org":  org,
@@ -77,7 +78,7 @@ func (c *client) List(sType, org, name string, _, _ int, _ []string) ([]*library
 		}
 
 		// capture the secret from the Vault service
-		sec, err := c.Get(sType, org, name, key)
+		sec, err := c.Get(ctx, sType, org, name, key)
 		if err != nil {
 			return nil, err
 		}

--- a/secret/vault/list_test.go
+++ b/secret/vault/list_test.go
@@ -5,6 +5,7 @@
 package vault
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -99,7 +100,7 @@ func TestVault_List_Org(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
-			got, err := s.List("org", "foo", "*", 1, 10, []string{})
+			got, err := s.List(context.TODO(), "org", "foo", "*", 1, 10, []string{})
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("List returned %v, want %v", resp.Code, http.StatusOK)
@@ -230,7 +231,7 @@ func TestVault_List_Repo(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
-			got, err := s.List("repo", "foo", "bar", 1, 10, []string{})
+			got, err := s.List(context.TODO(), "repo", "foo", "bar", 1, 10, []string{})
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("List returned %v, want %v", resp.Code, http.StatusOK)
@@ -346,7 +347,7 @@ func TestVault_List_Shared(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
-			got, err := s.List("shared", "foo", "bar", 1, 10, []string{})
+			got, err := s.List(context.TODO(), "shared", "foo", "bar", 1, 10, []string{})
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("List returned %v, want %v", resp.Code, http.StatusOK)
@@ -397,7 +398,7 @@ func TestVault_List_InvalidType(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			got, err := s.List("invalid", "foo", "bar", 1, 10, []string{})
+			got, err := s.List(context.TODO(), "invalid", "foo", "bar", 1, 10, []string{})
 			if err == nil {
 				t.Errorf("List should have returned err")
 			}
@@ -428,7 +429,7 @@ func TestVault_List_ClosedServer(t *testing.T) {
 		t.Errorf("New returned err: %v", err)
 	}
 
-	got, err := s.List("repo", "foo", "bar", 1, 10, []string{})
+	got, err := s.List(context.TODO(), "repo", "foo", "bar", 1, 10, []string{})
 	if err == nil {
 		t.Errorf("List should have returned err")
 	}
@@ -496,7 +497,7 @@ func TestVault_List_EmptyList(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			got, err := s.List("repo", "foo", "bar", 1, 10, []string{})
+			got, err := s.List(context.TODO(), "repo", "foo", "bar", 1, 10, []string{})
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("List returned %v, want %v", resp.Code, http.StatusOK)
@@ -571,7 +572,7 @@ func TestVault_List_InvalidList(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			got, err := s.List("repo", "foo", "bar", 1, 10, []string{})
+			got, err := s.List(context.TODO(), "repo", "foo", "bar", 1, 10, []string{})
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("List returned %v, want %v", resp.Code, http.StatusOK)
@@ -655,7 +656,7 @@ func TestVault_List_NoRead(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			got, err := s.List("repo", "foo", "bar", 1, 10, []string{})
+			got, err := s.List(context.TODO(), "repo", "foo", "bar", 1, 10, []string{})
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("List returned %v, want %v", resp.Code, http.StatusOK)

--- a/secret/vault/update.go
+++ b/secret/vault/update.go
@@ -5,6 +5,7 @@
 package vault
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -16,7 +17,7 @@ import (
 )
 
 // Update updates a secret.
-func (c *client) Update(sType, org, name string, s *library.Secret) (*library.Secret, error) {
+func (c *client) Update(ctx context.Context, sType, org, name string, s *library.Secret) (*library.Secret, error) {
 	// create log fields from secret metadata
 	fields := logrus.Fields{
 		"org":    org,
@@ -39,7 +40,7 @@ func (c *client) Update(sType, org, name string, s *library.Secret) (*library.Se
 	c.Logger.WithFields(fields).Tracef("updating vault %s secret %s for %s/%s", sType, s.GetName(), org, name)
 
 	// capture the secret from the Vault service
-	sec, err := c.Get(sType, org, name, s.GetName())
+	sec, err := c.Get(ctx, sType, org, name, s.GetName())
 	if err != nil {
 		return nil, err
 	}

--- a/secret/vault/update_test.go
+++ b/secret/vault/update_test.go
@@ -5,6 +5,7 @@
 package vault
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -98,7 +99,7 @@ func TestVault_Update_Org(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			got, err := s.Update("org", "foo", "*", sec)
+			got, err := s.Update(context.TODO(), "org", "foo", "*", sec)
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Update returned %v, want %v", resp.Code, http.StatusOK)
@@ -198,7 +199,7 @@ func TestVault_Update_Repo(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			got, err := s.Update("repo", "foo", "bar", sec)
+			got, err := s.Update(context.TODO(), "repo", "foo", "bar", sec)
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Update returned %v, want %v", resp.Code, http.StatusOK)
@@ -298,7 +299,7 @@ func TestVault_Update_Shared(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			got, err := s.Update("shared", "foo", "bar", sec)
+			got, err := s.Update(context.TODO(), "shared", "foo", "bar", sec)
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Update returned %v, want %v", resp.Code, http.StatusOK)
@@ -384,7 +385,7 @@ func TestVault_Update_InvalidSecret(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			_, err = s.Update("repo", "foo", "bar", sec)
+			_, err = s.Update(context.TODO(), "repo", "foo", "bar", sec)
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Update returned %v, want %v", resp.Code, http.StatusOK)
@@ -441,7 +442,7 @@ func TestVault_Update_InvalidType(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			_, err = s.Update("invalid", "foo", "bar", sec)
+			_, err = s.Update(context.TODO(), "invalid", "foo", "bar", sec)
 			if err == nil {
 				t.Errorf("Update should have returned err")
 			}
@@ -493,7 +494,7 @@ func TestVault_Update_ClosedServer(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			_, err = s.Update("repo", "foo", "bar", sec)
+			_, err = s.Update(context.TODO(), "repo", "foo", "bar", sec)
 			if err == nil {
 				t.Errorf("Update should have returned err")
 			}
@@ -563,7 +564,7 @@ func TestVault_Update_NoWrite(t *testing.T) {
 				t.Errorf("New returned err: %v", err)
 			}
 
-			_, err = s.Update("repo", "foo", "bar", sec)
+			_, err = s.Update(context.TODO(), "repo", "foo", "bar", sec)
 
 			if resp.Code != http.StatusOK {
 				t.Errorf("Update returned %v, want %v", resp.Code, http.StatusOK)


### PR DESCRIPTION
continuing the efforts started in #898 #922 #923 #930 #937 #938 #941 #942 #950

this is prep to add support for OpenTelemetry tracing.

the reason being, otel can (for the most part) work out of the box if you pass around contexts properly.