### PR TITLE
fix(compiler): remove template param from CompileLite

### DIFF
--- a/api/pipeline/compile.go
+++ b/api/pipeline/compile.go
@@ -95,7 +95,7 @@ func CompilePipeline(c *gin.Context) {
 	compiler := compiler.FromContext(c).Duplicate().WithCommit(p.GetCommit()).WithMetadata(m).WithRepo(r).WithUser(u)
 
 	// compile the pipeline
-	pipeline, _, err := compiler.CompileLite(p.GetData(), true, true)
+	pipeline, _, err := compiler.CompileLite(p.GetData(), true)
 	if err != nil {
 		retErr := fmt.Errorf("unable to compile pipeline %s: %w", entry, err)
 

--- a/api/pipeline/expand.go
+++ b/api/pipeline/expand.go
@@ -96,7 +96,7 @@ func ExpandPipeline(c *gin.Context) {
 	compiler := compiler.FromContext(c).Duplicate().WithCommit(p.GetCommit()).WithMetadata(m).WithRepo(r).WithUser(u)
 
 	// expand the templates in the pipeline
-	pipeline, _, err := compiler.CompileLite(p.GetData(), true, false)
+	pipeline, _, err := compiler.CompileLite(p.GetData(), false)
 	if err != nil {
 		retErr := fmt.Errorf("unable to expand pipeline %s: %w", entry, err)
 

--- a/api/pipeline/validate.go
+++ b/api/pipeline/validate.go
@@ -5,7 +5,6 @@ package pipeline
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-vela/server/compiler"
@@ -94,16 +93,8 @@ func ValidatePipeline(c *gin.Context) {
 	// create the compiler object
 	compiler := compiler.FromContext(c).Duplicate().WithCommit(p.GetCommit()).WithMetadata(m).WithRepo(r).WithUser(u)
 
-	// capture optional template query parameter
-	template, err := strconv.ParseBool(c.DefaultQuery("template", "true"))
-	if err != nil {
-		util.HandleError(c, http.StatusBadRequest, fmt.Errorf("unable to parse template query parameter for %s: %w", entry, err))
-
-		return
-	}
-
 	// validate the pipeline
-	pipeline, _, err := compiler.CompileLite(p.GetData(), template, false)
+	pipeline, _, err := compiler.CompileLite(p.GetData(), false)
 	if err != nil {
 		retErr := fmt.Errorf("unable to validate pipeline %s: %w", entry, err)
 

--- a/compiler/engine.go
+++ b/compiler/engine.go
@@ -23,7 +23,7 @@ type Engine interface {
 	// CompileLite defines a function that produces an light executable
 	// representation of a pipeline from an object. This calls
 	// Parse internally to convert the object to a yaml configuration.
-	CompileLite(interface{}, bool, bool) (*yaml.Build, *library.Pipeline, error)
+	CompileLite(interface{}, bool) (*yaml.Build, *library.Pipeline, error)
 
 	// Duplicate defines a function that
 	// creates a clone of the Engine.

--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -97,7 +97,7 @@ func (c *client) Compile(v interface{}) (*pipeline.Build, *library.Pipeline, err
 }
 
 // CompileLite produces a partial of an executable pipeline from a yaml configuration.
-func (c *client) CompileLite(v interface{}, template, substitute bool) (*yaml.Build, *library.Pipeline, error) {
+func (c *client) CompileLite(v interface{}, substitute bool) (*yaml.Build, *library.Pipeline, error) {
 	p, data, err := c.Parse(v, c.repo.GetPipelineType(), new(yaml.Template))
 	if err != nil {
 		return nil, nil, err
@@ -122,10 +122,10 @@ func (c *client) CompileLite(v interface{}, template, substitute bool) (*yaml.Bu
 		p = newPipeline
 	}
 
-	if template {
-		// create map of templates for easy lookup
-		templates := mapFromTemplates(p.Templates)
+	// create map of templates for easy lookup
+	templates := mapFromTemplates(p.Templates)
 
+	if len(templates) > 0 {
 		switch {
 		case len(p.Stages) > 0:
 			// inject the templates into the steps

--- a/compiler/native/compile_test.go
+++ b/compiler/native/compile_test.go
@@ -3206,7 +3206,6 @@ func Test_CompileLite(t *testing.T) {
 	type args struct {
 		file         string
 		pipelineType string
-		template     bool
 		substitute   bool
 	}
 
@@ -3221,7 +3220,6 @@ func Test_CompileLite(t *testing.T) {
 			args: args{
 				file:         "testdata/inline_with_stages.yml",
 				pipelineType: "",
-				template:     true,
 				substitute:   true,
 			},
 			want: &yaml.Build{
@@ -3313,7 +3311,6 @@ func Test_CompileLite(t *testing.T) {
 			args: args{
 				file:         "testdata/inline_with_steps.yml",
 				pipelineType: "",
-				template:     true,
 				substitute:   true,
 			},
 			want: &yaml.Build{
@@ -3369,7 +3366,6 @@ func Test_CompileLite(t *testing.T) {
 			args: args{
 				file:         "testdata/golang_inline_stages.yml",
 				pipelineType: "golang",
-				template:     false,
 				substitute:   false,
 			},
 			want: &yaml.Build{
@@ -3423,7 +3419,6 @@ func Test_CompileLite(t *testing.T) {
 			args: args{
 				file:         "testdata/step_inline_template.yml",
 				pipelineType: "",
-				template:     false,
 				substitute:   false,
 			},
 			want:    nil,
@@ -3434,7 +3429,6 @@ func Test_CompileLite(t *testing.T) {
 			args: args{
 				file:         "testdata/stage_inline_template.yml",
 				pipelineType: "",
-				template:     false,
 				substitute:   false,
 			},
 			want:    nil,
@@ -3459,7 +3453,7 @@ func Test_CompileLite(t *testing.T) {
 				t.Errorf("Reading yaml file return err: %v", err)
 			}
 
-			got, _, err := compiler.CompileLite(yaml, tt.args.template, tt.args.substitute)
+			got, _, err := compiler.CompileLite(yaml, tt.args.substitute)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CompileLite() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Context: with the update to the pipeline [validation function](https://github.com/go-vela/server/pull/1036), leveraging `CompileLite(_data, false, false)` with templates present in the pipeline became an impossibility since the resulting pipeline would contain a step without an image. 

Two approaches: revert that enhancement to validation or "fail forward" so to speak and fetch templates if they exist / are replaced locally. 

A downstream benefit of this is the removal of the arguably confusing `--template` boolean flag in the CLI.

I think one could argue that the benefit of an "ignore templates" option is the opportunity to validate pipeline changes without worrying about pulling in templates. I think this is a fair point, but I also think combining [our YAML schema](https://github.com/go-vela/types/blob/main/cmd/schema/main.go) with any sort of standard YAML validator is perfectly suitable. 

Let me know if you disagree!

