### PR TITLE
fix(vault): fix for integer64 fields

### DIFF
--- a/secret/vault/vault.go
+++ b/secret/vault/vault.go
@@ -3,6 +3,7 @@
 package vault
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -158,9 +159,12 @@ func secretFromVault(vault *api.Secret) *library.Secret {
 
 	v, ok = data["allow_events"]
 	if ok {
-		mask, ok := v.(int64)
+		maskJSON, ok := v.(json.Number)
 		if ok {
-			s.SetAllowEvents(library.NewEventsFromMask(mask))
+			mask, err := maskJSON.Int64()
+			if err == nil {
+				s.SetAllowEvents(library.NewEventsFromMask(mask))
+			}
 		}
 	}
 
@@ -241,12 +245,24 @@ func secretFromVault(vault *api.Secret) *library.Secret {
 		}
 	}
 
+	// set allow_substitution if found in Vault secret
+	v, ok = data["allow_substitution"]
+	if ok {
+		substitution, ok := v.(bool)
+		if ok {
+			s.SetAllowSubstitution(substitution)
+		}
+	}
+
 	// set created_at if found in Vault secret
 	v, ok = data["created_at"]
 	if ok {
-		createdAt, ok := v.(int64)
+		createdAtJSON, ok := v.(json.Number)
 		if ok {
-			s.SetCreatedAt(createdAt)
+			createdAt, err := createdAtJSON.Int64()
+			if err == nil {
+				s.SetCreatedAt(createdAt)
+			}
 		}
 	}
 
