### PR TITLE
fix(api/build): cancel build removes build_executable from table

### DIFF
--- a/api/build/cancel.go
+++ b/api/build/cancel.go
@@ -199,6 +199,15 @@ func CancelBuild(c *gin.Context) {
 		return
 	}
 
+	// remove build executable for clean up
+	_, err = database.FromContext(c).PopBuildExecutable(ctx, b.GetID())
+	if err != nil {
+		retErr := fmt.Errorf("unable to pop build %s from executables table: %w", entry, err)
+		util.HandleError(c, http.StatusInternalServerError, retErr)
+
+		return
+	}
+
 	// retrieve the steps for the build from the step table
 	steps := []*library.Step{}
 	page := 1


### PR DESCRIPTION
This will prevent stale build_executable items from piling up if users cancel pending builds.