### PR TITLE
fix(compiler): return error on bad regular expressions that fail to compile in Purge

### DIFF
--- a/compiler/native/compile_test.go
+++ b/compiler/native/compile_test.go
@@ -110,6 +110,7 @@ func TestNative_Compile_StagesPipeline(t *testing.T) {
 			Clone:       true,
 			Template:    false,
 			Environment: []string{"steps", "services", "secrets"},
+			AutoCancel:  &pipeline.CancelOptions{},
 		},
 		Stages: pipeline.StageSlice{
 			&pipeline.Stage{
@@ -482,6 +483,10 @@ func TestNative_Compile_StepsPipeline(t *testing.T) {
 			Clone:       true,
 			Template:    false,
 			Environment: []string{"steps", "services", "secrets"},
+			AutoCancel: &pipeline.CancelOptions{
+				Running: true,
+				Pending: true,
+			},
 		},
 		Steps: pipeline.ContainerSlice{
 			&pipeline.Container{
@@ -693,6 +698,7 @@ func TestNative_Compile_StagesPipelineTemplate(t *testing.T) {
 			Clone:       true,
 			Template:    false,
 			Environment: []string{"steps", "services", "secrets"},
+			AutoCancel:  &pipeline.CancelOptions{},
 		},
 		Stages: pipeline.StageSlice{
 			&pipeline.Stage{
@@ -960,6 +966,7 @@ func TestNative_Compile_StepsPipelineTemplate(t *testing.T) {
 			Clone:       true,
 			Template:    false,
 			Environment: []string{"steps", "services", "secrets"},
+			AutoCancel:  &pipeline.CancelOptions{},
 		},
 		Steps: pipeline.ContainerSlice{
 			&pipeline.Container{
@@ -1155,6 +1162,7 @@ func TestNative_Compile_StepsPipelineTemplate_VelaFunction_TemplateName(t *testi
 			Clone:       true,
 			Template:    false,
 			Environment: []string{"steps", "services", "secrets"},
+			AutoCancel:  &pipeline.CancelOptions{},
 		},
 		Steps: pipeline.ContainerSlice{
 			&pipeline.Container{
@@ -1275,6 +1283,7 @@ func TestNative_Compile_StepsPipelineTemplate_VelaFunction_TemplateName_Inline(t
 			Clone:       true,
 			Template:    false,
 			Environment: []string{"steps", "services", "secrets"},
+			AutoCancel:  &pipeline.CancelOptions{},
 		},
 		Steps: pipeline.ContainerSlice{
 			&pipeline.Container{
@@ -1449,6 +1458,7 @@ func TestNative_Compile_Clone(t *testing.T) {
 			Clone:       false,
 			Template:    false,
 			Environment: []string{"steps", "services", "secrets"},
+			AutoCancel:  &pipeline.CancelOptions{},
 		},
 		Steps: pipeline.ContainerSlice{
 			&pipeline.Container{
@@ -1479,6 +1489,7 @@ func TestNative_Compile_Clone(t *testing.T) {
 			Clone:       true,
 			Template:    false,
 			Environment: []string{"steps", "services", "secrets"},
+			AutoCancel:  &pipeline.CancelOptions{},
 		},
 		Steps: pipeline.ContainerSlice{
 			&pipeline.Container{
@@ -1518,6 +1529,7 @@ func TestNative_Compile_Clone(t *testing.T) {
 			Clone:       false,
 			Template:    false,
 			Environment: []string{"steps", "services", "secrets"},
+			AutoCancel:  &pipeline.CancelOptions{},
 		},
 		Steps: pipeline.ContainerSlice{
 			&pipeline.Container{
@@ -1638,6 +1650,7 @@ func TestNative_Compile_Pipeline_Type(t *testing.T) {
 			Clone:       true,
 			Template:    false,
 			Environment: []string{"steps", "services", "secrets"},
+			AutoCancel:  &pipeline.CancelOptions{},
 		},
 		Steps: pipeline.ContainerSlice{
 			&pipeline.Container{
@@ -1683,6 +1696,7 @@ func TestNative_Compile_Pipeline_Type(t *testing.T) {
 			Clone:       true,
 			Template:    false,
 			Environment: []string{"steps", "services", "secrets"},
+			AutoCancel:  &pipeline.CancelOptions{},
 		},
 		Steps: pipeline.ContainerSlice{
 			&pipeline.Container{
@@ -1728,6 +1742,7 @@ func TestNative_Compile_Pipeline_Type(t *testing.T) {
 			Clone:       true,
 			Template:    false,
 			Environment: []string{"steps", "services", "secrets"},
+			AutoCancel:  &pipeline.CancelOptions{},
 		},
 		Steps: pipeline.ContainerSlice{
 			&pipeline.Container{
@@ -2232,6 +2247,7 @@ func Test_Compile_Inline(t *testing.T) {
 				Metadata: pipeline.Metadata{
 					Clone:       true,
 					Environment: []string{"steps", "services", "secrets"},
+					AutoCancel:  &pipeline.CancelOptions{},
 				},
 				Stages: []*pipeline.Stage{
 					{
@@ -2387,6 +2403,7 @@ func Test_Compile_Inline(t *testing.T) {
 				Metadata: pipeline.Metadata{
 					Clone:       true,
 					Environment: []string{"steps", "services", "secrets"},
+					AutoCancel:  &pipeline.CancelOptions{},
 				},
 				Stages: []*pipeline.Stage{
 					{
@@ -2560,6 +2577,7 @@ func Test_Compile_Inline(t *testing.T) {
 				Metadata: pipeline.Metadata{
 					Clone:       true,
 					Environment: []string{"steps", "services", "secrets"},
+					AutoCancel:  &pipeline.CancelOptions{},
 				},
 				Steps: []*pipeline.Container{
 					{
@@ -2676,6 +2694,7 @@ func Test_Compile_Inline(t *testing.T) {
 				Metadata: pipeline.Metadata{
 					Clone:       true,
 					Environment: []string{"steps", "services", "secrets"},
+					AutoCancel:  &pipeline.CancelOptions{},
 				},
 				Steps: []*pipeline.Container{
 					{
@@ -2773,6 +2792,7 @@ func Test_Compile_Inline(t *testing.T) {
 				Metadata: pipeline.Metadata{
 					Clone:       true,
 					Environment: []string{"steps", "services", "secrets"},
+					AutoCancel:  &pipeline.CancelOptions{},
 				},
 				Steps: []*pipeline.Container{
 					{
@@ -2848,6 +2868,7 @@ func Test_Compile_Inline(t *testing.T) {
 				Metadata: pipeline.Metadata{
 					Clone:       true,
 					Environment: []string{"steps", "services", "secrets"},
+					AutoCancel:  &pipeline.CancelOptions{},
 				},
 				Steps: []*pipeline.Container{
 					{
@@ -2892,6 +2913,7 @@ func Test_Compile_Inline(t *testing.T) {
 				Metadata: pipeline.Metadata{
 					Clone:       true,
 					Environment: []string{"steps", "services", "secrets"},
+					AutoCancel:  &pipeline.CancelOptions{},
 				},
 				Stages: []*pipeline.Stage{
 					{

--- a/compiler/native/expand.go
+++ b/compiler/native/expand.go
@@ -89,7 +89,10 @@ func (c *client) ExpandSteps(s *yaml.Build, tmpls map[string]*yaml.Template, r *
 				Steps: *check.ToPipeline(),
 			}
 
-			pipeline = pipeline.Purge(r)
+			pipeline, err := pipeline.Purge(r)
+			if err != nil {
+				return nil, fmt.Errorf("unable to purge pipeline: %w", err)
+			}
 
 			// if step purged, do not proceed with expansion
 			if len(pipeline.Steps) == 0 {

--- a/compiler/native/parse_test.go
+++ b/compiler/native/parse_test.go
@@ -348,6 +348,7 @@ func TestNative_Parse_StagesPipeline(t *testing.T) {
 
 func TestNative_Parse_StepsPipeline(t *testing.T) {
 	// setup types
+	tBool := true
 	client, _ := New(cli.NewContext(nil, flag.NewFlagSet("test", 0), nil))
 	want := &yaml.Build{
 		Version: "1",
@@ -355,6 +356,9 @@ func TestNative_Parse_StepsPipeline(t *testing.T) {
 			Template:    false,
 			Clone:       nil,
 			Environment: []string{"steps", "services", "secrets"},
+			AutoCancel: &yaml.CancelOptions{
+				Running: &tBool,
+			},
 		},
 		Environment: map[string]string{
 			"HELLO": "Hello, Global Environment",

--- a/compiler/native/testdata/steps_pipeline.yml
+++ b/compiler/native/testdata/steps_pipeline.yml
@@ -3,6 +3,8 @@ version: "1"
 
 metadata:
   template: false
+  auto_cancel:
+    running: true
 
 environment:
   HELLO: "Hello, Global Environment"    

--- a/compiler/native/transform.go
+++ b/compiler/native/transform.go
@@ -113,7 +113,12 @@ func (c *client) TransformStages(r *pipeline.RuleData, p *yaml.Build) (*pipeline
 		secret.Origin.ID = pattern
 	}
 
-	return pipeline.Purge(r), nil
+	build, err := pipeline.Purge(r)
+	if err != nil {
+		return nil, fmt.Errorf("unable to purge pipeline: %w", err)
+	}
+
+	return build, nil
 }
 
 // TransformSteps converts a yaml configuration with steps into an executable pipeline.
@@ -192,5 +197,10 @@ func (c *client) TransformSteps(r *pipeline.RuleData, p *yaml.Build) (*pipeline.
 		secret.Origin.ID = pattern
 	}
 
-	return pipeline.Purge(r), nil
+	build, err := pipeline.Purge(r)
+	if err != nil {
+		return nil, fmt.Errorf("unable to purge pipeline: %w", err)
+	}
+
+	return build, nil
 }

--- a/compiler/native/transform_test.go
+++ b/compiler/native/transform_test.go
@@ -112,7 +112,8 @@ func TestNative_TransformStages(t *testing.T) {
 				ID:      "__0",
 				Version: "v1",
 				Metadata: pipeline.Metadata{
-					Clone: true,
+					Clone:      true,
+					AutoCancel: &pipeline.CancelOptions{},
 				},
 				Services: pipeline.ContainerSlice{
 					&pipeline.Container{
@@ -167,7 +168,8 @@ func TestNative_TransformStages(t *testing.T) {
 				ID:      "localOrg_localRepo_1",
 				Version: "v1",
 				Metadata: pipeline.Metadata{
-					Clone: true,
+					Clone:      true,
+					AutoCancel: &pipeline.CancelOptions{},
 				},
 				Services: pipeline.ContainerSlice{
 					&pipeline.Container{
@@ -339,7 +341,8 @@ func TestNative_TransformSteps(t *testing.T) {
 				ID:      "__0",
 				Version: "v1",
 				Metadata: pipeline.Metadata{
-					Clone: true,
+					Clone:      true,
+					AutoCancel: &pipeline.CancelOptions{},
 				},
 				Services: pipeline.ContainerSlice{
 					&pipeline.Container{
@@ -389,7 +392,8 @@ func TestNative_TransformSteps(t *testing.T) {
 				ID:      "localOrg_localRepo_1",
 				Version: "v1",
 				Metadata: pipeline.Metadata{
-					Clone: true,
+					Clone:      true,
+					AutoCancel: &pipeline.CancelOptions{},
 				},
 				Services: pipeline.ContainerSlice{
 					&pipeline.Container{

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/go-vela/server
 
 go 1.21
 
-replace github.com/go-vela/types => ../types
-
 require (
 	github.com/Bose/minisentinel v0.0.0-20200130220412-917c5a9223bb
 	github.com/DATA-DOG/go-sqlmock v1.5.0
@@ -16,7 +14,7 @@ require (
 	github.com/drone/envsubst v1.0.3
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-playground/assert/v2 v2.2.0
-	github.com/go-vela/types v0.21.0
+	github.com/go-vela/types v0.21.1-0.20231012142227-0c0b890487af
 	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github/v55 v55.0.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/go-vela/server
 
 go 1.21
 
+replace github.com/go-vela/types => ../types
+
 require (
 	github.com/Bose/minisentinel v0.0.0-20200130220412-917c5a9223bb
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/go-playground/validator/v10 v10.14.0 h1:vgvQWe3XCz3gIeFDm/HnTIbj6UGmg
 github.com/go-playground/validator/v10 v10.14.0/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-vela/types v0.21.1-0.20231012142227-0c0b890487af h1:qiP6pXFDyPDDP+hy8zY+nhmoWv9aoQrrnNmfAAT6yCA=
+github.com/go-vela/types v0.21.1-0.20231012142227-0c0b890487af/go.mod h1:Jn8K28uj7mACc55fkFgaIzL0q45iXydOFGEeoSeHUtQ=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,6 @@ github.com/go-playground/validator/v10 v10.14.0 h1:vgvQWe3XCz3gIeFDm/HnTIbj6UGmg
 github.com/go-playground/validator/v10 v10.14.0/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/go-vela/types v0.21.0 h1:yZrVUw4jKO0JHaUBkOIZZdniDGyDOpTMbKriemdm1jg=
-github.com/go-vela/types v0.21.0/go.mod h1:Jn8K28uj7mACc55fkFgaIzL0q45iXydOFGEeoSeHUtQ=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=


### PR DESCRIPTION
Depends on: https://github.com/go-vela/types/pull/327

Ref: https://github.com/go-vela/community/issues/435

Note: all the compiler pkg test changes for `AutoCancel` is so the tests can pass. They match what is in [this PR](https://github.com/go-vela/server/pull/911)