### PR TITLE
enhance: add context to scm

### DIFF
--- a/api/auth/get_token.go
+++ b/api/auth/get_token.go
@@ -72,7 +72,7 @@ func GetAuthToken(c *gin.Context) {
 	code := c.Request.FormValue("code")
 	if len(code) == 0 {
 		// start the initial OAuth workflow
-		oAuthState, err = scm.FromContext(c).Login(c.Writer, c.Request)
+		oAuthState, err = scm.FromContext(c).Login(ctx, c.Writer, c.Request)
 		if err != nil {
 			retErr := fmt.Errorf("unable to login user: %w", err)
 
@@ -83,7 +83,7 @@ func GetAuthToken(c *gin.Context) {
 	}
 
 	// complete the OAuth workflow and authenticates the user
-	newUser, err := scm.FromContext(c).Authenticate(c.Writer, c.Request, oAuthState)
+	newUser, err := scm.FromContext(c).Authenticate(ctx, c.Writer, c.Request, oAuthState)
 	if err != nil {
 		retErr := fmt.Errorf("unable to authenticate user: %w", err)
 

--- a/api/auth/post_token.go
+++ b/api/auth/post_token.go
@@ -53,7 +53,7 @@ func PostAuthToken(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	// attempt to get user from source
-	u, err := scm.FromContext(c).AuthenticateToken(c.Request)
+	u, err := scm.FromContext(c).AuthenticateToken(ctx, c.Request)
 	if err != nil {
 		retErr := fmt.Errorf("unable to authenticate user: %w", err)
 

--- a/api/build/create.go
+++ b/api/build/create.go
@@ -187,7 +187,7 @@ func CreateBuild(c *gin.Context) {
 	if !strings.EqualFold(input.GetEvent(), constants.EventComment) &&
 		!strings.EqualFold(input.GetEvent(), constants.EventPull) {
 		// send API call to capture list of files changed for the commit
-		files, err = scm.FromContext(c).Changeset(u, r, input.GetCommit())
+		files, err = scm.FromContext(c).Changeset(ctx, u, r, input.GetCommit())
 		if err != nil {
 			retErr := fmt.Errorf("unable to create new build: failed to get changeset for %s: %w", r.GetFullName(), err)
 
@@ -210,7 +210,7 @@ func CreateBuild(c *gin.Context) {
 		}
 
 		// send API call to capture list of files changed for the pull request
-		files, err = scm.FromContext(c).ChangesetPR(u, r, number)
+		files, err = scm.FromContext(c).ChangesetPR(ctx, u, r, number)
 		if err != nil {
 			retErr := fmt.Errorf("unable to create new build: failed to get changeset for %s: %w", r.GetFullName(), err)
 
@@ -235,7 +235,7 @@ func CreateBuild(c *gin.Context) {
 	pipeline, err = database.FromContext(c).GetPipelineForRepo(ctx, input.GetCommit(), r)
 	if err != nil { // assume the pipeline doesn't exist in the database yet
 		// send API call to capture the pipeline configuration file
-		config, err = scm.FromContext(c).ConfigBackoff(u, r, input.GetCommit())
+		config, err = scm.FromContext(c).ConfigBackoff(ctx, u, r, input.GetCommit())
 		if err != nil {
 			retErr := fmt.Errorf("unable to create new build: failed to get pipeline configuration for %s: %w", r.GetFullName(), err)
 
@@ -289,7 +289,7 @@ func CreateBuild(c *gin.Context) {
 		input.SetStatus(constants.StatusSuccess)
 
 		// send API call to set the status on the commit
-		err = scm.FromContext(c).Status(u, input, r.GetOrg(), r.GetName())
+		err = scm.FromContext(c).Status(ctx, u, input, r.GetOrg(), r.GetName())
 		if err != nil {
 			logger.Errorf("unable to set commit status for %s/%d: %v", r.GetFullName(), input.GetNumber(), err)
 		}
@@ -345,7 +345,7 @@ func CreateBuild(c *gin.Context) {
 	c.JSON(http.StatusCreated, input)
 
 	// send API call to set the status on the commit
-	err = scm.FromContext(c).Status(u, input, r.GetOrg(), r.GetName())
+	err = scm.FromContext(c).Status(ctx, u, input, r.GetOrg(), r.GetName())
 	if err != nil {
 		logger.Errorf("unable to set commit status for build %s/%d: %v", r.GetFullName(), input.GetNumber(), err)
 	}

--- a/api/build/get_id.go
+++ b/api/build/get_id.go
@@ -101,7 +101,7 @@ func GetBuildByID(c *gin.Context) {
 
 	// Capture user access from SCM. We do this in order to ensure user has access and is not
 	// just retrieving any build using a random id number.
-	perm, err := scm.FromContext(c).RepoAccess(u, u.GetToken(), r.GetOrg(), r.GetName())
+	perm, err := scm.FromContext(c).RepoAccess(ctx, u, u.GetToken(), r.GetOrg(), r.GetName())
 	if err != nil {
 		logrus.Errorf("unable to get user %s access level for repo %s", u.GetName(), r.GetFullName())
 	}

--- a/api/build/list_org.go
+++ b/api/build/list_org.go
@@ -190,7 +190,7 @@ func ListBuildsForOrg(c *gin.Context) {
 	perPage = util.MaxInt(1, util.MinInt(100, perPage))
 
 	// See if the user is an org admin to bypass individual permission checks
-	perm, err := scm.FromContext(c).OrgAccess(u, o)
+	perm, err := scm.FromContext(c).OrgAccess(ctx, u, o)
 	if err != nil {
 		logrus.Errorf("unable to get user %s access level for org %s", u.GetName(), o)
 	}

--- a/api/build/restart.go
+++ b/api/build/restart.go
@@ -177,7 +177,7 @@ func RestartBuild(c *gin.Context) {
 	if !strings.EqualFold(b.GetEvent(), constants.EventComment) &&
 		!strings.EqualFold(b.GetEvent(), constants.EventPull) {
 		// send API call to capture list of files changed for the commit
-		files, err = scm.FromContext(c).Changeset(u, r, b.GetCommit())
+		files, err = scm.FromContext(c).Changeset(ctx, u, r, b.GetCommit())
 		if err != nil {
 			retErr := fmt.Errorf("unable to restart build: failed to get changeset for %s: %w", r.GetFullName(), err)
 
@@ -200,7 +200,7 @@ func RestartBuild(c *gin.Context) {
 		}
 
 		// send API call to capture list of files changed for the pull request
-		files, err = scm.FromContext(c).ChangesetPR(u, r, number)
+		files, err = scm.FromContext(c).ChangesetPR(ctx, u, r, number)
 		if err != nil {
 			retErr := fmt.Errorf("unable to restart build: failed to get changeset for %s: %w", r.GetFullName(), err)
 
@@ -226,7 +226,7 @@ func RestartBuild(c *gin.Context) {
 	pipeline, err = database.FromContext(c).GetPipelineForRepo(ctx, b.GetCommit(), r)
 	if err != nil { // assume the pipeline doesn't exist in the database yet (before pipeline support was added)
 		// send API call to capture the pipeline configuration file
-		config, err = scm.FromContext(c).ConfigBackoff(u, r, b.GetCommit())
+		config, err = scm.FromContext(c).ConfigBackoff(ctx, u, r, b.GetCommit())
 		if err != nil {
 			retErr := fmt.Errorf("unable to get pipeline configuration for %s: %w", r.GetFullName(), err)
 
@@ -281,7 +281,7 @@ func RestartBuild(c *gin.Context) {
 		b.SetStatus(constants.StatusSkipped)
 
 		// send API call to set the status on the commit
-		err = scm.FromContext(c).Status(u, b, r.GetOrg(), r.GetName())
+		err = scm.FromContext(c).Status(ctx, u, b, r.GetOrg(), r.GetName())
 		if err != nil {
 			logrus.Errorf("unable to set commit status for %s/%d: %v", r.GetFullName(), b.GetNumber(), err)
 		}
@@ -336,7 +336,7 @@ func RestartBuild(c *gin.Context) {
 	c.JSON(http.StatusCreated, b)
 
 	// send API call to set the status on the commit
-	err = scm.FromContext(c).Status(u, b, r.GetOrg(), r.GetName())
+	err = scm.FromContext(c).Status(ctx, u, b, r.GetOrg(), r.GetName())
 	if err != nil {
 		logger.Errorf("unable to set commit status for build %s: %v", entry, err)
 	}

--- a/api/build/update.go
+++ b/api/build/update.go
@@ -176,7 +176,7 @@ func UpdateBuild(c *gin.Context) {
 		}
 
 		// send API call to set the status on the commit
-		err = scm.FromContext(c).Status(u, b, r.GetOrg(), r.GetName())
+		err = scm.FromContext(c).Status(ctx, u, b, r.GetOrg(), r.GetName())
 		if err != nil {
 			logrus.Errorf("unable to set commit status for build %s: %v", entry, err)
 		}

--- a/api/deployment/create.go
+++ b/api/deployment/create.go
@@ -59,6 +59,7 @@ func CreateDeployment(c *gin.Context) {
 	o := org.Retrieve(c)
 	r := repo.Retrieve(c)
 	u := user.Retrieve(c)
+	ctx := c.Request.Context()
 
 	// update engine logger with API metadata
 	//
@@ -99,7 +100,7 @@ func CreateDeployment(c *gin.Context) {
 	}
 
 	// send API call to create the deployment
-	err = scm.FromContext(c).CreateDeployment(u, r, input)
+	err = scm.FromContext(c).CreateDeployment(ctx, u, r, input)
 	if err != nil {
 		retErr := fmt.Errorf("unable to create new deployment for %s: %w", r.GetFullName(), err)
 

--- a/api/deployment/get.go
+++ b/api/deployment/get.go
@@ -65,6 +65,7 @@ func GetDeployment(c *gin.Context) {
 	r := repo.Retrieve(c)
 	u := user.Retrieve(c)
 	deployment := util.PathParameter(c, "deployment")
+	ctx := c.Request.Context()
 
 	entry := fmt.Sprintf("%s/%s", r.GetFullName(), deployment)
 
@@ -87,7 +88,7 @@ func GetDeployment(c *gin.Context) {
 	}
 
 	// send API call to capture the deployment
-	d, err := scm.FromContext(c).GetDeployment(u, r, int64(number))
+	d, err := scm.FromContext(c).GetDeployment(ctx, u, r, int64(number))
 	if err != nil {
 		retErr := fmt.Errorf("unable to get deployment %s: %w", entry, err)
 

--- a/api/deployment/list.go
+++ b/api/deployment/list.go
@@ -117,7 +117,7 @@ func ListDeployments(c *gin.Context) {
 	perPage = util.MaxInt(1, util.MinInt(100, perPage))
 
 	// send API call to capture the total number of deployments for the repo
-	t, err := scm.FromContext(c).GetDeploymentCount(u, r)
+	t, err := scm.FromContext(c).GetDeploymentCount(ctx, u, r)
 	if err != nil {
 		retErr := fmt.Errorf("unable to get deployment count for %s: %w", r.GetFullName(), err)
 
@@ -127,7 +127,7 @@ func ListDeployments(c *gin.Context) {
 	}
 
 	// send API call to capture the list of deployments for the repo
-	d, err := scm.FromContext(c).GetDeploymentList(u, r, page, perPage)
+	d, err := scm.FromContext(c).GetDeploymentList(ctx, u, r, page, perPage)
 	if err != nil {
 		retErr := fmt.Errorf("unable to get deployments for %s: %w", r.GetFullName(), err)
 

--- a/api/pipeline/template.go
+++ b/api/pipeline/template.go
@@ -146,7 +146,7 @@ func GetTemplates(c *gin.Context) {
 		}
 
 		// retrieve link to template file from github
-		link, err := scm.FromContext(c).GetHTMLURL(user, src.Org, src.Repo, src.Name, src.Ref)
+		link, err := scm.FromContext(c).GetHTMLURL(ctx, user, src.Org, src.Repo, src.Name, src.Ref)
 		if err != nil {
 			util.HandleError(c, http.StatusBadRequest, fmt.Errorf("%s: unable to get html url for %s/%s/%s/@%s: %w", baseErr, src.Org, src.Repo, src.Name, src.Ref, err))
 

--- a/api/repo/create.go
+++ b/api/repo/create.go
@@ -99,7 +99,7 @@ func CreateRepo(c *gin.Context) {
 	}).Infof("creating new repo %s", input.GetFullName())
 
 	// get repo information from the source
-	r, err := scm.FromContext(c).GetRepo(u, input)
+	r, err := scm.FromContext(c).GetRepo(ctx, u, input)
 	if err != nil {
 		retErr := fmt.Errorf("unable to retrieve repo info for %s from source: %w", r.GetFullName(), err)
 
@@ -255,7 +255,7 @@ func CreateRepo(c *gin.Context) {
 	// check if we should create the webhook
 	if c.Value("webhookvalidation").(bool) {
 		// send API call to create the webhook
-		h, _, err = scm.FromContext(c).Enable(u, r, h)
+		h, _, err = scm.FromContext(c).Enable(ctx, u, r, h)
 		if err != nil {
 			retErr := fmt.Errorf("unable to create webhook for %s: %w", r.GetFullName(), err)
 

--- a/api/repo/delete.go
+++ b/api/repo/delete.go
@@ -71,7 +71,7 @@ func DeleteRepo(c *gin.Context) {
 	}).Infof("deleting repo %s", r.GetFullName())
 
 	// send API call to remove the webhook
-	err := scm.FromContext(c).Disable(u, r.GetOrg(), r.GetName())
+	err := scm.FromContext(c).Disable(ctx, u, r.GetOrg(), r.GetName())
 	if err != nil {
 		retErr := fmt.Errorf("unable to delete webhook for %s: %w", r.GetFullName(), err)
 

--- a/api/repo/list_org.go
+++ b/api/repo/list_org.go
@@ -132,7 +132,7 @@ func ListReposForOrg(c *gin.Context) {
 	}
 
 	// See if the user is an org admin to bypass individual permission checks
-	perm, err := scm.FromContext(c).OrgAccess(u, o)
+	perm, err := scm.FromContext(c).OrgAccess(ctx, u, o)
 	if err != nil {
 		logrus.Errorf("unable to get user %s access level for org %s", u.GetName(), o)
 	}

--- a/api/repo/repair.go
+++ b/api/repo/repair.go
@@ -69,7 +69,7 @@ func RepairRepo(c *gin.Context) {
 	// check if we should create the webhook
 	if c.Value("webhookvalidation").(bool) {
 		// send API call to remove the webhook
-		err := scm.FromContext(c).Disable(u, r.GetOrg(), r.GetName())
+		err := scm.FromContext(c).Disable(ctx, u, r.GetOrg(), r.GetName())
 		if err != nil {
 			retErr := fmt.Errorf("unable to delete webhook for %s: %w", r.GetFullName(), err)
 
@@ -88,7 +88,7 @@ func RepairRepo(c *gin.Context) {
 		}
 
 		// send API call to create the webhook
-		hook, _, err = scm.FromContext(c).Enable(u, r, hook)
+		hook, _, err = scm.FromContext(c).Enable(ctx, u, r, hook)
 		if err != nil {
 			retErr := fmt.Errorf("unable to create webhook for %s: %w", r.GetFullName(), err)
 

--- a/api/repo/update.go
+++ b/api/repo/update.go
@@ -285,7 +285,7 @@ func UpdateRepo(c *gin.Context) {
 			}).Infof("platform admin %s updating repo webhook events for repo %s", admn, r.GetFullName())
 		}
 		// update webhook with new events
-		_, err = scm.FromContext(c).Update(u, r, lastHook.GetWebhookID())
+		_, err = scm.FromContext(c).Update(ctx, u, r, lastHook.GetWebhookID())
 		if err != nil {
 			retErr := fmt.Errorf("unable to update repo webhook for %s: %w", r.GetFullName(), err)
 

--- a/api/scm/sync.go
+++ b/api/scm/sync.go
@@ -73,7 +73,7 @@ func SyncRepo(c *gin.Context) {
 	logger.Infof("syncing repo %s", r.GetFullName())
 
 	// retrieve repo from source code manager service
-	_, err := scm.FromContext(c).GetRepo(u, r)
+	_, err := scm.FromContext(c).GetRepo(ctx, u, r)
 
 	// if there is an error retrieving repo, we know it is deleted: set to inactive
 	if err != nil {
@@ -98,7 +98,7 @@ func SyncRepo(c *gin.Context) {
 
 	// verify the user is an admin of the repo
 	// we cannot use our normal permissions check due to the possibility the repo was deleted
-	perm, err := scm.FromContext(c).RepoAccess(u, u.GetToken(), o, r.GetName())
+	perm, err := scm.FromContext(c).RepoAccess(ctx, u, u.GetToken(), o, r.GetName())
 	if err != nil {
 		logger.Errorf("unable to get user %s access level for org %s", u.GetName(), o)
 	}
@@ -125,7 +125,7 @@ func SyncRepo(c *gin.Context) {
 		}
 
 		// update webhook
-		webhookExists, err := scm.FromContext(c).Update(u, r, lastHook.GetWebhookID())
+		webhookExists, err := scm.FromContext(c).Update(ctx, u, r, lastHook.GetWebhookID())
 		if err != nil {
 
 			// if webhook has been manually deleted from GitHub,

--- a/api/scm/sync_org.go
+++ b/api/scm/sync_org.go
@@ -65,7 +65,7 @@ func SyncReposForOrg(c *gin.Context) {
 	logger.Infof("syncing repos for org %s", o)
 
 	// see if the user is an org admin
-	perm, err := scm.FromContext(c).OrgAccess(u, o)
+	perm, err := scm.FromContext(c).OrgAccess(ctx, u, o)
 	if err != nil {
 		logger.Errorf("unable to get user %s access level for org %s", u.GetName(), o)
 	}
@@ -109,7 +109,7 @@ func SyncReposForOrg(c *gin.Context) {
 
 	// iterate through captured repos and check if they are in GitHub
 	for _, repo := range repos {
-		_, err := scm.FromContext(c).GetRepo(u, repo)
+		_, err := scm.FromContext(c).GetRepo(ctx, u, repo)
 		// if repo cannot be captured from GitHub, set to inactive in database
 		if err != nil {
 			repo.SetActive(false)
@@ -138,7 +138,7 @@ func SyncReposForOrg(c *gin.Context) {
 			}
 
 			// update webhook
-			webhookExists, err := scm.FromContext(c).Update(u, repo, lastHook.GetWebhookID())
+			webhookExists, err := scm.FromContext(c).Update(ctx, u, repo, lastHook.GetWebhookID())
 			if err != nil {
 
 				// if webhook has been manually deleted from GitHub,

--- a/api/secret/create.go
+++ b/api/secret/create.go
@@ -118,7 +118,7 @@ func CreateSecret(c *gin.Context) {
 		// but Org/Repo != org/repo in Vela. So this check ensures that
 		// what a user inputs matches the casing we expect in Vela since
 		// the SCM will have the source of truth for casing.
-		org, err := scm.FromContext(c).GetOrgName(u, o)
+		org, err := scm.FromContext(c).GetOrgName(ctx, u, o)
 		if err != nil {
 			retErr := fmt.Errorf("unable to retrieve organization %s", o)
 
@@ -141,7 +141,7 @@ func CreateSecret(c *gin.Context) {
 		// retrieve org and repo name from SCM
 		//
 		// same story as org secret. SCM has accurate casing.
-		scmOrg, scmRepo, err := scm.FromContext(c).GetOrgAndRepoName(u, o, n)
+		scmOrg, scmRepo, err := scm.FromContext(c).GetOrgAndRepoName(ctx, u, o, n)
 		if err != nil {
 			retErr := fmt.Errorf("unable to retrieve repository %s/%s", o, n)
 

--- a/api/secret/list.go
+++ b/api/secret/list.go
@@ -106,7 +106,7 @@ func ListSecrets(c *gin.Context) {
 	if t == constants.SecretShared && n == "*" {
 		var err error
 
-		teams, err = scm.FromContext(c).ListUsersTeamsForOrg(u, o)
+		teams, err = scm.FromContext(c).ListUsersTeamsForOrg(ctx, u, o)
 		if err != nil {
 			retErr := fmt.Errorf("unable to list users %s teams for org %s: %w", u.GetName(), o, err)
 

--- a/api/user/get_source.go
+++ b/api/user/get_source.go
@@ -55,7 +55,7 @@ func GetSourceRepos(c *gin.Context) {
 	output := make(map[string][]library.Repo)
 
 	// send API call to capture the list of repos for the user
-	srcRepos, err := scm.FromContext(c).ListUserRepos(u)
+	srcRepos, err := scm.FromContext(c).ListUserRepos(ctx, u)
 	if err != nil {
 		retErr := fmt.Errorf("unable to get SCM repos for user %s: %w", u.GetName(), err)
 

--- a/cmd/vela-server/schedule.go
+++ b/cmd/vela-server/schedule.go
@@ -162,7 +162,7 @@ func processSchedule(ctx context.Context, s *library.Schedule, compiler compiler
 	}
 
 	// send API call to confirm repo owner has at least write access to repo
-	_, err = scm.RepoAccess(u, u.GetToken(), r.GetOrg(), r.GetName())
+	_, err = scm.RepoAccess(ctx, u, u.GetToken(), r.GetOrg(), r.GetName())
 	if err != nil {
 		return fmt.Errorf("%s does not have at least write access for repo %s", u.GetName(), r.GetFullName())
 	}
@@ -184,7 +184,7 @@ func processSchedule(ctx context.Context, s *library.Schedule, compiler compiler
 	}
 
 	// send API call to capture the commit sha for the branch
-	_, commit, err := scm.GetBranch(u, r, s.GetBranch())
+	_, commit, err := scm.GetBranch(ctx, u, r, s.GetBranch())
 	if err != nil {
 		return fmt.Errorf("failed to get commit for repo %s on %s branch: %w", r.GetFullName(), r.GetBranch(), err)
 	}
@@ -240,7 +240,7 @@ func processSchedule(ctx context.Context, s *library.Schedule, compiler compiler
 		pipeline, err = database.GetPipelineForRepo(context.TODO(), b.GetCommit(), r)
 		if err != nil { // assume the pipeline doesn't exist in the database yet
 			// send API call to capture the pipeline configuration file
-			config, err = scm.ConfigBackoff(u, r, b.GetCommit())
+			config, err = scm.ConfigBackoff(ctx, u, r, b.GetCommit())
 			if err != nil {
 				return fmt.Errorf("unable to get pipeline config for %s/%s: %w", r.GetFullName(), b.GetCommit(), err)
 			}

--- a/database/build/list_deployment.go
+++ b/database/build/list_deployment.go
@@ -27,7 +27,7 @@ func (e *engine) ListBuildsForDeployment(ctx context.Context, d *library.Deploym
 	builds := []*library.Build{}
 
 	// count the results
-	count, err := e.CountBuildsForDeployment(context.TODO(), d, filters)
+	count, err := e.CountBuildsForDeployment(ctx, d, filters)
 	if err != nil {
 		return builds, 0, err
 	}

--- a/database/pipeline/list_repo.go
+++ b/database/pipeline/list_repo.go
@@ -28,7 +28,7 @@ func (e *engine) ListPipelinesForRepo(ctx context.Context, r *library.Repo, page
 	pipelines := []*library.Pipeline{}
 
 	// count the results
-	count, err := e.CountPipelinesForRepo(context.TODO(), r)
+	count, err := e.CountPipelinesForRepo(ctx, r)
 	if err != nil {
 		return pipelines, 0, err
 	}

--- a/database/pipeline/pipeline.go
+++ b/database/pipeline/pipeline.go
@@ -53,7 +53,6 @@ func New(opts ...EngineOpt) (*engine, error) {
 	e.client = new(gorm.DB)
 	e.config = new(config)
 	e.logger = new(logrus.Entry)
-	e.ctx = context.TODO()
 
 	// apply all provided configuration options
 	for _, opt := range opts {

--- a/router/middleware/perm/perm.go
+++ b/router/middleware/perm/perm.go
@@ -188,6 +188,7 @@ func MustSecretAdmin() gin.HandlerFunc {
 		n := util.PathParameter(c, "name")
 		s := util.PathParameter(c, "secret")
 		m := c.Request.Method
+		ctx := c.Request.Context()
 
 		// create log fields from API metadata
 		fields := logrus.Fields{
@@ -262,7 +263,7 @@ func MustSecretAdmin() gin.HandlerFunc {
 		case constants.SecretOrg:
 			logger.Debugf("verifying user %s has 'admin' permissions for org %s", u.GetName(), o)
 
-			perm, err := scm.FromContext(c).OrgAccess(u, o)
+			perm, err := scm.FromContext(c).OrgAccess(ctx, u, o)
 			if err != nil {
 				logger.Errorf("unable to get user %s access level for org %s: %v", u.GetName(), o, err)
 			}
@@ -277,7 +278,7 @@ func MustSecretAdmin() gin.HandlerFunc {
 		case constants.SecretRepo:
 			logger.Debugf("verifying user %s has 'admin' permissions for repo %s/%s", u.GetName(), o, n)
 
-			perm, err := scm.FromContext(c).RepoAccess(u, u.GetToken(), o, n)
+			perm, err := scm.FromContext(c).RepoAccess(ctx, u, u.GetToken(), o, n)
 			if err != nil {
 				logger.Errorf("unable to get user %s access level for repo %s/%s: %v", u.GetName(), o, n, err)
 			}
@@ -303,7 +304,7 @@ func MustSecretAdmin() gin.HandlerFunc {
 
 				logger.Debugf("gathering teams user %s is a member of in the org %s", u.GetName(), o)
 
-				teams, err := scm.FromContext(c).ListUsersTeamsForOrg(u, o)
+				teams, err := scm.FromContext(c).ListUsersTeamsForOrg(ctx, u, o)
 				if err != nil {
 					logger.Errorf("unable to get users %s teams for org %s: %v", u.GetName(), o, err)
 				}
@@ -318,7 +319,7 @@ func MustSecretAdmin() gin.HandlerFunc {
 			} else {
 				logger.Debugf("verifying user %s has 'admin' permissions for team %s/%s", u.GetName(), o, n)
 
-				perm, err := scm.FromContext(c).TeamAccess(u, o, n)
+				perm, err := scm.FromContext(c).TeamAccess(ctx, u, o, n)
 				if err != nil {
 					logger.Errorf("unable to get user %s access level for team %s/%s: %v", u.GetName(), o, n, err)
 				}
@@ -366,7 +367,7 @@ func MustAdmin() gin.HandlerFunc {
 		}
 
 		// query source to determine requesters permissions for the repo using the requester's token
-		perm, err := scm.FromContext(c).RepoAccess(u, u.GetToken(), r.GetOrg(), r.GetName())
+		perm, err := scm.FromContext(c).RepoAccess(ctx, u, u.GetToken(), r.GetOrg(), r.GetName())
 		if err != nil {
 			// requester may not have permissions to use the Github API endpoint (requires read access)
 			// try again using the repo owner token
@@ -381,7 +382,7 @@ func MustAdmin() gin.HandlerFunc {
 				return
 			}
 
-			perm, err = scm.FromContext(c).RepoAccess(u, ro.GetToken(), r.GetOrg(), r.GetName())
+			perm, err = scm.FromContext(c).RepoAccess(ctx, u, ro.GetToken(), r.GetOrg(), r.GetName())
 			if err != nil {
 				logger.Errorf("unable to get user %s access level for repo %s", u.GetName(), r.GetFullName())
 			}
@@ -425,7 +426,7 @@ func MustWrite() gin.HandlerFunc {
 		}
 
 		// query source to determine requesters permissions for the repo using the requester's token
-		perm, err := scm.FromContext(c).RepoAccess(u, u.GetToken(), r.GetOrg(), r.GetName())
+		perm, err := scm.FromContext(c).RepoAccess(ctx, u, u.GetToken(), r.GetOrg(), r.GetName())
 		if err != nil {
 			// requester may not have permissions to use the Github API endpoint (requires read access)
 			// try again using the repo owner token
@@ -440,7 +441,7 @@ func MustWrite() gin.HandlerFunc {
 				return
 			}
 
-			perm, err = scm.FromContext(c).RepoAccess(u, ro.GetToken(), r.GetOrg(), r.GetName())
+			perm, err = scm.FromContext(c).RepoAccess(ctx, u, ro.GetToken(), r.GetOrg(), r.GetName())
 			if err != nil {
 				logger.Errorf("unable to get user %s access level for repo %s", u.GetName(), r.GetFullName())
 			}
@@ -508,7 +509,7 @@ func MustRead() gin.HandlerFunc {
 		}
 
 		// query source to determine requesters permissions for the repo using the requester's token
-		perm, err := scm.FromContext(c).RepoAccess(u, u.GetToken(), r.GetOrg(), r.GetName())
+		perm, err := scm.FromContext(c).RepoAccess(ctx, u, u.GetToken(), r.GetOrg(), r.GetName())
 		if err != nil {
 			// requester may not have permissions to use the Github API endpoint (requires read access)
 			// try again using the repo owner token
@@ -523,7 +524,7 @@ func MustRead() gin.HandlerFunc {
 				return
 			}
 
-			perm, err = scm.FromContext(c).RepoAccess(u, ro.GetToken(), r.GetOrg(), r.GetName())
+			perm, err = scm.FromContext(c).RepoAccess(ctx, u, ro.GetToken(), r.GetOrg(), r.GetName())
 			if err != nil {
 				logger.Errorf("unable to get user %s access level for repo %s", u.GetName(), r.GetFullName())
 			}

--- a/router/middleware/pipeline/pipeline.go
+++ b/router/middleware/pipeline/pipeline.go
@@ -66,7 +66,7 @@ func Establish() gin.HandlerFunc {
 		pipeline, err := database.FromContext(c).GetPipelineForRepo(ctx, p, r)
 		if err != nil { // assume the pipeline doesn't exist in the database yet (before pipeline support was added)
 			// send API call to capture the pipeline configuration file
-			config, err := scm.FromContext(c).ConfigBackoff(u, r, p)
+			config, err := scm.FromContext(c).ConfigBackoff(ctx, u, r, p)
 			if err != nil {
 				retErr := fmt.Errorf("unable to get pipeline configuration for %s: %w", entry, err)
 

--- a/scm/github/access.go
+++ b/scm/github/access.go
@@ -5,6 +5,7 @@
 package github
 
 import (
+	"context"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -14,7 +15,7 @@ import (
 )
 
 // OrgAccess captures the user's access level for an org.
-func (c *client) OrgAccess(u *library.User, org string) (string, error) {
+func (c *client) OrgAccess(ctx context.Context, u *library.User, org string) (string, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  org,
 		"user": u.GetName(),
@@ -49,7 +50,7 @@ func (c *client) OrgAccess(u *library.User, org string) (string, error) {
 }
 
 // RepoAccess captures the user's access level for a repo.
-func (c *client) RepoAccess(u *library.User, token, org, repo string) (string, error) {
+func (c *client) RepoAccess(ctx context.Context, u *library.User, token, org, repo string) (string, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  org,
 		"repo": repo,
@@ -80,7 +81,7 @@ func (c *client) RepoAccess(u *library.User, token, org, repo string) (string, e
 }
 
 // TeamAccess captures the user's access level for a team.
-func (c *client) TeamAccess(u *library.User, org, team string) (string, error) {
+func (c *client) TeamAccess(ctx context.Context, u *library.User, org, team string) (string, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  org,
 		"team": team,
@@ -142,7 +143,7 @@ func (c *client) TeamAccess(u *library.User, org, team string) (string, error) {
 }
 
 // ListUsersTeamsForOrg captures the user's teams for an org.
-func (c *client) ListUsersTeamsForOrg(u *library.User, org string) ([]string, error) {
+func (c *client) ListUsersTeamsForOrg(ctx context.Context, u *library.User, org string) ([]string, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  org,
 		"user": u.GetName(),

--- a/scm/github/access_test.go
+++ b/scm/github/access_test.go
@@ -5,6 +5,7 @@
 package github
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -42,7 +43,7 @@ func TestGithub_OrgAccess_Admin(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.OrgAccess(u, "github")
+	got, err := client.OrgAccess(context.TODO(), u, "github")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("OrgAccess returned %v, want %v", resp.Code, http.StatusOK)
@@ -84,7 +85,7 @@ func TestGithub_OrgAccess_Member(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.OrgAccess(u, "github")
+	got, err := client.OrgAccess(context.TODO(), u, "github")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("OrgAccess returned %v, want %v", resp.Code, http.StatusOK)
@@ -114,7 +115,7 @@ func TestGithub_OrgAccess_NotFound(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.OrgAccess(u, "github")
+	got, err := client.OrgAccess(context.TODO(), u, "github")
 
 	if err == nil {
 		t.Errorf("OrgAccess should have returned err")
@@ -152,7 +153,7 @@ func TestGithub_OrgAccess_Pending(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.OrgAccess(u, "github")
+	got, err := client.OrgAccess(context.TODO(), u, "github")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("OrgAccess returned %v, want %v", resp.Code, http.StatusOK)
@@ -182,7 +183,7 @@ func TestGithub_OrgAccess_Personal(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.OrgAccess(u, "foo")
+	got, err := client.OrgAccess(context.TODO(), u, "foo")
 
 	if err != nil {
 		t.Errorf("OrgAccess returned err: %v", err)
@@ -220,7 +221,7 @@ func TestGithub_RepoAccess_Admin(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.RepoAccess(u, u.GetToken(), "github", "octocat")
+	got, err := client.RepoAccess(context.TODO(), u, u.GetToken(), "github", "octocat")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("RepoAccess returned %v, want %v", resp.Code, http.StatusOK)
@@ -250,7 +251,7 @@ func TestGithub_RepoAccess_NotFound(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.RepoAccess(u, u.GetToken(), "github", "octocat")
+	got, err := client.RepoAccess(context.TODO(), u, u.GetToken(), "github", "octocat")
 
 	if err == nil {
 		t.Errorf("RepoAccess should have returned err")
@@ -288,7 +289,7 @@ func TestGithub_TeamAccess_Admin(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.TeamAccess(u, "github", "octocat")
+	got, err := client.TeamAccess(context.TODO(), u, "github", "octocat")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("TeamAccess returned %v, want %v", resp.Code, http.StatusOK)
@@ -330,7 +331,7 @@ func TestGithub_TeamAccess_NoAccess(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.TeamAccess(u, "github", "baz")
+	got, err := client.TeamAccess(context.TODO(), u, "github", "baz")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("TeamAccess returned %v, want %v", resp.Code, http.StatusOK)
@@ -360,7 +361,7 @@ func TestGithub_TeamAccess_NotFound(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.TeamAccess(u, "github", "octocat")
+	got, err := client.TeamAccess(context.TODO(), u, "github", "octocat")
 
 	if err == nil {
 		t.Errorf("TeamAccess should have returned err")
@@ -398,7 +399,7 @@ func TestGithub_TeamList(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.ListUsersTeamsForOrg(u, "github")
+	got, err := client.ListUsersTeamsForOrg(context.TODO(), u, "github")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("TeamAccess returned %v, want %v", resp.Code, http.StatusOK)

--- a/scm/github/authentication.go
+++ b/scm/github/authentication.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Authorize uses the given access token to authorize the user.
-func (c *client) Authorize(token string) (string, error) {
+func (c *client) Authorize(ctx context.Context, token string) (string, error) {
 	c.Logger.Trace("authorizing user with token")
 
 	// create GitHub OAuth client with user's token
@@ -34,7 +34,7 @@ func (c *client) Authorize(token string) (string, error) {
 }
 
 // Login begins the authentication workflow for the session.
-func (c *client) Login(w http.ResponseWriter, r *http.Request) (string, error) {
+func (c *client) Login(ctx context.Context, w http.ResponseWriter, r *http.Request) (string, error) {
 	c.Logger.Trace("processing login request")
 
 	// generate a random string for creating the OAuth state
@@ -57,7 +57,7 @@ func (c *client) Login(w http.ResponseWriter, r *http.Request) (string, error) {
 
 // Authenticate completes the authentication workflow for the session
 // and returns the remote user details.
-func (c *client) Authenticate(w http.ResponseWriter, r *http.Request, oAuthState string) (*library.User, error) {
+func (c *client) Authenticate(ctx context.Context, w http.ResponseWriter, r *http.Request, oAuthState string) (*library.User, error) {
 	c.Logger.Trace("authenticating user")
 
 	// get the OAuth code
@@ -85,7 +85,7 @@ func (c *client) Authenticate(w http.ResponseWriter, r *http.Request, oAuthState
 	}
 
 	// authorize the user for the token
-	u, err := c.Authorize(token.AccessToken)
+	u, err := c.Authorize(ctx, token.AccessToken)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (c *client) Authenticate(w http.ResponseWriter, r *http.Request, oAuthState
 
 // AuthenticateToken completes the authentication workflow
 // for the session and returns the remote user details.
-func (c *client) AuthenticateToken(r *http.Request) (*library.User, error) {
+func (c *client) AuthenticateToken(ctx context.Context, r *http.Request) (*library.User, error) {
 	c.Logger.Trace("authenticating user via token")
 
 	token := r.Header.Get("Token")
@@ -151,7 +151,7 @@ func (c *client) AuthenticateToken(r *http.Request) (*library.User, error) {
 		return nil, errors.New("token must not be created by vela")
 	}
 
-	u, err := c.Authorize(token)
+	u, err := c.Authorize(ctx, token)
 	if err != nil {
 		return nil, err
 	}

--- a/scm/github/authentication_test.go
+++ b/scm/github/authentication_test.go
@@ -10,6 +10,8 @@ import (
 	"reflect"
 	"testing"
 
+	_context "context"
+
 	"github.com/gin-gonic/gin"
 	"github.com/go-vela/types/library"
 )
@@ -45,7 +47,7 @@ func TestGithub_Authenticate(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Authenticate(context.Writer, context.Request, "bar")
+	got, err := client.Authenticate(_context.TODO(), context.Writer, context.Request, "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Authenticate returned %v, want %v", resp.Code, http.StatusOK)
@@ -80,7 +82,7 @@ func TestGithub_Authenticate_NoCode(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Authenticate(context.Writer, context.Request, "bar")
+	got, err := client.Authenticate(_context.TODO(), context.Writer, context.Request, "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Authenticate returned %v, want %v", resp.Code, http.StatusOK)
@@ -115,7 +117,7 @@ func TestGithub_Authenticate_NoState(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Authenticate(context.Writer, context.Request, "bar")
+	got, err := client.Authenticate(_context.TODO(), context.Writer, context.Request, "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Authenticate returned %v, want %v", resp.Code, http.StatusOK)
@@ -150,7 +152,7 @@ func TestGithub_Authenticate_BadToken(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Authenticate(context.Writer, context.Request, "bar")
+	got, err := client.Authenticate(_context.TODO(), context.Writer, context.Request, "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Authenticate returned %v, want %v", resp.Code, http.StatusOK)
@@ -190,7 +192,7 @@ func TestGithub_Authenticate_NotFound(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Authenticate(context.Writer, context.Request, "bar")
+	got, err := client.Authenticate(_context.TODO(), context.Writer, context.Request, "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Authenticate returned %v, want %v", resp.Code, http.StatusOK)
@@ -227,7 +229,7 @@ func TestGithub_Authorize(t *testing.T) {
 
 	// run test
 	want := "octocat"
-	got, err := client.Authorize("foobar")
+	got, err := client.Authorize(_context.TODO(), "foobar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Authorize returned %v, want %v", resp.Code, http.StatusOK)
@@ -261,7 +263,7 @@ func TestGithub_Authorize_NotFound(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Authorize("foobar")
+	got, err := client.Authorize(_context.TODO(), "foobar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Authorize returned %v, want %v", resp.Code, http.StatusOK)
@@ -296,7 +298,7 @@ func TestGithub_Login(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	_, err := client.Login(context.Writer, context.Request)
+	_, err := client.Login(_context.TODO(), context.Writer, context.Request)
 
 	if resp.Code != http.StatusTemporaryRedirect {
 		t.Errorf("Login returned %v, want %v", resp.Code, http.StatusTemporaryRedirect)
@@ -333,7 +335,7 @@ func TestGithub_AuthenticateToken(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.AuthenticateToken(context.Request)
+	got, err := client.AuthenticateToken(_context.TODO(), context.Request)
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Authenticate returned %v, want %v", resp.Code, http.StatusOK)
@@ -369,7 +371,7 @@ func TestGithub_AuthenticateToken_Invalid(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.AuthenticateToken(context.Request)
+	got, err := client.AuthenticateToken(_context.TODO(), context.Request)
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Authenticate returned %v, want %v", resp.Code, http.StatusOK)
@@ -410,7 +412,7 @@ func TestGithub_AuthenticateToken_Vela_OAuth(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	_, err := client.AuthenticateToken(context.Request)
+	_, err := client.AuthenticateToken(_context.TODO(), context.Request)
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("AuthenticateToken returned %v, want %v", resp.Code, http.StatusOK)
@@ -441,7 +443,7 @@ func TestGithub_LoginWCreds(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	_, err := client.Login(context.Writer, context.Request)
+	_, err := client.Login(_context.TODO(), context.Writer, context.Request)
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Enable returned %v, want %v", resp.Code, http.StatusOK)

--- a/scm/github/changeset.go
+++ b/scm/github/changeset.go
@@ -5,6 +5,7 @@
 package github
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -14,7 +15,7 @@ import (
 )
 
 // Changeset captures the list of files changed for a commit.
-func (c *client) Changeset(u *library.User, r *library.Repo, sha string) ([]string, error) {
+func (c *client) Changeset(ctx context.Context, u *library.User, r *library.Repo, sha string) ([]string, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),
@@ -43,7 +44,7 @@ func (c *client) Changeset(u *library.User, r *library.Repo, sha string) ([]stri
 }
 
 // ChangesetPR captures the list of files changed for a pull request.
-func (c *client) ChangesetPR(u *library.User, r *library.Repo, number int) ([]string, error) {
+func (c *client) ChangesetPR(ctx context.Context, u *library.User, r *library.Repo, number int) ([]string, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),

--- a/scm/github/changeset_test.go
+++ b/scm/github/changeset_test.go
@@ -5,6 +5,7 @@
 package github
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -46,7 +47,7 @@ func TestGithub_Changeset(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Changeset(u, r, "6dcb09b5b57875f334f61aebed695e2e4193db5e")
+	got, err := client.Changeset(context.TODO(), u, r, "6dcb09b5b57875f334f61aebed695e2e4193db5e")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Changeset returned %v, want %v", resp.Code, http.StatusOK)
@@ -92,7 +93,7 @@ func TestGithub_ChangesetPR(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.ChangesetPR(u, r, 1)
+	got, err := client.ChangesetPR(context.TODO(), u, r, 1)
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("ChangesetPR returned %v, want %v", resp.Code, http.StatusOK)

--- a/scm/github/deployment.go
+++ b/scm/github/deployment.go
@@ -5,6 +5,7 @@
 package github
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/sirupsen/logrus"
@@ -15,7 +16,7 @@ import (
 )
 
 // GetDeployment gets a deployment from the GitHub repo.
-func (c *client) GetDeployment(u *library.User, r *library.Repo, id int64) (*library.Deployment, error) {
+func (c *client) GetDeployment(ctx context.Context, u *library.User, r *library.Repo, id int64) (*library.Deployment, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),
@@ -53,7 +54,7 @@ func (c *client) GetDeployment(u *library.User, r *library.Repo, id int64) (*lib
 }
 
 // GetDeploymentCount counts a list of deployments from the GitHub repo.
-func (c *client) GetDeploymentCount(u *library.User, r *library.Repo) (int64, error) {
+func (c *client) GetDeploymentCount(ctx context.Context, u *library.User, r *library.Repo) (int64, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),
@@ -95,7 +96,7 @@ func (c *client) GetDeploymentCount(u *library.User, r *library.Repo) (int64, er
 }
 
 // GetDeploymentList gets a list of deployments from the GitHub repo.
-func (c *client) GetDeploymentList(u *library.User, r *library.Repo, page, perPage int) ([]*library.Deployment, error) {
+func (c *client) GetDeploymentList(ctx context.Context, u *library.User, r *library.Repo, page, perPage int) ([]*library.Deployment, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),
@@ -149,7 +150,7 @@ func (c *client) GetDeploymentList(u *library.User, r *library.Repo, page, perPa
 }
 
 // CreateDeployment creates a new deployment for the GitHub repo.
-func (c *client) CreateDeployment(u *library.User, r *library.Repo, d *library.Deployment) error {
+func (c *client) CreateDeployment(ctx context.Context, u *library.User, r *library.Repo, d *library.Deployment) error {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),

--- a/scm/github/deployment_test.go
+++ b/scm/github/deployment_test.go
@@ -5,6 +5,7 @@
 package github
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -59,7 +60,7 @@ func TestGithub_CreateDeployment(t *testing.T) {
 	client, _ := NewTest(s.URL, "https://foo.bar.com")
 
 	// run test
-	err := client.CreateDeployment(u, r, d)
+	err := client.CreateDeployment(context.TODO(), u, r, d)
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("CreateDeployment returned %v, want %v", resp.Code, http.StatusOK)
@@ -113,7 +114,7 @@ func TestGithub_GetDeployment(t *testing.T) {
 	client, _ := NewTest(s.URL, "https://foo.bar.com")
 
 	// run test
-	got, err := client.GetDeployment(u, r, 1)
+	got, err := client.GetDeployment(context.TODO(), u, r, 1)
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("GetDeployment returned %v, want %v", resp.Code, http.StatusOK)
@@ -161,7 +162,7 @@ func TestGithub_GetDeploymentCount(t *testing.T) {
 	client, _ := NewTest(s.URL, "https://foo.bar.com")
 
 	// run test
-	got, err := client.GetDeploymentCount(u, r)
+	got, err := client.GetDeploymentCount(context.TODO(), u, r)
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("GetDeployment returned %v, want %v", resp.Code, http.StatusOK)
@@ -233,7 +234,7 @@ func TestGithub_GetDeploymentList(t *testing.T) {
 	client, _ := NewTest(s.URL, "https://foo.bar.com")
 
 	// run test
-	got, err := client.GetDeploymentList(u, r, 1, 100)
+	got, err := client.GetDeploymentList(context.TODO(), u, r, 1, 100)
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("GetDeployment returned %v, want %v", resp.Code, http.StatusOK)

--- a/scm/github/github.go
+++ b/scm/github/github.go
@@ -28,8 +28,6 @@ const (
 	eventInitialize   = "initialize"
 )
 
-var ctx = context.Background()
-
 type config struct {
 	// specifies the address to use for the GitHub client
 	Address string

--- a/scm/github/org.go
+++ b/scm/github/org.go
@@ -5,6 +5,7 @@
 package github
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
@@ -13,7 +14,7 @@ import (
 )
 
 // GetOrgName gets org name from Github.
-func (c *client) GetOrgName(u *library.User, o string) (string, error) {
+func (c *client) GetOrgName(ctx context.Context, u *library.User, o string) (string, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  o,
 		"user": u.GetName(),

--- a/scm/github/org_test.go
+++ b/scm/github/org_test.go
@@ -5,6 +5,7 @@
 package github
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -42,7 +43,7 @@ func TestGithub_GetOrgName(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.GetOrgName(u, "github")
+	got, err := client.GetOrgName(context.TODO(), u, "github")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("GetOrgName returned %v, want %v", resp.Code, http.StatusOK)
@@ -84,7 +85,7 @@ func TestGithub_GetOrgName_Personal(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.GetOrgName(u, "octocat")
+	got, err := client.GetOrgName(context.TODO(), u, "octocat")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("GetOrgName returned %v, want %v", resp.Code, http.StatusOK)
@@ -123,7 +124,7 @@ func TestGithub_GetOrgName_Fail(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	_, err := client.GetOrgName(u, "octocat")
+	_, err := client.GetOrgName(context.TODO(), u, "octocat")
 
 	if err == nil {
 		t.Error("GetOrgName should return error")

--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -5,6 +5,7 @@
 package github
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -20,14 +21,14 @@ import (
 
 // ConfigBackoff is a wrapper for Config that will retry five times if the function
 // fails to retrieve the yaml/yml file.
-func (c *client) ConfigBackoff(u *library.User, r *library.Repo, ref string) (data []byte, err error) {
+func (c *client) ConfigBackoff(ctx context.Context, u *library.User, r *library.Repo, ref string) (data []byte, err error) {
 	// number of times to retry
 	retryLimit := 5
 
 	for i := 0; i < retryLimit; i++ {
 		logrus.Debugf("Fetching config file - Attempt %d", i+1)
 		// attempt to fetch the config
-		data, err = c.Config(u, r, ref)
+		data, err = c.Config(ctx, u, r, ref)
 
 		// return err if the last attempt returns error
 		if err != nil && i == retryLimit-1 {
@@ -48,7 +49,7 @@ func (c *client) ConfigBackoff(u *library.User, r *library.Repo, ref string) (da
 }
 
 // Config gets the pipeline configuration from the GitHub repo.
-func (c *client) Config(u *library.User, r *library.Repo, ref string) ([]byte, error) {
+func (c *client) Config(ctx context.Context, u *library.User, r *library.Repo, ref string) ([]byte, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),
@@ -93,7 +94,7 @@ func (c *client) Config(u *library.User, r *library.Repo, ref string) ([]byte, e
 }
 
 // Disable deactivates a repo by deleting the webhook.
-func (c *client) Disable(u *library.User, org, name string) error {
+func (c *client) Disable(ctx context.Context, u *library.User, org, name string) error {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  org,
 		"repo": name,
@@ -151,7 +152,7 @@ func (c *client) Disable(u *library.User, org, name string) error {
 }
 
 // Enable activates a repo by creating the webhook.
-func (c *client) Enable(u *library.User, r *library.Repo, h *library.Hook) (*library.Hook, string, error) {
+func (c *client) Enable(ctx context.Context, u *library.User, r *library.Repo, h *library.Hook) (*library.Hook, string, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),
@@ -217,7 +218,7 @@ func (c *client) Enable(u *library.User, r *library.Repo, h *library.Hook) (*lib
 }
 
 // Update edits a repo webhook.
-func (c *client) Update(u *library.User, r *library.Repo, hookID int64) (bool, error) {
+func (c *client) Update(ctx context.Context, u *library.User, r *library.Repo, hookID int64) (bool, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),
@@ -266,7 +267,7 @@ func (c *client) Update(u *library.User, r *library.Repo, hookID int64) (bool, e
 }
 
 // Status sends the commit status for the given SHA from the GitHub repo.
-func (c *client) Status(u *library.User, b *library.Build, org, name string) error {
+func (c *client) Status(ctx context.Context, u *library.User, b *library.Build, org, name string) error {
 	c.Logger.WithFields(logrus.Fields{
 		"build": b.GetNumber(),
 		"org":   org,
@@ -368,7 +369,7 @@ func (c *client) Status(u *library.User, b *library.Build, org, name string) err
 }
 
 // GetRepo gets repo information from Github.
-func (c *client) GetRepo(u *library.User, r *library.Repo) (*library.Repo, error) {
+func (c *client) GetRepo(ctx context.Context, u *library.User, r *library.Repo) (*library.Repo, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),
@@ -388,7 +389,7 @@ func (c *client) GetRepo(u *library.User, r *library.Repo) (*library.Repo, error
 }
 
 // GetOrgAndRepoName returns the name of the org and the repository in the SCM.
-func (c *client) GetOrgAndRepoName(u *library.User, o string, r string) (string, string, error) {
+func (c *client) GetOrgAndRepoName(ctx context.Context, u *library.User, o string, r string) (string, string, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  o,
 		"repo": r,
@@ -408,7 +409,7 @@ func (c *client) GetOrgAndRepoName(u *library.User, o string, r string) (string,
 }
 
 // ListUserRepos returns a list of all repos the user has access to.
-func (c *client) ListUserRepos(u *library.User) ([]*library.Repo, error) {
+func (c *client) ListUserRepos(ctx context.Context, u *library.User) ([]*library.Repo, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"user": u.GetName(),
 	}).Tracef("listing source repositories for %s", u.GetName())
@@ -486,7 +487,7 @@ func toLibraryRepo(gr github.Repository) *library.Repo {
 
 // GetPullRequest defines a function that retrieves
 // a pull request for a repo.
-func (c *client) GetPullRequest(u *library.User, r *library.Repo, number int) (string, string, string, string, error) {
+func (c *client) GetPullRequest(ctx context.Context, u *library.User, r *library.Repo, number int) (string, string, string, string, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),
@@ -510,7 +511,7 @@ func (c *client) GetPullRequest(u *library.User, r *library.Repo, number int) (s
 }
 
 // GetHTMLURL retrieves the html_url from repository contents from the GitHub repo.
-func (c *client) GetHTMLURL(u *library.User, org, repo, name, ref string) (string, error) {
+func (c *client) GetHTMLURL(ctx context.Context, u *library.User, org, repo, name, ref string) (string, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  org,
 		"repo": repo,
@@ -546,7 +547,7 @@ func (c *client) GetHTMLURL(u *library.User, org, repo, name, ref string) (strin
 }
 
 // GetBranch defines a function that retrieves a branch for a repo.
-func (c *client) GetBranch(u *library.User, r *library.Repo, branch string) (string, string, error) {
+func (c *client) GetBranch(ctx context.Context, u *library.User, r *library.Repo, branch string) (string, string, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),

--- a/scm/github/repo_test.go
+++ b/scm/github/repo_test.go
@@ -5,6 +5,7 @@
 package github
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -58,7 +59,7 @@ func TestGithub_Config_YML(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Config(u, r, "")
+	got, err := client.Config(context.TODO(), u, r, "")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Config returned %v, want %v", resp.Code, http.StatusOK)
@@ -112,7 +113,7 @@ func TestGithub_ConfigBackoff_YML(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Config(u, r, "")
+	got, err := client.Config(context.TODO(), u, r, "")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Config returned %v, want %v", resp.Code, http.StatusOK)
@@ -154,7 +155,7 @@ func TestGithub_Config_YML_BadRequest(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Config(u, r, "")
+	got, err := client.Config(context.TODO(), u, r, "")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Config returned %v, want %v", resp.Code, http.StatusOK)
@@ -208,7 +209,7 @@ func TestGithub_Config_YAML(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Config(u, r, "")
+	got, err := client.Config(context.TODO(), u, r, "")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Config returned %v, want %v", resp.Code, http.StatusOK)
@@ -263,7 +264,7 @@ func TestGithub_Config_Star(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Config(u, r, "")
+	got, err := client.Config(context.TODO(), u, r, "")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Config returned %v, want %v", resp.Code, http.StatusOK)
@@ -318,7 +319,7 @@ func TestGithub_Config_Py(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Config(u, r, "")
+	got, err := client.Config(context.TODO(), u, r, "")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Config returned %v, want %v", resp.Code, http.StatusOK)
@@ -365,7 +366,7 @@ func TestGithub_Config_YAML_BadRequest(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Config(u, r, "")
+	got, err := client.Config(context.TODO(), u, r, "")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Config returned %v, want %v", resp.Code, http.StatusOK)
@@ -407,7 +408,7 @@ func TestGithub_Config_NotFound(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Config(u, r, "")
+	got, err := client.Config(context.TODO(), u, r, "")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Config returned %v, want %v", resp.Code, http.StatusOK)
@@ -450,7 +451,7 @@ func TestGithub_Disable(t *testing.T) {
 	client, _ := NewTest(s.URL, "https://foo.bar.com")
 
 	// run test
-	err := client.Disable(u, "foo", "bar")
+	err := client.Disable(context.TODO(), u, "foo", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Disable returned %v, want %v", resp.Code, http.StatusOK)
@@ -484,7 +485,7 @@ func TestGithub_Disable_NotFoundHooks(t *testing.T) {
 	client, _ := NewTest(s.URL, "https://foo.bar.com")
 
 	// run test
-	err := client.Disable(u, "foo", "bar")
+	err := client.Disable(context.TODO(), u, "foo", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Disable returned %v, want %v", resp.Code, http.StatusOK)
@@ -523,7 +524,7 @@ func TestGithub_Disable_HooksButNotFound(t *testing.T) {
 	client, _ := NewTest(s.URL, "https://foos.ball.com")
 
 	// run test
-	err := client.Disable(u, "foo", "bar")
+	err := client.Disable(context.TODO(), u, "foo", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Disable returned %v, want %v", resp.Code, http.StatusOK)
@@ -565,7 +566,7 @@ func TestGithub_Disable_MultipleHooks(t *testing.T) {
 	client, _ := NewTest(s.URL, "https://foo.bar.com")
 
 	// run test
-	err := client.Disable(u, "foo", "bar")
+	err := client.Disable(context.TODO(), u, "foo", "bar")
 
 	if count != wantCount {
 		t.Errorf("Count returned %d, want %d", count, wantCount)
@@ -622,7 +623,7 @@ func TestGithub_Enable(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, _, err := client.Enable(u, r, new(library.Hook))
+	got, _, err := client.Enable(context.TODO(), u, r, new(library.Hook))
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Enable returned %v, want %v", resp.Code, http.StatusOK)
@@ -673,7 +674,7 @@ func TestGithub_Update(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	_, err := client.Update(u, r, hookID)
+	_, err := client.Update(context.TODO(), u, r, hookID)
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Update returned %v, want %v", resp.Code, http.StatusOK)
@@ -710,7 +711,7 @@ func TestGithub_Update_webhookExists_True(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	webhookExists, err := client.Update(u, r, 0)
+	webhookExists, err := client.Update(context.TODO(), u, r, 0)
 
 	if !webhookExists {
 		t.Errorf("Update returned %v, want %v", webhookExists, true)
@@ -747,7 +748,7 @@ func TestGithub_Update_webhookExists_False(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	webhookExists, err := client.Update(u, r, 0)
+	webhookExists, err := client.Update(context.TODO(), u, r, 0)
 
 	if webhookExists {
 		t.Errorf("Update returned %v, want %v", webhookExists, false)
@@ -792,7 +793,7 @@ func TestGithub_Status_Deployment(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	err := client.Status(u, b, "foo", "bar")
+	err := client.Status(context.TODO(), u, b, "foo", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -836,7 +837,7 @@ func TestGithub_Status_Running(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	err := client.Status(u, b, "foo", "bar")
+	err := client.Status(context.TODO(), u, b, "foo", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -880,7 +881,7 @@ func TestGithub_Status_Success(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	err := client.Status(u, b, "foo", "bar")
+	err := client.Status(context.TODO(), u, b, "foo", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -924,7 +925,7 @@ func TestGithub_Status_Failure(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	err := client.Status(u, b, "foo", "bar")
+	err := client.Status(context.TODO(), u, b, "foo", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -968,7 +969,7 @@ func TestGithub_Status_Killed(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	err := client.Status(u, b, "foo", "bar")
+	err := client.Status(context.TODO(), u, b, "foo", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -1012,7 +1013,7 @@ func TestGithub_Status_Skipped(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	err := client.Status(u, b, "foo", "bar")
+	err := client.Status(context.TODO(), u, b, "foo", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -1056,7 +1057,7 @@ func TestGithub_Status_Error(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	err := client.Status(u, b, "foo", "bar")
+	err := client.Status(context.TODO(), u, b, "foo", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -1107,7 +1108,7 @@ func TestGithub_GetRepo(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.GetRepo(u, r)
+	got, err := client.GetRepo(context.TODO(), u, r)
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("GetRepo returned %v, want %v", resp.Code, http.StatusOK)
@@ -1150,7 +1151,7 @@ func TestGithub_GetRepo_Fail(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	_, err := client.GetRepo(u, r)
+	_, err := client.GetRepo(context.TODO(), u, r)
 
 	if err == nil {
 		t.Error("GetRepo should return error")
@@ -1185,7 +1186,7 @@ func TestGithub_GetOrgAndRepoName(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	gotOrg, gotRepo, err := client.GetOrgAndRepoName(u, "octocat", "Hello-World")
+	gotOrg, gotRepo, err := client.GetOrgAndRepoName(context.TODO(), u, "octocat", "Hello-World")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("GetRepoName returned %v, want %v", resp.Code, http.StatusOK)
@@ -1228,7 +1229,7 @@ func TestGithub_GetOrgAndRepoName_Fail(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	_, _, err := client.GetOrgAndRepoName(u, "octocat", "Hello-World")
+	_, _, err := client.GetOrgAndRepoName(context.TODO(), u, "octocat", "Hello-World")
 
 	if err == nil {
 		t.Error("GetRepoName should return error")
@@ -1273,7 +1274,7 @@ func TestGithub_ListUserRepos(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.ListUserRepos(u)
+	got, err := client.ListUserRepos(context.TODO(), u)
 
 	if err != nil {
 		t.Errorf("Status returned err: %v", err)
@@ -1311,7 +1312,7 @@ func TestGithub_ListUserRepos_Ineligible(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.ListUserRepos(u)
+	got, err := client.ListUserRepos(context.TODO(), u)
 
 	if err != nil {
 		t.Errorf("Status returned err: %v", err)
@@ -1356,7 +1357,7 @@ func TestGithub_GetPullRequest(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	gotCommit, gotBranch, gotBaseRef, gotHeadRef, err := client.GetPullRequest(u, r, 1)
+	gotCommit, gotBranch, gotBaseRef, gotHeadRef, err := client.GetPullRequest(context.TODO(), u, r, 1)
 
 	if err != nil {
 		t.Errorf("Status returned err: %v", err)
@@ -1413,7 +1414,7 @@ func TestGithub_GetBranch(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	gotBranch, gotCommit, err := client.GetBranch(u, r, "main")
+	gotBranch, gotCommit, err := client.GetBranch(context.TODO(), u, r, "main")
 
 	if err != nil {
 		t.Errorf("Status returned err: %v", err)

--- a/scm/github/webhook.go
+++ b/scm/github/webhook.go
@@ -26,7 +26,7 @@ import (
 // ProcessWebhook parses the webhook from a repo.
 //
 //nolint:nilerr // ignore webhook returning nil
-func (c *client) ProcessWebhook(request *http.Request) (*types.Webhook, error) {
+func (c *client) ProcessWebhook(ctx context.Context, request *http.Request) (*types.Webhook, error) {
 	c.Logger.Tracef("processing GitHub webhook")
 
 	// create our own record of the hook and populate its fields
@@ -85,7 +85,7 @@ func (c *client) ProcessWebhook(request *http.Request) (*types.Webhook, error) {
 }
 
 // VerifyWebhook verifies the webhook from a repo.
-func (c *client) VerifyWebhook(request *http.Request, r *library.Repo) error {
+func (c *client) VerifyWebhook(ctx context.Context, request *http.Request, r *library.Repo) error {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),

--- a/scm/github/webhook_test.go
+++ b/scm/github/webhook_test.go
@@ -89,7 +89,7 @@ func TestGithub_ProcessWebhook_Push(t *testing.T) {
 		Build:   wantBuild,
 	}
 
-	got, err := client.ProcessWebhook(request)
+	got, err := client.ProcessWebhook(context.TODO(), request)
 
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
@@ -168,7 +168,7 @@ func TestGithub_ProcessWebhook_Push_NoSender(t *testing.T) {
 		Build:   wantBuild,
 	}
 
-	got, err := client.ProcessWebhook(request)
+	got, err := client.ProcessWebhook(context.TODO(), request)
 
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
@@ -250,7 +250,7 @@ func TestGithub_ProcessWebhook_PullRequest(t *testing.T) {
 		Build:    wantBuild,
 	}
 
-	got, err := client.ProcessWebhook(request)
+	got, err := client.ProcessWebhook(context.TODO(), request)
 
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
@@ -305,7 +305,7 @@ func TestGithub_ProcessWebhook_PullRequest_ClosedAction(t *testing.T) {
 		Build:   nil,
 	}
 
-	got, err := client.ProcessWebhook(request)
+	got, err := client.ProcessWebhook(context.TODO(), request)
 
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
@@ -360,7 +360,7 @@ func TestGithub_ProcessWebhook_PullRequest_ClosedState(t *testing.T) {
 		Build:   nil,
 	}
 
-	got, err := client.ProcessWebhook(request)
+	got, err := client.ProcessWebhook(context.TODO(), request)
 
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
@@ -457,7 +457,7 @@ func TestGithub_ProcessWebhook_Deployment(t *testing.T) {
 				Build:   tt.args.build,
 			}
 
-			got, err := client.ProcessWebhook(request)
+			got, err := client.ProcessWebhook(context.TODO(), request)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ProcessWebhook() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -538,7 +538,7 @@ func TestGithub_ProcessWebhook_Deployment_Commit(t *testing.T) {
 		Build:   wantBuild,
 	}
 
-	got, err := client.ProcessWebhook(request)
+	got, err := client.ProcessWebhook(context.TODO(), request)
 
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
@@ -591,7 +591,7 @@ func TestGithub_ProcessWebhook_BadGithubEvent(t *testing.T) {
 		Build:   nil,
 	}
 
-	got, err := client.ProcessWebhook(request)
+	got, err := client.ProcessWebhook(context.TODO(), request)
 
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
@@ -644,7 +644,7 @@ func TestGithub_ProcessWebhook_BadContentType(t *testing.T) {
 		Build:   nil,
 	}
 
-	got, err := client.ProcessWebhook(request)
+	got, err := client.ProcessWebhook(context.TODO(), request)
 
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
@@ -681,7 +681,7 @@ func TestGithub_VerifyWebhook_EmptyRepo(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	err = client.VerifyWebhook(request, new(library.Repo))
+	err = client.VerifyWebhook(context.TODO(), request, new(library.Repo))
 	if err != nil {
 		t.Errorf("VerifyWebhook should have returned err")
 	}
@@ -722,7 +722,7 @@ func TestGithub_VerifyWebhook_NoSecret(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	err = client.VerifyWebhook(request, r)
+	err = client.VerifyWebhook(context.TODO(), request, r)
 	if err != nil {
 		t.Errorf("VerifyWebhook should have returned err")
 	}
@@ -794,7 +794,7 @@ func TestGithub_ProcessWebhook_IssueComment_PR(t *testing.T) {
 		Build:    wantBuild,
 	}
 
-	got, err := client.ProcessWebhook(request)
+	got, err := client.ProcessWebhook(context.TODO(), request)
 
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
@@ -871,7 +871,7 @@ func TestGithub_ProcessWebhook_IssueComment_Created(t *testing.T) {
 		Build:    wantBuild,
 	}
 
-	got, err := client.ProcessWebhook(request)
+	got, err := client.ProcessWebhook(context.TODO(), request)
 
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
@@ -926,7 +926,7 @@ func TestGithub_ProcessWebhook_IssueComment_Deleted(t *testing.T) {
 		Build:    nil,
 	}
 
-	got, err := client.ProcessWebhook(request)
+	got, err := client.ProcessWebhook(context.TODO(), request)
 
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
@@ -990,7 +990,7 @@ func TestGitHub_ProcessWebhook_RepositoryRename(t *testing.T) {
 		Repo:    wantRepo,
 	}
 
-	got, err := client.ProcessWebhook(request)
+	got, err := client.ProcessWebhook(context.TODO(), request)
 
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
@@ -1054,7 +1054,7 @@ func TestGitHub_ProcessWebhook_RepositoryTransfer(t *testing.T) {
 		Repo:    wantRepo,
 	}
 
-	got, err := client.ProcessWebhook(request)
+	got, err := client.ProcessWebhook(context.TODO(), request)
 
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
@@ -1118,7 +1118,7 @@ func TestGitHub_ProcessWebhook_RepositoryArchived(t *testing.T) {
 		Repo:    wantRepo,
 	}
 
-	got, err := client.ProcessWebhook(request)
+	got, err := client.ProcessWebhook(context.TODO(), request)
 
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
@@ -1182,7 +1182,7 @@ func TestGitHub_ProcessWebhook_RepositoryEdited(t *testing.T) {
 		Repo:    wantRepo,
 	}
 
-	got, err := client.ProcessWebhook(request)
+	got, err := client.ProcessWebhook(context.TODO(), request)
 
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
@@ -1246,7 +1246,7 @@ func TestGitHub_ProcessWebhook_Repository(t *testing.T) {
 		Repo:    wantRepo,
 	}
 
-	got, err := client.ProcessWebhook(request)
+	got, err := client.ProcessWebhook(context.TODO(), request)
 
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
@@ -1300,7 +1300,7 @@ func TestGithub_Redeliver_Webhook(t *testing.T) {
 	client, _ := NewTest(s.URL, "https://foo.bar.com")
 
 	// run test
-	err := client.RedeliverWebhook(ctx, u, _repo, _hook)
+	err := client.RedeliverWebhook(context.TODO(), u, _repo, _hook)
 
 	if err != nil {
 		t.Errorf("RedeliverWebhook returned err: %v", err)
@@ -1348,7 +1348,7 @@ func TestGithub_GetDeliveryID(t *testing.T) {
 	ghClient := client.newClientToken(*u.Token)
 
 	// run test
-	got, err := client.getDeliveryID(ctx, ghClient, _repo, _hook)
+	got, err := client.getDeliveryID(context.TODO(), ghClient, _repo, _hook)
 
 	if err != nil {
 		t.Errorf("RedeliverWebhook returned err: %v", err)

--- a/scm/service.go
+++ b/scm/service.go
@@ -25,36 +25,36 @@ type Service interface {
 
 	// Authorize defines a function that uses the
 	// given access token to authorize the user.
-	Authorize(string) (string, error)
+	Authorize(context.Context, string) (string, error)
 	// Authenticate defines a function that completes
 	// the OAuth workflow for the session.
-	Authenticate(http.ResponseWriter, *http.Request, string) (*library.User, error)
+	Authenticate(context.Context, http.ResponseWriter, *http.Request, string) (*library.User, error)
 
 	// AuthenticateToken defines a function that completes
 	// the OAuth workflow for the session using PAT Token
-	AuthenticateToken(*http.Request) (*library.User, error)
+	AuthenticateToken(context.Context, *http.Request) (*library.User, error)
 
 	// Login defines a function that begins
 	// the OAuth workflow for the session.
-	Login(http.ResponseWriter, *http.Request) (string, error)
+	Login(context.Context, http.ResponseWriter, *http.Request) (string, error)
 
 	// Access SCM Interface Functions
 
 	// OrgAccess defines a function that captures
 	// the user's access level for an org.
-	OrgAccess(*library.User, string) (string, error)
+	OrgAccess(context.Context, *library.User, string) (string, error)
 	// RepoAccess defines a function that captures
 	// the user's access level for a repo.
-	RepoAccess(*library.User, string, string, string) (string, error)
+	RepoAccess(context.Context, *library.User, string, string, string) (string, error)
 	// TeamAccess defines a function that captures
 	// the user's access level for a team.
-	TeamAccess(*library.User, string, string) (string, error)
+	TeamAccess(context.Context, *library.User, string, string) (string, error)
 
 	// Teams SCM Interface Functions
 
 	// ListUsersTeamsForOrg defines a function that captures
 	// the user's teams for an org
-	ListUsersTeamsForOrg(*library.User, string) ([]string, error)
+	ListUsersTeamsForOrg(context.Context, *library.User, string) ([]string, error)
 
 	// Changeset SCM Interface Functions
 
@@ -62,79 +62,79 @@ type Service interface {
 	// of files changed for a commit.
 	//
 	// https://en.wikipedia.org/wiki/Changeset.
-	Changeset(*library.User, *library.Repo, string) ([]string, error)
+	Changeset(context.Context, *library.User, *library.Repo, string) ([]string, error)
 	// ChangesetPR defines a function that captures the list
 	// of files changed for a pull request.
 	//
 	// https://en.wikipedia.org/wiki/Changeset.
-	ChangesetPR(*library.User, *library.Repo, int) ([]string, error)
+	ChangesetPR(context.Context, *library.User, *library.Repo, int) ([]string, error)
 
 	// Deployment SCM Interface Functions
 
 	// GetDeployment defines a function that
 	// gets a deployment by number and repo.
-	GetDeployment(*library.User, *library.Repo, int64) (*library.Deployment, error)
+	GetDeployment(context.Context, *library.User, *library.Repo, int64) (*library.Deployment, error)
 	// GetDeploymentCount defines a function that
 	// counts a list of all deployment for a repo.
-	GetDeploymentCount(*library.User, *library.Repo) (int64, error)
+	GetDeploymentCount(context.Context, *library.User, *library.Repo) (int64, error)
 	// GetDeploymentList defines a function that gets
 	// a list of all deployments for a repo.
-	GetDeploymentList(*library.User, *library.Repo, int, int) ([]*library.Deployment, error)
+	GetDeploymentList(context.Context, *library.User, *library.Repo, int, int) ([]*library.Deployment, error)
 	// CreateDeployment defines a function that
 	// creates a new deployment.
-	CreateDeployment(*library.User, *library.Repo, *library.Deployment) error
+	CreateDeployment(context.Context, *library.User, *library.Repo, *library.Deployment) error
 
 	// Repo SCM Interface Functions
 
 	// Config defines a function that captures
 	// the pipeline configuration from a repo.
-	Config(*library.User, *library.Repo, string) ([]byte, error)
+	Config(context.Context, *library.User, *library.Repo, string) ([]byte, error)
 	// ConfigBackoff is a truncated constant backoff wrapper for Config.
 	// Retry again in five seconds if Config fails to retrieve yaml/yml file.
 	// Will return an error after five failed attempts.
-	ConfigBackoff(*library.User, *library.Repo, string) ([]byte, error)
+	ConfigBackoff(context.Context, *library.User, *library.Repo, string) ([]byte, error)
 	// Disable defines a function that deactivates
 	// a repo by destroying the webhook.
-	Disable(*library.User, string, string) error
+	Disable(context.Context, *library.User, string, string) error
 	// Enable defines a function that activates
 	// a repo by creating the webhook.
-	Enable(*library.User, *library.Repo, *library.Hook) (*library.Hook, string, error)
+	Enable(context.Context, *library.User, *library.Repo, *library.Hook) (*library.Hook, string, error)
 	// Update defines a function that updates
 	// a webhook for a specified repo.
-	Update(*library.User, *library.Repo, int64) (bool, error)
+	Update(context.Context, *library.User, *library.Repo, int64) (bool, error)
 	// Status defines a function that sends the
 	// commit status for the given SHA from a repo.
-	Status(*library.User, *library.Build, string, string) error
+	Status(context.Context, *library.User, *library.Build, string, string) error
 	// ListUserRepos defines a function that retrieves
 	// all repos with admin rights for the user.
-	ListUserRepos(*library.User) ([]*library.Repo, error)
+	ListUserRepos(context.Context, *library.User) ([]*library.Repo, error)
 	// GetBranch defines a function that retrieves
 	// a branch for a repo.
-	GetBranch(*library.User, *library.Repo, string) (string, string, error)
+	GetBranch(context.Context, *library.User, *library.Repo, string) (string, string, error)
 	// GetPullRequest defines a function that retrieves
 	// a pull request for a repo.
-	GetPullRequest(*library.User, *library.Repo, int) (string, string, string, string, error)
+	GetPullRequest(context.Context, *library.User, *library.Repo, int) (string, string, string, string, error)
 	// GetRepo defines a function that retrieves
 	// details for a repo.
-	GetRepo(*library.User, *library.Repo) (*library.Repo, error)
+	GetRepo(context.Context, *library.User, *library.Repo) (*library.Repo, error)
 	// GetOrgAndRepoName defines a function that retrieves
 	// the name of the org and repo in the SCM.
-	GetOrgAndRepoName(*library.User, string, string) (string, string, error)
+	GetOrgAndRepoName(context.Context, *library.User, string, string) (string, string, error)
 	// GetOrg defines a function that retrieves
 	// the name for an org in the SCM.
-	GetOrgName(*library.User, string) (string, error)
+	GetOrgName(context.Context, *library.User, string) (string, error)
 	// GetHTMLURL defines a function that retrieves
 	// a repository file's html_url.
-	GetHTMLURL(*library.User, string, string, string, string) (string, error)
+	GetHTMLURL(context.Context, *library.User, string, string, string, string) (string, error)
 
 	// Webhook SCM Interface Functions
 
 	// ProcessWebhook defines a function that
 	// parses the webhook from a repo.
-	ProcessWebhook(*http.Request) (*types.Webhook, error)
+	ProcessWebhook(context.Context, *http.Request) (*types.Webhook, error)
 	// VerifyWebhook defines a function that
 	// verifies the webhook from a repo.
-	VerifyWebhook(*http.Request, *library.Repo) error
+	VerifyWebhook(context.Context, *http.Request, *library.Repo) error
 	// RedeliverWebhook defines a function that
 	// redelivers the webhook from the SCM.
 	RedeliverWebhook(context.Context, *library.User, *library.Repo, *library.Hook) error


### PR DESCRIPTION
continuing the efforts started in #898 #922 #923 #930 #937 #938 #941 #942 #950 #951

this is prep to add support for OpenTelemetry tracing.

the reason being, otel can (for the most part) work out of the box if you pass around contexts properly.