### PR TITLE
fix(templates): handle nil PrivateGitHub

### DIFF
--- a/compiler/native/expand.go
+++ b/compiler/native/expand.go
@@ -274,6 +274,11 @@ func (c *client) getTemplate(tmpl *yaml.Template, name string) ([]byte, error) {
 				"host": src.Host,
 			}).Tracef("Using authenticated GitHub client to pull template")
 
+			// verify private GitHub is actually set up
+			if c.PrivateGithub == nil {
+				return nil, fmt.Errorf("unable to fetch template %s: missing credentials", src.Name)
+			}
+
 			// use private (authenticated) github instance to pull from
 			bytes, err = c.PrivateGithub.Template(c.user, src)
 			if err != nil {
@@ -306,6 +311,10 @@ func (c *client) getTemplate(tmpl *yaml.Template, name string) ([]byte, error) {
 				"repo": src.Repo,
 				"path": src.Name,
 			}).Tracef("Using authenticated GitHub client to pull template")
+
+			if c.PrivateGithub == nil {
+				return nil, fmt.Errorf("unable to fetch template %s: missing credentials", src.Name)
+			}
 
 			// use private (authenticated) github instance to pull from
 			bytes, err = c.PrivateGithub.Template(c.user, src)

--- a/compiler/native/expand_test.go
+++ b/compiler/native/expand_test.go
@@ -143,13 +143,43 @@ func TestNative_ExpandStages(t *testing.T) {
 		"bar":  "test4",
 	}
 
-	// run test
+	// run test -- missing private github
 	compiler, err := New(c)
 	if err != nil {
 		t.Errorf("Creating new compiler returned err: %v", err)
 	}
 
-	build, err := compiler.ExpandStages(&yaml.Build{Stages: stages, Services: yaml.ServiceSlice{}, Environment: raw.StringSliceMap{}}, tmpls, new(pipeline.RuleData))
+	compiler.PrivateGithub = nil
+	_, err = compiler.ExpandStages(
+		&yaml.Build{
+			Stages:      stages,
+			Services:    yaml.ServiceSlice{},
+			Environment: raw.StringSliceMap{},
+		},
+		tmpls,
+		new(pipeline.RuleData),
+	)
+
+	if err == nil {
+		t.Errorf("ExpandStages should have returned error with empty PrivateGitHub")
+	}
+
+	// run test
+	compiler, err = New(c)
+	if err != nil {
+		t.Errorf("Creating new compiler returned err: %v", err)
+	}
+
+	build, err := compiler.ExpandStages(
+		&yaml.Build{
+			Stages:      stages,
+			Services:    yaml.ServiceSlice{},
+			Environment: raw.StringSliceMap{},
+		},
+		tmpls,
+		new(pipeline.RuleData),
+	)
+
 	if err != nil {
 		t.Errorf("ExpandStages returned err: %v", err)
 	}


### PR DESCRIPTION
A `nil` check that primarily impacts CLI use, as the chances of this happening during normal pipeline expansion within the Vela server is pretty much 0%. 

However, if a user doesn't supply git credentials and tries to validate a pipeline with a remote template, this prevents a seg fault.