### PR TITLE
chore: minor tweaks for local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ bump-deps-full: check
 pull:
 	@echo
 	@echo "### Pulling images for docker-compose stack"
-	@docker-compose pull
+	@docker compose pull
 
 # The `compose-up` target is intended to build and create
 # all containers for the local Docker compose stack.
@@ -237,7 +237,7 @@ pull:
 compose-up:
 	@echo
 	@echo "### Creating containers for docker-compose stack"
-	@docker-compose -f docker-compose.yml up -d --build
+	@docker compose -f docker-compose.yml up -d --build
 
 # The `compose-down` target is intended to destroy
 # all containers for the local Docker compose stack.
@@ -247,7 +247,7 @@ compose-up:
 compose-down:
 	@echo
 	@echo "### Destroying containers for docker-compose stack"
-	@docker-compose -f docker-compose.yml down
+	@docker compose -f docker-compose.yml down
 
 # The `spec-install` target is intended to install the
 # the needed dependencies to generate the api spec.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@
 version: '3'
 
 services:
-
   # The `server` compose service hosts the Vela server and API.
   #
   # This component is used for processing web requests and
@@ -16,7 +15,6 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: server
-    image: server:local
     networks:
       - vela
     environment:
@@ -52,10 +50,12 @@ services:
     ports:
       - '8080:8080'
     depends_on:
-      - postgres
-      - redis
-      - vault
-
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      vault:
+        condition: service_started
 
   # The `worker` compose service hosts the Vela build daemon.
   #
@@ -140,6 +140,11 @@ services:
       POSTGRES_USER: vela
     ports:
       - '5432:5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready']
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   # The `vault` compose service hosts the HashiCorp Vault instance.
   #


### PR DESCRIPTION
couple of minor tweaks and fixes for annoyances i intend to carry over to the other core repos if accepted:

1. after running `make up` there's a 95%+ chance i will attempt to access the stack before it is ready (mainly due to postgres service taking a while on my machine). this is fixed by adding a health check for postgres and making sure the server doesn't start until it's healthy. could maybe tweak interval to check more frequently. lmk.
1. changes `docker-compose` -> `docker compose`. ref: https://www.docker.com/blog/announcing-compose-v2-general-availability/ . i don't want to alias something that is deprecated, so i typically apply this edit locally before i run `make ...` 