### PR TITLE
fix(restart): instantiate compiler with commit

### DIFF
--- a/api/build/restart.go
+++ b/api/build/restart.go
@@ -253,6 +253,7 @@ func RestartBuild(c *gin.Context) {
 	p, compiled, err = compiler.FromContext(c).
 		Duplicate().
 		WithBuild(b).
+		WithCommit(b.GetCommit()).
 		WithFiles(files).
 		WithMetadata(m).
 		WithRepo(r).


### PR DESCRIPTION
[This change](https://github.com/go-vela/server/pull/859) forgot to add the new `WithCommit` option to the restart API handler. When users would restart a build that leveraged a same-commit template, it would attempt to source the template from the default branch rather than the commit.