### PR TITLE
fix(webhook): repo transfer handling with renaming - support newer GitHub versions

### DIFF
--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -779,7 +779,7 @@ func renameRepository(ctx context.Context, h *library.Hook, r *library.Repo, c *
 	logrus.Infof("renaming repository from %s to %s", r.GetPreviousName(), r.GetName())
 
 	// get any matching hook with the repo's unique webhook ID in the SCM
-	hook, err := database.FromContext(c).GetHookByWebhook(ctx, h.GetWebhookID())
+	hook, err := database.FromContext(c).GetHookByWebhookID(ctx, h.GetWebhookID())
 	if err != nil {
 		return nil, fmt.Errorf("%s: failed to get hook with webhook ID %d from database", baseErr, h.GetWebhookID())
 	}

--- a/database/hook/get_webhook.go
+++ b/database/hook/get_webhook.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-vela/types/library"
 )
 
-// GetHookByWebhook gets a single hook with a matching webhook id in the database.
+// GetHookByWebhookID gets a single hook with a matching webhook id in the database.
 func (e *engine) GetHookByWebhookID(ctx context.Context, webhookID int64) (*library.Hook, error) {
 	e.logger.Tracef("getting a hook with webhook id %d from the database", webhookID)
 

--- a/database/hook/get_webhook.go
+++ b/database/hook/get_webhook.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package hook
+
+import (
+	"context"
+
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+)
+
+// GetHookByWebhook gets a single hook with a matching webhook id in the database.
+func (e *engine) GetHookByWebhook(ctx context.Context, webhookID int64) (*library.Hook, error) {
+	e.logger.Tracef("getting a hook with webhook id %d from the database", webhookID)
+
+	// variable to store query results
+	h := new(database.Hook)
+
+	// send query to the database and store result in variable
+	err := e.client.
+		Table(constants.TableHook).
+		Where("webhook_id = ?", webhookID).
+		Take(h).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	// return the hook
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#Hook.ToLibrary
+	return h.ToLibrary(), nil
+}

--- a/database/hook/get_webhook.go
+++ b/database/hook/get_webhook.go
@@ -13,7 +13,7 @@ import (
 )
 
 // GetHookByWebhook gets a single hook with a matching webhook id in the database.
-func (e *engine) GetHookByWebhook(ctx context.Context, webhookID int64) (*library.Hook, error) {
+func (e *engine) GetHookByWebhookID(ctx context.Context, webhookID int64) (*library.Hook, error) {
 	e.logger.Tracef("getting a hook with webhook id %d from the database", webhookID)
 
 	// variable to store query results

--- a/database/hook/get_webhook_test.go
+++ b/database/hook/get_webhook_test.go
@@ -70,18 +70,18 @@ func TestHook_Engine_GetHookByWebhookID(t *testing.T) {
 
 			if test.failure {
 				if err == nil {
-					t.Errorf("GetHookByWebhook for %s should have returned err", test.name)
+					t.Errorf("GetHookByWebhookID for %s should have returned err", test.name)
 				}
 
 				return
 			}
 
 			if err != nil {
-				t.Errorf("GetHookByWebhook for %s returned err: %v", test.name, err)
+				t.Errorf("GetHookByWebhookID for %s returned err: %v", test.name, err)
 			}
 
 			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("GetHookByWebhook for %s is %v, want %v", test.name, got, test.want)
+				t.Errorf("GetHookByWebhookID for %s is %v, want %v", test.name, got, test.want)
 			}
 		})
 	}

--- a/database/hook/get_webhook_test.go
+++ b/database/hook/get_webhook_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-vela/types/library"
 )
 
