### PR TITLE
fix(graph): return proper error on complex builds

### DIFF
--- a/api/build/graph.go
+++ b/api/build/graph.go
@@ -319,7 +319,10 @@ func GetBuildGraph(c *gin.Context) {
 	// but it will save on processing a massive build that should not be rendered
 	complexity := len(steps) + len(p.Stages) + len(services)
 	if complexity > GraphComplexityLimit {
-		c.JSON(http.StatusInternalServerError, "build is too complex, too many resources")
+		retErr := fmt.Errorf("build is too complex, too many resources")
+
+		util.HandleError(c, http.StatusInternalServerError, retErr)
+
 		return
 	}
 
@@ -584,7 +587,10 @@ func GetBuildGraph(c *gin.Context) {
 
 	// validate the generated graph's complexity is beneath the limit
 	if len(nodes)+len(edges) > GraphComplexityLimit {
-		c.JSON(http.StatusInternalServerError, "graph is too complex, too many nodes and edges")
+		retErr := fmt.Errorf("build is too complex, too many resources")
+
+		util.HandleError(c, http.StatusInternalServerError, retErr)
+
 		return
 	}
 


### PR DESCRIPTION
closes https://github.com/go-vela/community/issues/883

the error returned when complexity is high wasn't properly formatted, so it couldn't be displayed in UI like other errors; you would just end up with a generic internal network error without any other information. this should help signal to the user what is going on better, though maybe the message itself could be tweaked even more?!