### PR TITLE
fix: swagger typo in CreateWorker

### DIFF
--- a/api/worker/create.go
+++ b/api/worker/create.go
@@ -40,7 +40,7 @@ import (
 //   '201':
 //     description: Successfully created the worker and retrieved auth token
 //     schema:
-//       "$ref": "#definitions/Token"
+//       "$ref": "#/definitions/Token"
 //   '400':
 //     description: Unable to create the worker
 //     schema:


### PR DESCRIPTION
simple typo fix 
v0.23 api-spec.json causes an error in swagger

```
Semantic error at paths./api/v1/workers.post.responses.201.schema.$ref
$ref paths must begin with `#/`
```

