### PR TITLE
fix: minor tweak in messaging for event not enabled

### DIFF
--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -264,7 +264,7 @@ func PostWebhook(c *gin.Context) {
 			actionErr = ":" + b.GetEventAction()
 		}
 
-		retErr := fmt.Errorf("%s: %s does not have %s%s events enabled", baseErr, repo.GetFullName(), b.GetEvent(), actionErr)
+		retErr := fmt.Errorf("%s: %s does not have %s%s event enabled", baseErr, repo.GetFullName(), b.GetEvent(), actionErr)
 		util.HandleError(c, http.StatusBadRequest, retErr)
 
 		h.SetStatus(constants.StatusSkipped)


### PR DESCRIPTION
can be confusing since `push` and `tag`, for example, are grouped under "Push" events in the UI and when you have `tag` enabled it says "no push events enabled" when you actually have one of them enabled. plus, it references single events anyway.