### PR TITLE
fix(vault): parse pre-v0.23 vault secrets

### DIFF
--- a/secret/vault/vault.go
+++ b/secret/vault/vault.go
@@ -174,6 +174,7 @@ func secretFromVault(vault *api.Secret) *library.Secret {
 		events, ok := data["events"]
 		if ok {
 			allowEventsMask := int64(0)
+
 			for _, element := range events.([]interface{}) {
 				event, ok := element.(string)
 				if ok {

--- a/secret/vault/vault.go
+++ b/secret/vault/vault.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/hashicorp/vault/api"
 	"github.com/pkg/errors"
@@ -157,6 +158,7 @@ func secretFromVault(vault *api.Secret) *library.Secret {
 		}
 	}
 
+	// set allow_events if found in Vault secret
 	v, ok = data["allow_events"]
 	if ok {
 		maskJSON, ok := v.(json.Number)
@@ -165,6 +167,34 @@ func secretFromVault(vault *api.Secret) *library.Secret {
 			if err == nil {
 				s.SetAllowEvents(library.NewEventsFromMask(mask))
 			}
+		}
+	} else {
+		// if not found, convert events to allow_events
+		// this happens when vault secret has not been updated since before v0.23
+		events, ok := data["events"]
+		if ok {
+			allowEventsMask := int64(0)
+			for _, element := range events.([]interface{}) {
+				event, ok := element.(string)
+				if ok {
+					switch event {
+					case constants.EventPush:
+						allowEventsMask |= constants.AllowPushBranch
+					case constants.EventPull:
+						allowEventsMask |= constants.AllowPullOpen | constants.AllowPullReopen | constants.AllowPullSync
+					case constants.EventComment:
+						allowEventsMask |= constants.AllowCommentCreate | constants.AllowCommentEdit
+					case constants.EventDeploy:
+						allowEventsMask |= constants.AllowDeployCreate
+					case constants.EventTag:
+						allowEventsMask |= constants.AllowPushTag
+					case constants.EventSchedule:
+						allowEventsMask |= constants.AllowSchedule
+					}
+				}
+			}
+
+			s.SetAllowEvents(library.NewEventsFromMask(allowEventsMask))
 		}
 	}
 
@@ -251,6 +281,15 @@ func secretFromVault(vault *api.Secret) *library.Secret {
 		substitution, ok := v.(bool)
 		if ok {
 			s.SetAllowSubstitution(substitution)
+		}
+	} else {
+		// set allow_substitution to allow_command value if not found in Vault secret
+		cmd, ok := data["allow_command"]
+		if ok {
+			command, ok := cmd.(bool)
+			if ok {
+				s.SetAllowSubstitution(command)
+			}
 		}
 	}
 

--- a/secret/vault/vault_test.go
+++ b/secret/vault/vault_test.go
@@ -105,6 +105,27 @@ func TestVault_secretFromVault(t *testing.T) {
 		},
 	}
 
+	// test vault secret from pre-v0.23 release
+	inputLegacy := &api.Secret{
+		Data: map[string]interface{}{
+			"data": map[string]interface{}{
+				"events":        []interface{}{"push", "tag", "deployment"},
+				"images":        []interface{}{"foo", "bar"},
+				"name":          "bar",
+				"org":           "foo",
+				"repo":          "*",
+				"team":          "foob",
+				"type":          "org",
+				"value":         "baz",
+				"allow_command": true,
+				"created_at":    json.Number("1563474077"),
+				"created_by":    "octocat",
+				"updated_at":    json.Number("1563474079"),
+				"updated_by":    "octocat2",
+			},
+		},
+	}
+
 	want := new(library.Secret)
 	want.SetOrg("foo")
 	want.SetRepo("*")
@@ -112,8 +133,8 @@ func TestVault_secretFromVault(t *testing.T) {
 	want.SetName("bar")
 	want.SetValue("baz")
 	want.SetType("org")
-	want.SetEvents([]string{"foo", "bar"})
-	want.SetAllowEvents(library.NewEventsFromMask(1))
+	want.SetEvents([]string{"push", "tag", "deployment"})
+	want.SetAllowEvents(library.NewEventsFromMask(8195))
 	want.SetImages([]string{"foo", "bar"})
 	want.SetAllowCommand(true)
 	want.SetAllowSubstitution(true)
@@ -132,6 +153,7 @@ func TestVault_secretFromVault(t *testing.T) {
 	}{
 		{"v1", args{secret: inputV1}},
 		{"v2", args{secret: inputV2}},
+		{"legacy", args{secret: inputLegacy}},
 	}
 
 	for _, tt := range tests {
@@ -221,8 +243,8 @@ func TestVault_AccurateSecretFields(t *testing.T) {
 // helper function to return a test Vault secret data.
 func testVaultSecretData() map[string]interface{} {
 	return map[string]interface{}{
-		"events":             []interface{}{"foo", "bar"},
-		"allow_events":       json.Number("1"),
+		"events":             []interface{}{"push", "tag", "deployment"},
+		"allow_events":       json.Number("8195"),
 		"images":             []interface{}{"foo", "bar"},
 		"name":               "bar",
 		"org":                "foo",


### PR DESCRIPTION
If a vault secret has not been updated since before `v0.23`, it will not have `allow_events` or `allow_substitution`. We can infer these values by converting event slice into the allow events mask and by setting substitution setting to the same setting as the command setting.

I didn't include any update process on the Vela side. Fortunately the UI submits the entire secret form on update, so users will slowly update their vault secrets on their own accord. 

We could also consider creating a migration script of sorts to prevent this code, but we're also supporting v1 and v2 of Vault in code as well. Not saying that's an excuse, but perhaps revisiting our backwards compatibility in general could be a good future issue 🤷 