### PR TITLE
fix(api/schedule): early exit for empty name

### DIFF
--- a/api/schedule/create.go
+++ b/api/schedule/create.go
@@ -104,6 +104,8 @@ func CreateSchedule(c *gin.Context) {
 	// ensure schedule name is defined
 	if input.GetName() == "" {
 		util.HandleError(c, http.StatusBadRequest, fmt.Errorf("schedule name must be set"))
+
+		return
 	}
 
 	// update engine logger with API metadata


### PR DESCRIPTION
Before:
```json
{
    "error": "schedule name must be set"
}{
    "error": "unable to create new schedule myvela: empty schedule name provided"
}
```

After:
```json
{
    "error": "schedule name must be set"
}
```

UI can't handle the first one and just prints `Status 400`