### PR TITLE
fix(compiler): validate yaml.Build post-expansion and fully validate step image

### DIFF
--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -50,12 +50,6 @@ func (c *client) Compile(v interface{}) (*pipeline.Build, *library.Pipeline, err
 	_pipeline.SetData(data)
 	_pipeline.SetType(c.repo.GetPipelineType())
 
-	// validate the yaml configuration
-	err = c.Validate(p)
-	if err != nil {
-		return nil, _pipeline, err
-	}
-
 	// create map of templates for easy lookup
 	templates := mapFromTemplates(p.Templates)
 

--- a/compiler/native/validate.go
+++ b/compiler/native/validate.go
@@ -101,8 +101,8 @@ func validateStages(s yaml.StageSlice) error {
 				return fmt.Errorf("no name provided for step for stage %s", stage.Name)
 			}
 
-			if len(step.Image) == 0 && len(step.Template.Name) == 0 {
-				return fmt.Errorf("no image or template provided for step %s for stage %s", step.Name, stage.Name)
+			if len(step.Image) == 0 {
+				return fmt.Errorf("no image provided for step %s for stage %s", step.Name, stage.Name)
 			}
 
 			if step.Name == "clone" || step.Name == "init" {
@@ -128,8 +128,8 @@ func validateSteps(s yaml.StepSlice) error {
 			return fmt.Errorf("no name provided for step")
 		}
 
-		if len(step.Image) == 0 && len(step.Template.Name) == 0 {
-			return fmt.Errorf("no image or template provided for step %s", step.Name)
+		if len(step.Image) == 0 {
+			return fmt.Errorf("no image provided for step %s", step.Name)
 		}
 
 		if step.Name == "clone" || step.Name == "init" {

--- a/scm/github/webhook.go
+++ b/scm/github/webhook.go
@@ -152,7 +152,10 @@ func (c *client) processPushEvent(h *library.Hook, payload *github.PushEvent) (*
 	b.SetClone(repo.GetCloneURL())
 	b.SetSource(payload.GetHeadCommit().GetURL())
 	b.SetTitle(fmt.Sprintf("%s received from %s", constants.EventPush, repo.GetHTMLURL()))
-	b.SetMessage(payload.GetHeadCommit().GetMessage())
+
+	sanitizedMessage := strings.Replace(payload.GetHeadCommit().GetMessage(), `\`, `\\`, -1)
+
+	b.SetMessage(sanitizedMessage)
 	b.SetCommit(payload.GetHeadCommit().GetID())
 	b.SetSender(payload.GetSender().GetLogin())
 	b.SetAuthor(payload.GetHeadCommit().GetAuthor().GetLogin())

--- a/scm/github/webhook.go
+++ b/scm/github/webhook.go
@@ -152,10 +152,7 @@ func (c *client) processPushEvent(h *library.Hook, payload *github.PushEvent) (*
 	b.SetClone(repo.GetCloneURL())
 	b.SetSource(payload.GetHeadCommit().GetURL())
 	b.SetTitle(fmt.Sprintf("%s received from %s", constants.EventPush, repo.GetHTMLURL()))
-
-	sanitizedMessage := strings.Replace(payload.GetHeadCommit().GetMessage(), `\`, `\\`, -1)
-
-	b.SetMessage(sanitizedMessage)
+	b.SetMessage(payload.GetHeadCommit().GetMessage())
 	b.SetCommit(payload.GetHeadCommit().GetID())
 	b.SetSender(payload.GetSender().GetLogin())
 	b.SetAuthor(payload.GetHeadCommit().GetAuthor().GetLogin())


### PR DESCRIPTION
Closes https://github.com/go-vela/community/issues/899

I think the real error in the issue is the fact that the pipeline passes validation more so than the repo counter not being updated. By not immediately validating the pipeline after unmarshaling, and rather waiting for the final expansion to validate, we don't need to specify `&& len(step.Template.Name) == 0 `.

This should result in an audit error rather than a build error — thus, no build.