### PR TITLE
enhance(compiler): environment and template adjustments for local compilation

### DIFF
--- a/compiler/native/environment.go
+++ b/compiler/native/environment.go
@@ -90,18 +90,6 @@ func (c *client) EnvironmentStep(s *yaml.Step, stageEnv raw.StringSliceMap) (*ya
 	// gather set of default environment variables
 	defaultEnv := environment(c.build, c.metadata, c.repo, c.user)
 
-	// check if the compiler is setup for a local pipeline
-	// and the step isn't setup to run in a detached state
-	if c.local && !s.Detach {
-		// capture all environment variables from the local environment
-		for _, e := range os.Environ() {
-			// split the environment variable on = into a key value pair
-			parts := strings.SplitN(e, "=", 2)
-
-			env[parts[0]] = parts[1]
-		}
-	}
-
 	// inject the declared stage environment
 	// WARNING: local env can override global + stage
 	env = appendMap(env, stageEnv)
@@ -118,6 +106,17 @@ func (c *client) EnvironmentStep(s *yaml.Step, stageEnv raw.StringSliceMap) (*ya
 	// to ensure the default env overrides any conflicts
 	for k, v := range defaultEnv {
 		env[k] = v
+	}
+
+	// check if the compiler is setup for a local pipeline
+	if c.local && !s.Detach {
+		// capture all environment variables from the local environment
+		for _, e := range os.Environ() {
+			// split the environment variable on = into a key value pair
+			parts := strings.SplitN(e, "=", 2)
+
+			env[parts[0]] = parts[1]
+		}
 	}
 
 	// inject the declared parameter
@@ -192,17 +191,6 @@ func (c *client) EnvironmentSecrets(s yaml.SecretSlice, globalEnv raw.StringSlic
 		// gather set of default environment variables
 		defaultEnv := environment(c.build, c.metadata, c.repo, c.user)
 
-		// check if the compiler is setup for a local pipeline
-		if c.local {
-			// capture all environment variables from the local environment
-			for _, e := range os.Environ() {
-				// split the environment variable on = into a key value pair
-				parts := strings.SplitN(e, "=", 2)
-
-				env[parts[0]] = parts[1]
-			}
-		}
-
 		// inject the declared global environment
 		// WARNING: local env can override global
 		env = appendMap(env, globalEnv)
@@ -219,6 +207,17 @@ func (c *client) EnvironmentSecrets(s yaml.SecretSlice, globalEnv raw.StringSlic
 		// to ensure the default env overrides any conflicts
 		for k, v := range defaultEnv {
 			env[k] = v
+		}
+
+		// check if the compiler is setup for a local pipeline
+		if c.local {
+			// capture all environment variables from the local environment
+			for _, e := range os.Environ() {
+				// split the environment variable on = into a key value pair
+				parts := strings.SplitN(e, "=", 2)
+
+				env[parts[0]] = parts[1]
+			}
 		}
 
 		// inject the declared parameter
@@ -250,6 +249,14 @@ func (c *client) EnvironmentBuild() map[string]string {
 	// gather set of default environment variables
 	defaultEnv := environment(c.build, c.metadata, c.repo, c.user)
 
+	// inject the default environment
+	// variables to the build
+	// we do this after injecting the declared environment
+	// to ensure the default env overrides any conflicts
+	for k, v := range defaultEnv {
+		env[k] = v
+	}
+
 	// check if the compiler is setup for a local pipeline
 	if c.local {
 		// capture all environment variables from the local environment
@@ -259,14 +266,6 @@ func (c *client) EnvironmentBuild() map[string]string {
 
 			env[parts[0]] = parts[1]
 		}
-	}
-
-	// inject the default environment
-	// variables to the build secret
-	// we do this after injecting the declared environment
-	// to ensure the default env overrides any conflicts
-	for k, v := range defaultEnv {
-		env[k] = v
 	}
 
 	return env

--- a/compiler/native/environment_test.go
+++ b/compiler/native/environment_test.go
@@ -5,6 +5,7 @@ package native
 import (
 	"flag"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/go-vela/types/raw"
@@ -208,13 +209,43 @@ func TestNative_EnvironmentSteps(t *testing.T) {
 		},
 	}
 
-	// run test
+	// run test non-local
 	compiler, err := New(c)
 	if err != nil {
 		t.Errorf("Unable to create new compiler: %v", err)
 	}
 
+	// run test local
+	compiler.WithLocal(true)
+
+	t.Setenv("VELA_BUILD_COMMIT", "123abc")
+
 	got, err := compiler.EnvironmentSteps(s, e)
+	if err != nil {
+		t.Errorf("EnvironmentSteps returned err: %v", err)
+	}
+
+	// cannot use complete diff since local compiler pulls from OS env
+	if !strings.EqualFold(got[0].Environment["VELA_BUILD_COMMIT"], "123abc") {
+		t.Errorf("EnvironmentSteps with local compiler should have set VELA_BUILD_COMMIT to 123abc, got %s", got[0].Environment["VELA_BUILD_COMMIT"])
+	}
+
+	// test without local
+	compiler.WithLocal(false)
+
+	// reset s
+	s = yaml.StepSlice{
+		&yaml.Step{
+			Image: "alpine",
+			Name:  str,
+			Pull:  "always",
+			Environment: raw.StringSliceMap{
+				"BUILD_CHANNEL": "foo",
+			},
+		},
+	}
+
+	got, err = compiler.EnvironmentSteps(s, e)
 	if err != nil {
 		t.Errorf("EnvironmentSteps returned err: %v", err)
 	}

--- a/compiler/native/expand.go
+++ b/compiler/native/expand.go
@@ -204,6 +204,10 @@ func (c *client) getTemplate(tmpl *yaml.Template, name string) ([]byte, error) {
 
 	switch {
 	case c.local:
+		a := &afero.Afero{
+			Fs: afero.NewOsFs(),
+		}
+
 		// iterate over locally provided templates
 		for _, t := range c.localTemplates {
 			parts := strings.Split(t, ":")
@@ -211,11 +215,8 @@ func (c *client) getTemplate(tmpl *yaml.Template, name string) ([]byte, error) {
 				return nil, fmt.Errorf("local templates must be provided in the form <name>:<path>, got %s", t)
 			}
 
+			// if local template has a match, read file path provided
 			if strings.EqualFold(tmpl.Name, parts[0]) {
-				a := &afero.Afero{
-					Fs: afero.NewOsFs(),
-				}
-
 				bytes, err = a.ReadFile(parts[1])
 				if err != nil {
 					return bytes, err
@@ -225,8 +226,22 @@ func (c *client) getTemplate(tmpl *yaml.Template, name string) ([]byte, error) {
 			}
 		}
 
-		// no template found in provided templates, exit with error
-		return nil, fmt.Errorf("unable to find template %s: not supplied in list %s", tmpl.Name, c.localTemplates)
+		// file type templates can be retrieved locally using `source`
+		if strings.EqualFold(tmpl.Type, "file") {
+			bytes, err = a.ReadFile(tmpl.Source)
+			if err != nil {
+				return nil, fmt.Errorf("unable to read file for template %s. `File` type templates must be located at `source` or supplied to local template files", tmpl.Name)
+			}
+
+			return bytes, nil
+		}
+
+		// local exec may still request remote templates
+		if !strings.EqualFold(tmpl.Type, "github") {
+			return nil, fmt.Errorf("unable to find template %s: not supplied in list %s", tmpl.Name, c.localTemplates)
+		}
+
+		fallthrough
 
 	case strings.EqualFold(tmpl.Type, "github"):
 		// parse source from template


### PR DESCRIPTION
This is the first of three changes that will enhance the `vela exec pipeline` command. These changes fall under the `Server` section below.

### The Issue

`vela exec pipeline` does not work with templates. It also does not work with custom environments if the user is trying to emulate any of the default environment variables, such as `VELA_BUILD_COMMIT`.

### Server Changes

1. Execute the local environment sourcing _after_ the default env override. This will ensure that user-set values that would be found in the default environment will be properly interpreted by the compiler.
2. Adjustments to `getTemplate` that allows the compiler to read both from local file tree as well as remote using a GitHub token.

### Worker Changes

1. Remove calls to merge environment with default environment found in [executor/local/step.go](https://github.com/go-vela/worker/blob/be492bd1e78717a54717c183983845be3234c236/executor/local/step.go#L64-L70). This call is unnecessary and will only overwrite user-supplied environment values found in the default env.

### CLI Changes

1. Support for `--template`, `--template-file`, `--compiler.github.token`, and `--compiler.github.url` flags to the `exec pipeline` command. This will allow users the option to leverage templates in local pipeline execution, both local and remote.
2. Support for `--env-file` and `--env-file-path` to allow users to source environment variables from a file.
