### PR TITLE
patch(sync): address sync bug with update webhook call

### DIFF
--- a/api/repo/update.go
+++ b/api/repo/update.go
@@ -284,7 +284,7 @@ func UpdateRepo(c *gin.Context) {
 			}).Infof("platform admin %s updating repo webhook events for repo %s", admn, r.GetFullName())
 		}
 		// update webhook with new events
-		err = scm.FromContext(c).Update(u, r, lastHook.GetWebhookID())
+		_, err = scm.FromContext(c).Update(u, r, lastHook.GetWebhookID())
 		if err != nil {
 			retErr := fmt.Errorf("unable to update repo webhook for %s: %w", r.GetFullName(), err)
 

--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -217,7 +217,7 @@ func (c *client) Enable(u *library.User, r *library.Repo, h *library.Hook) (*lib
 }
 
 // Update edits a repo webhook.
-func (c *client) Update(u *library.User, r *library.Repo, hookID int64) error {
+func (c *client) Update(u *library.User, r *library.Repo, hookID int64) (bool, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),
@@ -258,13 +258,11 @@ func (c *client) Update(u *library.User, r *library.Repo, hookID int64) error {
 	}
 
 	// send API call to update the webhook
-	_, _, err := client.Repositories.EditHook(ctx, r.GetOrg(), r.GetName(), hookID, hook)
+	_, resp, err := client.Repositories.EditHook(ctx, r.GetOrg(), r.GetName(), hookID, hook)
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	// track if webhook exists in GitHub; a missing webhook
+	// indicates the webhook has been manually deleted from GitHub
+	return resp.StatusCode != http.StatusNotFound, err
 }
 
 // Status sends the commit status for the given SHA from the GitHub repo.

--- a/scm/service.go
+++ b/scm/service.go
@@ -101,7 +101,7 @@ type Service interface {
 	Enable(*library.User, *library.Repo, *library.Hook) (*library.Hook, string, error)
 	// Update defines a function that updates
 	// a webhook for a specified repo.
-	Update(*library.User, *library.Repo, int64) error
+	Update(*library.User, *library.Repo, int64) (bool, error)
 	// Status defines a function that sends the
 	// commit status for the given SHA from a repo.
 	Status(*library.User, *library.Build, string, string) error


### PR DESCRIPTION
Preparing for patch `v0.20.2`. This will include these changes: https://github.com/go-vela/server/pull/953