### PR TITLE
patch(compiler): reintroduce fix from v0.20.1 that got lost

### DIFF
--- a/api/pipeline/compile.go
+++ b/api/pipeline/compile.go
@@ -97,7 +97,7 @@ func CompilePipeline(c *gin.Context) {
 	compiler := compiler.FromContext(c).Duplicate().WithCommit(p.GetCommit()).WithMetadata(m).WithRepo(r).WithUser(u)
 
 	// compile the pipeline
-	pipeline, _, err := compiler.CompileLite(p.GetData(), true, true, nil)
+	pipeline, _, err := compiler.CompileLite(p.GetData(), true, true)
 	if err != nil {
 		retErr := fmt.Errorf("unable to compile pipeline %s: %w", entry, err)
 

--- a/api/pipeline/expand.go
+++ b/api/pipeline/expand.go
@@ -98,7 +98,7 @@ func ExpandPipeline(c *gin.Context) {
 	compiler := compiler.FromContext(c).Duplicate().WithCommit(p.GetCommit()).WithMetadata(m).WithRepo(r).WithUser(u)
 
 	// expand the templates in the pipeline
-	pipeline, _, err := compiler.CompileLite(p.GetData(), true, false, nil)
+	pipeline, _, err := compiler.CompileLite(p.GetData(), true, false)
 	if err != nil {
 		retErr := fmt.Errorf("unable to expand pipeline %s: %w", entry, err)
 

--- a/api/pipeline/validate.go
+++ b/api/pipeline/validate.go
@@ -105,7 +105,7 @@ func ValidatePipeline(c *gin.Context) {
 	}
 
 	// validate the pipeline
-	pipeline, _, err := compiler.CompileLite(p.GetData(), template, false, nil)
+	pipeline, _, err := compiler.CompileLite(p.GetData(), template, false)
 	if err != nil {
 		retErr := fmt.Errorf("unable to validate pipeline %s: %w", entry, err)
 

--- a/compiler/engine.go
+++ b/compiler/engine.go
@@ -25,7 +25,7 @@ type Engine interface {
 	// CompileLite defines a function that produces an light executable
 	// representation of a pipeline from an object. This calls
 	// Parse internally to convert the object to a yaml configuration.
-	CompileLite(interface{}, bool, bool, []string) (*yaml.Build, *library.Pipeline, error)
+	CompileLite(interface{}, bool, bool) (*yaml.Build, *library.Pipeline, error)
 
 	// Duplicate defines a function that
 	// creates a clone of the Engine.
@@ -130,6 +130,9 @@ type Engine interface {
 	// WithLocal defines a function that sets
 	// the compiler local field in the Engine.
 	WithLocal(bool) Engine
+	// WithLocalTemplates defines a function that sets
+	// the compiler local templates field in the Engine.
+	WithLocalTemplates([]string) Engine
 	// WithMetadata defines a function that sets
 	// the compiler Metadata type in the Engine.
 	WithMetadata(*types.Metadata) Engine

--- a/compiler/native/compile_test.go
+++ b/compiler/native/compile_test.go
@@ -3422,7 +3422,7 @@ func Test_CompileLite(t *testing.T) {
 				t.Errorf("Reading yaml file return err: %v", err)
 			}
 
-			got, _, err := compiler.CompileLite(yaml, tt.args.template, tt.args.substitute, nil)
+			got, _, err := compiler.CompileLite(yaml, tt.args.template, tt.args.substitute)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CompileLite() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/compiler/native/native.go
+++ b/compiler/native/native.go
@@ -34,14 +34,15 @@ type client struct {
 	CloneImage          string
 	TemplateDepth       int
 
-	build    *library.Build
-	comment  string
-	commit   string
-	files    []string
-	local    bool
-	metadata *types.Metadata
-	repo     *library.Repo
-	user     *library.User
+	build          *library.Build
+	comment        string
+	commit         string
+	files          []string
+	local          bool
+	localTemplates []string
+	metadata       *types.Metadata
+	repo           *library.Repo
+	user           *library.User
 }
 
 // New returns a Pipeline implementation that integrates with the supported registries.
@@ -157,6 +158,13 @@ func (c *client) WithFiles(f []string) compiler.Engine {
 // WithLocal sets the compiler metadata type in the Engine.
 func (c *client) WithLocal(local bool) compiler.Engine {
 	c.local = local
+
+	return c
+}
+
+// WithLocalTemplates sets the compiler local templates in the Engine.
+func (c *client) WithLocalTemplates(templates []string) compiler.Engine {
+	c.localTemplates = templates
 
 	return c
 }

--- a/compiler/native/native_test.go
+++ b/compiler/native/native_test.go
@@ -202,6 +202,26 @@ func TestNative_WithLocal(t *testing.T) {
 	}
 }
 
+func TestNative_WithLocalTemplates(t *testing.T) {
+	// setup types
+	set := flag.NewFlagSet("test", 0)
+	c := cli.NewContext(nil, set, nil)
+
+	localTemplates := []string{"example:tmpl.yml", "exmpl:template.yml"}
+	want, _ := New(c)
+	want.localTemplates = []string{"example:tmpl.yml", "exmpl:template.yml"}
+
+	// run test
+	got, err := New(c)
+	if err != nil {
+		t.Errorf("Unable to create new compiler: %v", err)
+	}
+
+	if !reflect.DeepEqual(got.WithLocalTemplates(localTemplates), want) {
+		t.Errorf("WithLocalTemplates is %v, want %v", got, want)
+	}
+}
+
 func TestNative_WithMetadata(t *testing.T) {
 	// setup types
 	set := flag.NewFlagSet("test", 0)

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/drone/envsubst v1.0.3
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-playground/assert/v2 v2.2.0
-	github.com/go-vela/types v0.20.2
+	github.com/go-vela/types v0.20.3
 	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github/v53 v53.2.0

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91
 github.com/go-playground/validator/v10 v10.14.0 h1:vgvQWe3XCz3gIeFDm/HnTIbj6UGmg/+t63MyGU2n5js=
 github.com/go-playground/validator/v10 v10.14.0/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
-github.com/go-vela/types v0.20.2 h1:PnyKJareZTEvVoAOe48tRnOMETVtpm+5JdHqOsMA0v0=
-github.com/go-vela/types v0.20.2/go.mod h1:AXO4oQSygOBQ02fPapsKjQHkx2aQO3zTu7clpvVbXBY=
+github.com/go-vela/types v0.20.3 h1:vrX9pFTzTHbtfjHdbAwp9Ii3hWx3OSZ8qTINyaq2j2k=
+github.com/go-vela/types v0.20.3/go.mod h1:AXO4oQSygOBQ02fPapsKjQHkx2aQO3zTu7clpvVbXBY=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=


### PR DESCRIPTION
The [patch](https://github.com/go-vela/server/pull/917) that was included in `v0.20.1` was reverted in the publishing of `v0.20.2` due to mistakes in the patching process.

This patch reintroduces the bug fix that resulted in the `v0.20.1` patch while also including all the fixes in `v0.20.2`.

It also pulls in the matching `v0.20.3` types version for consistency in the eventual `v0.20.3` server release.