### PR TITLE
patch(webhook): support transfer and rename

### DIFF
--- a/database/hook/get_webhook.go
+++ b/database/hook/get_webhook.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package hook
+
+import (
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/database"
+	"github.com/go-vela/types/library"
+)
+
+// GetHookByWebhookID gets a single hook with a matching webhook id in the database.
+func (e *engine) GetHookByWebhookID(webhookID int64) (*library.Hook, error) {
+	e.logger.Tracef("getting a hook with webhook id %d from the database", webhookID)
+
+	// variable to store query results
+	h := new(database.Hook)
+
+	// send query to the database and store result in variable
+	err := e.client.
+		Table(constants.TableHook).
+		Where("webhook_id = ?", webhookID).
+		Take(h).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	// return the hook
+	//
+	// https://pkg.go.dev/github.com/go-vela/types/database#Hook.ToLibrary
+	return h.ToLibrary(), nil
+}

--- a/database/hook/get_webhook_test.go
+++ b/database/hook/get_webhook_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package hook
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-vela/types/library"
+)
+
+func TestHook_Engine_GetHookByWebhookID(t *testing.T) {
+	// setup types
+	_hook := testHook()
+	_hook.SetID(1)
+	_hook.SetRepoID(1)
+	_hook.SetBuildID(1)
+	_hook.SetNumber(1)
+	_hook.SetSourceID("c8da1302-07d6-11ea-882f-4893bca275b8")
+	_hook.SetWebhookID(123456)
+
+	_postgres, _mock := testPostgres(t)
+	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
+
+	// create expected result in mock
+	_rows := sqlmock.NewRows(
+		[]string{"id", "repo_id", "build_id", "number", "source_id", "created", "host", "event", "event_action", "branch", "error", "status", "link", "webhook_id"},
+	).AddRow(1, 1, 1, 1, "c8da1302-07d6-11ea-882f-4893bca275b8", 0, "", "", "", "", "", "", "", 123456)
+
+	// ensure the mock expects the query
+	_mock.ExpectQuery(`SELECT * FROM "hooks" WHERE webhook_id = $1 LIMIT 1`).WithArgs(123456).WillReturnRows(_rows)
+
+	_sqlite := testSqlite(t)
+	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
+
+	_, err := _sqlite.CreateHook(_hook)
+	if err != nil {
+		t.Errorf("unable to create test hook for sqlite: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure  bool
+		name     string
+		database *engine
+		want     *library.Hook
+	}{
+		{
+			failure:  false,
+			name:     "postgres",
+			database: _postgres,
+			want:     _hook,
+		},
+		{
+			failure:  false,
+			name:     "sqlite3",
+			database: _sqlite,
+			want:     _hook,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.database.GetHookByWebhookID(123456)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("GetHookByWebhookID for %s should have returned err", test.name)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("GetHookByWebhookID for %s returned err: %v", test.name, err)
+			}
+
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("GetHookByWebhookID for %s is %v, want %v", test.name, got, test.want)
+			}
+		})
+	}
+}

--- a/database/hook/interface.go
+++ b/database/hook/interface.go
@@ -36,6 +36,8 @@ type HookInterface interface {
 	DeleteHook(*library.Hook) error
 	// GetHook defines a function that gets a hook by ID.
 	GetHook(int64) (*library.Hook, error)
+	// GetHookByWebhookID defines a function that gets any hook with a matching webhook_id.
+	GetHookByWebhookID(int64) (*library.Hook, error)
 	// GetHookForRepo defines a function that gets a hook by repo ID and number.
 	GetHookForRepo(*library.Repo, int) (*library.Hook, error)
 	// LastHookForRepo defines a function that gets the last hook by repo ID.

--- a/scm/github/webhook.go
+++ b/scm/github/webhook.go
@@ -464,22 +464,6 @@ func (c *client) processRepositoryEvent(h *library.Hook, payload *github.Reposit
 	r.SetActive(!repo.GetArchived())
 	r.SetTopics(repo.Topics)
 
-	// if action is renamed, then get the previous name from payload
-	if payload.GetAction() == constants.ActionRenamed {
-		r.SetPreviousName(repo.GetOwner().GetLogin() + "/" + payload.GetChanges().GetRepo().GetName().GetFrom())
-	}
-
-	// if action is transferred, then get the previous owner from payload
-	// could be a user or an org, but both are User structs
-	if payload.GetAction() == constants.ActionTransferred {
-		org := payload.GetChanges().GetOwner().GetOwnerInfo().GetOrg()
-		if org == nil {
-			org = payload.GetChanges().GetOwner().GetOwnerInfo().GetUser()
-		}
-
-		r.SetPreviousName(org.GetLogin() + "/" + repo.GetName())
-	}
-
 	h.SetEvent(constants.EventRepository)
 	h.SetEventAction(payload.GetAction())
 	h.SetBranch(r.GetBranch())

--- a/scm/github/webhook_test.go
+++ b/scm/github/webhook_test.go
@@ -982,7 +982,6 @@ func TestGitHub_ProcessWebhook_RepositoryRename(t *testing.T) {
 	wantRepo.SetClone("https://octocoders.github.io/Codertocat/Hello-World.git")
 	wantRepo.SetBranch("master")
 	wantRepo.SetPrivate(false)
-	wantRepo.SetPreviousName("Codertocat/Hello-Old-World")
 	wantRepo.SetTopics(nil)
 
 	want := &types.Webhook{
@@ -1047,7 +1046,6 @@ func TestGitHub_ProcessWebhook_RepositoryTransfer(t *testing.T) {
 	wantRepo.SetClone("https://octocoders.github.io/Codertocat/Hello-World.git")
 	wantRepo.SetBranch("master")
 	wantRepo.SetPrivate(false)
-	wantRepo.SetPreviousName("Old-Codertocat/Hello-World")
 	wantRepo.SetTopics(nil)
 
 	want := &types.Webhook{


### PR DESCRIPTION
Preparing patch release of `v0.20.2`. Includes these changes: https://github.com/go-vela/server/pull/955