### PR TITLE
fix(compiler): track templates in compileInline so CLI validate command works for nested

### DIFF
--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -170,7 +170,6 @@ func (c *client) CompileLite(v interface{}, substitute bool) (*yaml.Build, *libr
 // compileInline parses and expands out inline pipelines.
 func (c *client) compileInline(p *yaml.Build, depth int) (*yaml.Build, error) {
 	newPipeline := *p
-	newPipeline.Templates = yaml.TemplateSlice{}
 
 	// return if max template depth has been reached
 	if depth == 0 {
@@ -203,6 +202,8 @@ func (c *client) compileInline(p *yaml.Build, depth int) (*yaml.Build, error) {
 			if err != nil {
 				return nil, err
 			}
+
+			newPipeline.Templates = append(newPipeline.Templates, parsed.Templates...)
 		}
 
 		switch {

--- a/compiler/native/compile_test.go
+++ b/compiler/native/compile_test.go
@@ -3228,7 +3228,22 @@ func Test_CompileLite(t *testing.T) {
 					RenderInline: true,
 					Environment:  []string{"steps", "services", "secrets"},
 				},
-				Templates: []*yaml.Template{},
+				Templates: []*yaml.Template{
+					{
+						Name:      "golang",
+						Source:    "github.example.com/github/octocat/golang_inline_stages.yml",
+						Format:    "golang",
+						Type:      "github",
+						Variables: map[string]any{"image": string("golang:latest")},
+					},
+					{
+						Name:   "starlark",
+						Source: "github.example.com/github/octocat/starlark_inline_stages.star",
+						Format: "starlark",
+						Type:   "github",
+					},
+				},
+				Environment: raw.StringSliceMap{},
 				Stages: []*yaml.Stage{
 					{
 						Name:  "test",
@@ -3357,7 +3372,21 @@ func Test_CompileLite(t *testing.T) {
 						Pull:     "not_present",
 					},
 				},
-				Templates: yaml.TemplateSlice{},
+				Environment: raw.StringSliceMap{},
+				Templates: yaml.TemplateSlice{
+					{
+						Name:   "golang",
+						Source: "github.example.com/github/octocat/golang_inline_steps.yml",
+						Format: "golang",
+						Type:   "github",
+					},
+					{
+						Name:   "starlark",
+						Source: "github.example.com/github/octocat/starlark_inline_steps.star",
+						Format: "starlark",
+						Type:   "github",
+					},
+				},
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
[This validation](https://github.com/go-vela/cli/blob/00bbc8f12f9c05365a208a5881d612aea85168e9/action/pipeline/validate.go#L118-L132) fails for replaced nested templates without keeping track of what has been called. Generally good for visibility too I'd say, and it's what we do for normal compilations.