### PR TITLE
fix(schedule): honor allow list for previously created schedules

### DIFF
--- a/cmd/vela-server/server.go
+++ b/cmd/vela-server/server.go
@@ -212,7 +212,7 @@ func server(c *cli.Context) error {
 			// sleep for a duration of time before processing schedules
 			time.Sleep(jitter)
 
-			err = processSchedules(ctx, start, compiler, database, metadata, queue, scm)
+			err = processSchedules(ctx, start, compiler, database, metadata, queue, scm, c.StringSlice("vela-schedule-allowlist"))
 			if err != nil {
 				logrus.WithError(err).Warn("unable to process schedules")
 			} else {


### PR DESCRIPTION
This change makes sure that any repo taken off of the allowlist does not continue to trigger existing schedules