-func TestHook_Engine_GetHookByWebhook(t *testing.T) {
+func TestHook_Engine_GetHookByWebhookID(t *testing.T) {
 	// setup types
 	_hook := testHook()
 	_hook.SetID(1)
@@ -66,7 +66,7 @@ func TestHook_Engine_GetHookByWebhook(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.database.GetHookByWebhook(context.TODO(), 123456)
+			got, err := test.database.GetHookByWebhookID(context.TODO(), 123456)
 
 			if test.failure {
 				if err == nil {

--- a/database/hook/get_webhook_test.go
+++ b/database/hook/get_webhook_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package hook
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-vela/types/library"
+)
+
+func TestHook_Engine_GetHookByWebhook(t *testing.T) {
+	// setup types
+	_hook := testHook()
+	_hook.SetID(1)
+	_hook.SetRepoID(1)
+	_hook.SetBuildID(1)
+	_hook.SetNumber(1)
+	_hook.SetSourceID("c8da1302-07d6-11ea-882f-4893bca275b8")
+	_hook.SetWebhookID(123456)
+
+	_postgres, _mock := testPostgres(t)
+	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
+
+	// create expected result in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "repo_id", "build_id", "number", "source_id", "created", "host", "event", "event_action", "branch", "error", "status", "link", "webhook_id"},
+	).AddRow(1, 1, 1, 1, "c8da1302-07d6-11ea-882f-4893bca275b8", 0, "", "", "", "", "", "", "", 123456)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(`SELECT * FROM "hooks" WHERE webhook_id = $1 LIMIT 1`).WithArgs(123456).WillReturnRows(_rows)
+
+	_sqlite := testSqlite(t)
+	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
+
+	_, err := _sqlite.CreateHook(context.TODO(), _hook)
+	if err != nil {
+		t.Errorf("unable to create test hook for sqlite: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure  bool
+		name     string
+		database *engine
+		want     *library.Hook
+	}{
+		{
+			failure:  false,
+			name:     "postgres",
+			database: _postgres,
+			want:     _hook,
+		},
+		{
+			failure:  false,
+			name:     "sqlite3",
+			database: _sqlite,
+			want:     _hook,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.database.GetHookByWebhook(context.TODO(), 123456)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("GetHookByWebhook for %s should have returned err", test.name)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("GetHookByWebhook for %s returned err: %v", test.name, err)
+			}
+
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("GetHookByWebhook for %s is %v, want %v", test.name, got, test.want)
+			}
+		})
+	}
+}

--- a/database/hook/interface.go
+++ b/database/hook/interface.go
@@ -38,7 +38,7 @@ type HookInterface interface {
 	DeleteHook(context.Context, *library.Hook) error
 	// GetHook defines a function that gets a hook by ID.
 	GetHook(context.Context, int64) (*library.Hook, error)
-	// GetHookByWebhook defines a function that gets any hook with a matching webhook_id.
+	// GetHookByWebhookID defines a function that gets any hook with a matching webhook_id.
 	GetHookByWebhookID(context.Context, int64) (*library.Hook, error)
 	// GetHookForRepo defines a function that gets a hook by repo ID and number.
 	GetHookForRepo(context.Context, *library.Repo, int) (*library.Hook, error)

--- a/database/hook/interface.go
+++ b/database/hook/interface.go
@@ -39,7 +39,7 @@ type HookInterface interface {
 	// GetHook defines a function that gets a hook by ID.
 	GetHook(context.Context, int64) (*library.Hook, error)
 	// GetHookByWebhook defines a function that gets any hook with a matching webhook_id.
-	GetHookByWebhook(context.Context, int64) (*library.Hook, error)
+	GetHookByWebhookID(context.Context, int64) (*library.Hook, error)
 	// GetHookForRepo defines a function that gets a hook by repo ID and number.
 	GetHookForRepo(context.Context, *library.Repo, int) (*library.Hook, error)
 	// LastHookForRepo defines a function that gets the last hook by repo ID.

--- a/database/hook/interface.go
+++ b/database/hook/interface.go
@@ -38,6 +38,8 @@ type HookInterface interface {
 	DeleteHook(context.Context, *library.Hook) error
 	// GetHook defines a function that gets a hook by ID.
 	GetHook(context.Context, int64) (*library.Hook, error)
+	// GetHookByWebhook defines a function that gets any hook with a matching webhook_id.
+	GetHookByWebhook(context.Context, int64) (*library.Hook, error)
 	// GetHookForRepo defines a function that gets a hook by repo ID and number.
 	GetHookForRepo(context.Context, *library.Repo, int) (*library.Hook, error)
 	// LastHookForRepo defines a function that gets the last hook by repo ID.

--- a/database/integration_test.go
+++ b/database/integration_test.go
@@ -494,7 +494,7 @@ func testHooks(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list hooks for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
-	if int(count) != len(resources.Hooks) {
+	if int(count) != len(resources.Hooks)-1 {
 		t.Errorf("ListHooksForRepo() is %v, want %v", count, len(resources.Hooks))
 	}
 	if !reflect.DeepEqual(list, []*library.Hook{resources.Hooks[1], resources.Hooks[0]}) {
@@ -511,6 +511,16 @@ func testHooks(t *testing.T, db Interface, resources *Resources) {
 		t.Errorf("LastHookForRepo() is %v, want %v", got, resources.Hooks[1])
 	}
 	methods["LastHookForRepo"] = true
+
+	// lookup a hook with matching webhook_id
+	got, err = db.GetHookByWebhook(context.TODO(), resources.Hooks[2].GetWebhookID())
+	if err != nil {
+		t.Errorf("unable to get last hook for repo %d: %v", resources.Repos[0].GetID(), err)
+	}
+	if !reflect.DeepEqual(got, resources.Hooks[2]) {
+		t.Errorf("GetHookByWebhook() is %v, want %v", got, resources.Hooks[2])
+	}
+	methods["GetHookByWebhook"] = true
 
 	// lookup the hooks by name
 	for _, hook := range resources.Hooks {
@@ -1964,6 +1974,22 @@ func newResources() *Resources {
 	hookTwo.SetLink("https://github.com/github/octocat/settings/hooks/1")
 	hookTwo.SetWebhookID(123456)
 
+	hookThree := new(library.Hook)
+	hookThree.SetID(3)
+	hookThree.SetRepoID(2)
+	hookThree.SetBuildID(5)
+	hookThree.SetNumber(1)
+	hookThree.SetSourceID("c8da1302-07d6-11ea-882f-6793bca275b8")
+	hookThree.SetCreated(time.Now().UTC().Unix())
+	hookThree.SetHost("github.com")
+	hookThree.SetEvent("push")
+	hookThree.SetEventAction("")
+	hookThree.SetBranch("main")
+	hookThree.SetError("")
+	hookThree.SetStatus("success")
+	hookThree.SetLink("https://github.com/github/octocat/settings/hooks/1")
+	hookThree.SetWebhookID(78910)
+
 	logServiceOne := new(library.Log)
 	logServiceOne.SetID(1)
 	logServiceOne.SetBuildID(1)
@@ -2278,7 +2304,7 @@ func newResources() *Resources {
 		Builds:      []*library.Build{buildOne, buildTwo},
 		Deployments: []*library.Deployment{deploymentOne, deploymentTwo},
 		Executables: []*library.BuildExecutable{executableOne, executableTwo},
-		Hooks:       []*library.Hook{hookOne, hookTwo},
+		Hooks:       []*library.Hook{hookOne, hookTwo, hookThree},
 		Logs:        []*library.Log{logServiceOne, logServiceTwo, logStepOne, logStepTwo},
 		Pipelines:   []*library.Pipeline{pipelineOne, pipelineTwo},
 		Repos:       []*library.Repo{repoOne, repoTwo},

--- a/database/integration_test.go
+++ b/database/integration_test.go
@@ -521,7 +521,7 @@ func testHooks(t *testing.T, db Interface, resources *Resources) {
 	if !reflect.DeepEqual(got, resources.Hooks[2]) {
 		t.Errorf("GetHookByWebhookID() is %v, want %v", got, resources.Hooks[2])
 	}
-	methods["GetHookByWebhook"] = true
+	methods["GetHookByWebhookID"] = true
 
 	// lookup the hooks by name
 	for _, hook := range resources.Hooks {

--- a/database/integration_test.go
+++ b/database/integration_test.go
@@ -494,6 +494,7 @@ func testHooks(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list hooks for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
+	// only 2 of 3 hooks belong to Repos[0] repo
 	if int(count) != len(resources.Hooks)-1 {
 		t.Errorf("ListHooksForRepo() is %v, want %v", count, len(resources.Hooks))
 	}
@@ -513,12 +514,12 @@ func testHooks(t *testing.T, db Interface, resources *Resources) {
 	methods["LastHookForRepo"] = true
 
 	// lookup a hook with matching webhook_id
-	got, err = db.GetHookByWebhook(context.TODO(), resources.Hooks[2].GetWebhookID())
+	got, err = db.GetHookByWebhookID(context.TODO(), resources.Hooks[2].GetWebhookID())
 	if err != nil {
 		t.Errorf("unable to get last hook for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
 	if !reflect.DeepEqual(got, resources.Hooks[2]) {
-		t.Errorf("GetHookByWebhook() is %v, want %v", got, resources.Hooks[2])
+		t.Errorf("GetHookByWebhookID() is %v, want %v", got, resources.Hooks[2])
 	}
 	methods["GetHookByWebhook"] = true
 

--- a/scm/github/webhook.go
+++ b/scm/github/webhook.go
@@ -465,22 +465,6 @@ func (c *client) processRepositoryEvent(h *library.Hook, payload *github.Reposit
 	r.SetActive(!repo.GetArchived())
 	r.SetTopics(repo.Topics)
 
-	// if action is renamed, then get the previous name from payload
-	if payload.GetAction() == constants.ActionRenamed {
-		r.SetPreviousName(repo.GetOwner().GetLogin() + "/" + payload.GetChanges().GetRepo().GetName().GetFrom())
-	}
-
-	// if action is transferred, then get the previous owner from payload
-	// could be a user or an org, but both are User structs
-	if payload.GetAction() == constants.ActionTransferred {
-		org := payload.GetChanges().GetOwner().GetOwnerInfo().GetOrg()
-		if org == nil {
-			org = payload.GetChanges().GetOwner().GetOwnerInfo().GetUser()
-		}
-
-		r.SetPreviousName(org.GetLogin() + "/" + repo.GetName())
-	}
-
 	h.SetEvent(constants.EventRepository)
 	h.SetEventAction(payload.GetAction())
 	h.SetBranch(r.GetBranch())

--- a/scm/github/webhook_test.go
+++ b/scm/github/webhook_test.go
@@ -982,7 +982,6 @@ func TestGitHub_ProcessWebhook_RepositoryRename(t *testing.T) {
 	wantRepo.SetClone("https://octocoders.github.io/Codertocat/Hello-World.git")
 	wantRepo.SetBranch("master")
 	wantRepo.SetPrivate(false)
-	wantRepo.SetPreviousName("Codertocat/Hello-Old-World")
 	wantRepo.SetTopics(nil)
 
 	want := &types.Webhook{
@@ -1047,7 +1046,6 @@ func TestGitHub_ProcessWebhook_RepositoryTransfer(t *testing.T) {
 	wantRepo.SetClone("https://octocoders.github.io/Codertocat/Hello-World.git")
 	wantRepo.SetBranch("master")
 	wantRepo.SetPrivate(false)
-	wantRepo.SetPreviousName("Old-Codertocat/Hello-World")
 	wantRepo.SetTopics(nil)
 
 	want := &types.Webhook{


### PR DESCRIPTION
With newer GitHub versions allowing users to transfer _and_ rename in one fell swoop, there happened to be a bug in the payloads that are sent our way.

GitHub offered this `transfer` + `rename` option with the following events under the hood (example involves the transfer of `ExampleOrg/name` to `EastonCrupper/new-name`):

```json
{
  "action": "transferred",
  "changes": {
    "owner": {
      "from": {
        "user": {
          "login": "EastonCrupper",
          ....
        }
      }
    }
  },
  "repository": {
    "id": 352163,
    "name": "new-name",
.......
```

followed by

```json
{
  "action": "renamed",
  "changes": {
    "repository": {
      "name": {
        "from": "name"
      }
    }
  },
  "repository": {
    "id": 352163,
    "name": "new-name",
    "full_name": "EastonCrupper/new-name",
    "private": false,
    "owner": {
      "login": "EastonCrupper",
.......
```

The issue: **we have no way to find the old repository's name during the transfer event.** One would assume the first payload would contain info about the organization change and _only_ the organization change, and, in turn, the rename payload would contain info about the name change. This is unfortunately not the case and is surely a bug with GitHub.

This issue persists in the newest versions of GitHub, too.

Therefore, this change suggests we find our DB record of the repo in a different way: by using the `webhook_id` conveniently stored in all hooks, which is a unique identifier for repos. 

If I could do this over again, I would remove `repo.PreviousName` and replace it with `repo.WebhookID`, and rework the redelivery mechanism to find the webhook ID from the repo rather than the hook. Something to ponder....