### PR TITLE
enhance(templates): inject template name as variable

### DIFF
--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -191,6 +191,14 @@ func (c *client) compileInline(p *yaml.Build, depth int) (*yaml.Build, error) {
 			format = constants.PipelineTypeGo
 		}
 
+		// initialize variable map if not parsed from config
+		if len(template.Variables) == 0 {
+			template.Variables = make(map[string]interface{})
+		}
+
+		// inject template name into variables
+		template.Variables["VELA_TEMPLATE_NAME"] = template.Name
+
 		parsed, _, err := c.Parse(bytes, format, template)
 		if err != nil {
 			return nil, err

--- a/compiler/native/compile_test.go
+++ b/compiler/native/compile_test.go
@@ -680,7 +680,7 @@ func TestNative_Compile_StagesPipelineTemplate(t *testing.T) {
 	buildEnv["GRADLE_USER_HOME"] = ".gradle"
 	buildEnv["HOME"] = "/root"
 	buildEnv["SHELL"] = "/bin/sh"
-	buildEnv["VELA_BUILD_SCRIPT"] = generateScriptPosix([]string{"./gradlew build"})
+	buildEnv["VELA_BUILD_SCRIPT"] = generateScriptPosix([]string{"./gradlew build", "echo gradle"})
 	buildEnv["bar"] = "test4"
 	buildEnv["star"] = "test3"
 
@@ -951,7 +951,7 @@ func TestNative_Compile_StepsPipelineTemplate(t *testing.T) {
 	buildEnv["GRADLE_USER_HOME"] = ".gradle"
 	buildEnv["HOME"] = "/root"
 	buildEnv["SHELL"] = "/bin/sh"
-	buildEnv["VELA_BUILD_SCRIPT"] = generateScriptPosix([]string{"./gradlew build"})
+	buildEnv["VELA_BUILD_SCRIPT"] = generateScriptPosix([]string{"./gradlew build", "echo gradle"})
 	buildEnv["bar"] = "test4"
 	buildEnv["star"] = "test3"
 
@@ -3230,17 +3230,21 @@ func Test_CompileLite(t *testing.T) {
 				},
 				Templates: []*yaml.Template{
 					{
-						Name:      "golang",
-						Source:    "github.example.com/github/octocat/golang_inline_stages.yml",
-						Format:    "golang",
-						Type:      "github",
-						Variables: map[string]any{"image": string("golang:latest")},
+						Name:   "golang",
+						Source: "github.example.com/github/octocat/golang_inline_stages.yml",
+						Format: "golang",
+						Type:   "github",
+						Variables: map[string]any{
+							"image":              string("golang:latest"),
+							"VELA_TEMPLATE_NAME": string("golang"),
+						},
 					},
 					{
-						Name:   "starlark",
-						Source: "github.example.com/github/octocat/starlark_inline_stages.star",
-						Format: "starlark",
-						Type:   "github",
+						Name:      "starlark",
+						Source:    "github.example.com/github/octocat/starlark_inline_stages.star",
+						Format:    "starlark",
+						Type:      "github",
+						Variables: map[string]any{"VELA_TEMPLATE_NAME": string("starlark")},
 					},
 				},
 				Environment: raw.StringSliceMap{},
@@ -3375,16 +3379,18 @@ func Test_CompileLite(t *testing.T) {
 				Environment: raw.StringSliceMap{},
 				Templates: yaml.TemplateSlice{
 					{
-						Name:   "golang",
-						Source: "github.example.com/github/octocat/golang_inline_steps.yml",
-						Format: "golang",
-						Type:   "github",
+						Name:      "golang",
+						Source:    "github.example.com/github/octocat/golang_inline_steps.yml",
+						Format:    "golang",
+						Type:      "github",
+						Variables: map[string]any{"VELA_TEMPLATE_NAME": string("golang")},
 					},
 					{
-						Name:   "starlark",
-						Source: "github.example.com/github/octocat/starlark_inline_steps.star",
-						Format: "starlark",
-						Type:   "github",
+						Name:      "starlark",
+						Source:    "github.example.com/github/octocat/starlark_inline_steps.star",
+						Format:    "starlark",
+						Type:      "github",
+						Variables: map[string]any{"VELA_TEMPLATE_NAME": string("starlark")},
 					},
 				},
 			},

--- a/compiler/native/expand.go
+++ b/compiler/native/expand.go
@@ -120,6 +120,14 @@ func (c *client) ExpandSteps(s *yaml.Build, tmpls map[string]*yaml.Template, r *
 			return s, err
 		}
 
+		// initialize variable map if not parsed from config
+		if len(step.Template.Variables) == 0 {
+			step.Template.Variables = make(map[string]interface{})
+		}
+
+		// inject template name into variables
+		step.Template.Variables["VELA_TEMPLATE_NAME"] = step.Template.Name
+
 		tmplBuild, err := c.mergeTemplate(bytes, tmpl, step)
 		if err != nil {
 			return s, err

--- a/compiler/native/expand_test.go
+++ b/compiler/native/expand_test.go
@@ -98,7 +98,7 @@ func TestNative_ExpandStages(t *testing.T) {
 					Pull:  "always",
 				},
 				&yaml.Step{
-					Commands: []string{"./gradlew build"},
+					Commands: []string{"./gradlew build", "echo gradle"},
 					Environment: raw.StringSliceMap{
 						"GRADLE_OPTS":      "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false",
 						"GRADLE_USER_HOME": ".gradle",
@@ -301,7 +301,7 @@ func TestNative_ExpandSteps(t *testing.T) {
 			Pull:  "always",
 		},
 		&yaml.Step{
-			Commands: []string{"./gradlew build"},
+			Commands: []string{"./gradlew build", "echo gradle"},
 			Environment: raw.StringSliceMap{
 				"GRADLE_OPTS":      "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false",
 				"GRADLE_USER_HOME": ".gradle",
@@ -823,7 +823,7 @@ func TestNative_ExpandSteps_TemplateCallTemplate(t *testing.T) {
 			Pull:  "always",
 		},
 		&yaml.Step{
-			Commands: []string{"./gradlew build"},
+			Commands: []string{"./gradlew build", "echo test"},
 			Environment: raw.StringSliceMap{
 				"GRADLE_OPTS":      "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false",
 				"GRADLE_USER_HOME": ".gradle",

--- a/compiler/native/testdata/long_template.yml
+++ b/compiler/native/testdata/long_template.yml
@@ -23,6 +23,7 @@ steps:
   - name: build
     commands:
       - ./gradlew build
+      - echo {{ .VELA_TEMPLATE_NAME }}
     environment: {{ .environment }}
     image: {{ .image }}
     {{ .pull_policy }}


### PR DESCRIPTION
Example pipeline:

`.vela.yml`
```yaml
version: "1"

metadata:
  render_inline: true

templates:
  - name: example
    source: example.yml
    type: file
```

`example.yml`
```yaml
metadata:
  template: true

stages:
  wait:
    steps:
      - name: run
        image: alpine
        commands:
          - sleep 20
          - printenv

  test:
    needs: [ wait ]
    steps:
      - name: run
        image: alpine
        commands:
          - echo "Hello World"
```

Due to the fact that the steps and stages get modified to include the template name, this configuration will not work due to `wait` stage being transformed to `example_wait`. With this change, that part can be modified to

`needs: [{{ .VELA_TEMPLATE_NAME }}_wait]`

This is beneficial to developing widely used templates without instructing all adopters to use the same template name.