### PR TITLE
fix(api/list-org-repos): ensure active flag is boolean

### DIFF
--- a/api/repo/list_org.go
+++ b/api/repo/list_org.go
@@ -122,11 +122,16 @@ func ListReposForOrg(c *gin.Context) {
 	// capture the sort_by query parameter if present
 	sortBy := util.QueryParameter(c, "sort_by", "name")
 
+	// prep filters
+	filters := make(map[string]interface{})
+
 	// capture the query parameters if present:
 	//
 	// * active
-	filters := map[string]interface{}{
-		"active": util.QueryParameter(c, "active", "true"),
+	active := util.QueryParameter(c, "active", "true")
+	// ensure active is a boolean and add it to filters as such
+	if activeBool, err := strconv.ParseBool(active); err == nil {
+		filters["active"] = activeBool
 	}
 
 	// See if the user is an org admin to bypass individual permission checks


### PR DESCRIPTION
closes https://github.com/go-vela/community/issues/853

when GORM is given the proper type, it will use the appropriate query depending on which driver is in use.

tested in local setup with both postgres and sqlite. no functional differences.

as a side note, it's not intuitive to start up the local (or any) stack with sqlite. compilation requires CGO and when using alpine requires you to make sure you are on alpine 3.18 instead of the latest (see issue #1164 on github.com/mattn/go-sqlite3). latest gcc and musl in the newest alpine (3.19.x) apparently do not work with that library. alternatively, and probably preferably, it looks like you can pass `CGO_CFLAGS="-D_LARGEFILE64_SOURCE"` in addition to `CGO_ENABLED=1`.