### PR TITLE
enhance(api/deploy): use default branch if ref is not supplied

### DIFF
--- a/api/deployment/create.go
+++ b/api/deployment/create.go
@@ -93,6 +93,11 @@ func CreateDeployment(c *gin.Context) {
 		input.SetTask("deploy:vela")
 	}
 
+	// if ref isn't provided, use repo's default branch
+	if len(input.GetRef()) == 0 {
+		input.SetRef(fmt.Sprintf("refs/heads/%s", r.GetBranch()))
+	}
+
 	// send API call to create the deployment
 	err = scm.FromContext(c).CreateDeployment(u, r, input)
 	if err != nil {

--- a/api/deployment/create.go
+++ b/api/deployment/create.go
@@ -93,7 +93,7 @@ func CreateDeployment(c *gin.Context) {
 		input.SetTask("deploy:vela")
 	}
 
-	// if ref isn't provided, use repo's default branch
+	// if ref is not provided, use repo default branch
 	if len(input.GetRef()) == 0 {
 		input.SetRef(fmt.Sprintf("refs/heads/%s", r.GetBranch()))
 	}


### PR DESCRIPTION
Taking the injected default duty away from CLI [here](https://github.com/go-vela/cli/blob/010e3166b256e365315ceb91e30bb70403a458f5/command/deployment/add.go#L47). Will be a follow up PR after this.