@@ -262,9 +278,12 @@ func secretFromVault(vault *api.Secret) *library.Secret {
 	// set updated_at if found in Vault secret
 	v, ok = data["updated_at"]
 	if ok {
-		updatedAt, ok := v.(int64)
+		updatedAtJSON, ok := v.(json.Number)
 		if ok {
-			s.SetUpdatedAt(updatedAt)
+			updatedAt, err := updatedAtJSON.Int64()
+			if err == nil {
+				s.SetUpdatedAt(updatedAt)
+			}
 		}
 	}
 
@@ -334,6 +353,11 @@ func vaultFromSecret(s *library.Secret) *api.Secret {
 	// set allow_command if found in Vela secret
 	if s.AllowCommand != nil {
 		vault.Data["allow_command"] = s.GetAllowCommand()
+	}
+
+	// set allow_substitution if found in Vela secret
+	if s.AllowSubstitution != nil {
+		vault.Data["allow_substitution"] = s.GetAllowSubstitution()
 	}
 
 	// set created_at if found in Vela secret

--- a/secret/vault/vault_test.go
+++ b/secret/vault/vault_test.go
@@ -3,12 +3,15 @@
 package vault
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/go-vela/types/library"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/vault/api"
 )
 
@@ -93,42 +96,12 @@ func TestVault_New_Error(t *testing.T) {
 func TestVault_secretFromVault(t *testing.T) {
 	// setup types
 	inputV1 := &api.Secret{
-		Data: map[string]interface{}{
-			"events":        []interface{}{"foo", "bar"},
-			"allow_events":  int64(1),
-			"images":        []interface{}{"foo", "bar"},
-			"name":          "bar",
-			"org":           "foo",
-			"repo":          "*",
-			"team":          "foob",
-			"type":          "org",
-			"value":         "baz",
-			"allow_command": true,
-			"created_at":    int64(1563474077),
-			"created_by":    "octocat",
-			"updated_at":    int64(1563474079),
-			"updated_by":    "octocat2",
-		},
+		Data: testVaultSecretData(),
 	}
 
 	inputV2 := &api.Secret{
 		Data: map[string]interface{}{
-			"data": map[string]interface{}{
-				"events":        []interface{}{"foo", "bar"},
-				"allow_events":  int64(1),
-				"images":        []interface{}{"foo", "bar"},
-				"name":          "bar",
-				"org":           "foo",
-				"repo":          "*",
-				"team":          "foob",
-				"type":          "org",
-				"value":         "baz",
-				"allow_command": true,
-				"created_at":    int64(1563474077),
-				"created_by":    "octocat",
-				"updated_at":    int64(1563474079),
-				"updated_by":    "octocat2",
-			},
+			"data": testVaultSecretData(),
 		},
 	}
 
@@ -143,6 +116,7 @@ func TestVault_secretFromVault(t *testing.T) {
 	want.SetAllowEvents(library.NewEventsFromMask(1))
 	want.SetImages([]string{"foo", "bar"})
 	want.SetAllowCommand(true)
+	want.SetAllowSubstitution(true)
 	want.SetCreatedAt(1563474077)
 	want.SetCreatedBy("octocat")
 	want.SetUpdatedAt(1563474079)
@@ -184,6 +158,7 @@ func TestVault_vaultFromSecret(t *testing.T) {
 	s.SetAllowEvents(library.NewEventsFromMask(1))
 	s.SetImages([]string{"foo", "bar"})
 	s.SetAllowCommand(true)
+	s.SetAllowSubstitution(true)
 	s.SetCreatedAt(1563474077)
 	s.SetCreatedBy("octocat")
 	s.SetUpdatedAt(1563474079)
@@ -191,27 +166,75 @@ func TestVault_vaultFromSecret(t *testing.T) {
 
 	want := &api.Secret{
 		Data: map[string]interface{}{
-			"events":        []string{"foo", "bar"},
-			"allow_events":  int64(1),
-			"images":        []string{"foo", "bar"},
-			"name":          "bar",
-			"org":           "foo",
-			"repo":          "*",
-			"team":          "foob",
-			"type":          "org",
-			"value":         "baz",
-			"allow_command": true,
-			"created_at":    int64(1563474077),
-			"created_by":    "octocat",
-			"updated_at":    int64(1563474079),
-			"updated_by":    "octocat2",
+			"events":             []string{"foo", "bar"},
+			"allow_events":       int64(1),
+			"images":             []string{"foo", "bar"},
+			"name":               "bar",
+			"org":                "foo",
+			"repo":               "*",
+			"team":               "foob",
+			"type":               "org",
+			"value":              "baz",
+			"allow_command":      true,
+			"allow_substitution": true,
+			"created_at":         int64(1563474077),
+			"created_by":         "octocat",
+			"updated_at":         int64(1563474079),
+			"updated_by":         "octocat2",
 		},
 	}
 
 	// run test
 	got := vaultFromSecret(s)
 
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("vaultFromSecret is %v, want %v", got, want)
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("vaultFromSecret() mismatch (-got +want):\n%s", diff)
+	}
+}
+
+func TestVault_AccurateSecretFields(t *testing.T) {
+	testSecret := library.Secret{}
+
+	tSecret := reflect.TypeOf(testSecret)
+
+	vaultSecret := testVaultSecretData()
+
+	for i := 0; i < tSecret.NumField(); i++ {
+		field := tSecret.Field(i)
+
+		jsonTag := field.Tag.Get("json")
+		if jsonTag == "" {
+			continue
+		}
+
+		jsonTag = strings.Split(jsonTag, ",")[0]
+		if strings.EqualFold(jsonTag, "id") {
+			continue // skip id field
+		}
+
+		if vaultSecret[jsonTag] == nil {
+			t.Errorf("vaultSecret missing field with JSON tag %s", jsonTag)
+		}
+	}
+}
+
+// helper function to return a test Vault secret data.
+func testVaultSecretData() map[string]interface{} {
+	return map[string]interface{}{
+		"events":             []interface{}{"foo", "bar"},
+		"allow_events":       json.Number("1"),
+		"images":             []interface{}{"foo", "bar"},
+		"name":               "bar",
+		"org":                "foo",
+		"repo":               "*",
+		"team":               "foob",
+		"type":               "org",
+		"value":              "baz",
+		"allow_command":      true,
+		"allow_substitution": true,
+		"created_at":         json.Number("1563474077"),
+		"created_by":         "octocat",
+		"updated_at":         json.Number("1563474079"),
+		"updated_by":         "octocat2",
 	}
 }


### PR DESCRIPTION
Vault was turning our `int64` inputs into `json.Number` outputs, which caused all the type checking to fail and set those values to 0.

Also added a test to confirm existence of fields for library.Secret in api.Secret data