### PR TITLE
fix(api/pipeline): correct type for path query param + add testing

### DIFF
--- a/api/pipeline/compile.go
+++ b/api/pipeline/compile.go
@@ -6,7 +6,6 @@ package pipeline
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-vela/server/compiler"
@@ -127,19 +126,14 @@ func prepareRuleData(c *gin.Context) *pipeline.RuleData {
 	tag := c.Query("tag")
 	// capture the target parameter
 	target := c.Query("target")
-
-	var pathSet []string
 	// capture the path parameter
-	path := c.Query("path")
-	if len(path) > 0 {
-		pathSet = strings.Split(path, ",")
-	}
+	pathSet := c.QueryArray("path")
 
 	// if any ruledata query params were provided, create ruledata struct
 	if len(branch) > 0 ||
 		len(comment) > 0 ||
 		len(event) > 0 ||
-		len(path) > 0 ||
+		len(pathSet) > 0 ||
 		len(ruleDataRepo) > 0 ||
 		len(status) > 0 ||
 		len(tag) > 0 ||

--- a/api/pipeline/compile_test.go
+++ b/api/pipeline/compile_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package pipeline
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-vela/types/pipeline"
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestPrepareRuleData tests the prepareRuleData function.
+func TestPrepareRuleData(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name       string
+		parameters map[string]string
+		want       *pipeline.RuleData
+	}{
+		{
+			name: "all params provided",
+			parameters: map[string]string{
+				"branch":  "main",
+				"comment": "Test comment",
+				"event":   "push",
+				"repo":    "my-repo",
+				"status":  "success",
+				"tag":     "v1.0.0",
+				"target":  "production",
+				"path":    "README.md",
+			},
+			want: &pipeline.RuleData{
+				Branch:  "main",
+				Comment: "Test comment",
+				Event:   "push",
+				Repo:    "my-repo",
+				Status:  "success",
+				Tag:     "v1.0.0",
+				Target:  "production",
+				Path:    []string{"README.md"},
+			},
+		},
+		{
+			name: "multiple path params",
+			parameters: map[string]string{
+				"path":   "README.md",
+				"branch": "main",
+			},
+			want: &pipeline.RuleData{
+				Branch: "main",
+				Path:   []string{"README.md", "src/main.go"},
+			},
+		},
+		{
+			name:       "no params provided",
+			parameters: map[string]string{},
+			want:       nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/", nil)
+
+			q := req.URL.Query()
+			for key, value := range tt.parameters {
+				q.Add(key, value)
+			}
+
+			// add additional path parameter for multiple path test
+			if strings.EqualFold(tt.name, "multiple path params") {
+				q.Add("path", "src/main.go")
+			}
+
+			req.URL.RawQuery = q.Encode()
+
+			ctx, _ := gin.CreateTestContext(w)
+			ctx.Request = req
+
+			got := prepareRuleData(ctx)
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("prepareRuleData() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Immediate follow up to https://github.com/go-vela/server/pull/1076, as splitting a query value on a comma is very finicky given URL encoding and fortunately Gin and `"github.com/google/go-querystring/query"` (sdk-go) both handle multi key queries as a slice input.