### PR TITLE
fix(api/build): zero out error on restarted build

### DIFF
--- a/api/build/restart.go
+++ b/api/build/restart.go
@@ -149,6 +149,7 @@ func RestartBuild(c *gin.Context) {
 	b.SetStarted(0)
 	b.SetFinished(0)
 	b.SetStatus(constants.StatusPending)
+	b.SetError("")
 	b.SetHost("")
 	b.SetRuntime("")
 	b.SetDistribution("")


### PR DESCRIPTION
fixes https://github.com/go-vela/community/issues/462

i don't believe there are any other fields that need to be reset beyond this.