### PR TITLE
chore(deps): upgrade go-github to v61

### DIFF
--- a/compiler/native/compile_test.go
+++ b/compiler/native/compile_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/raw"
 
-	"github.com/google/go-github/v59/github"
+	"github.com/google/go-github/v61/github"
 
 	"testing"
 	"time"

--- a/compiler/registry/github/github.go
+++ b/compiler/registry/github/github.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/google/go-github/v59/github"
+	"github.com/google/go-github/v61/github"
 	"golang.org/x/oauth2"
 )
 

--- a/compiler/registry/github/github_test.go
+++ b/compiler/registry/github/github_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/go-github/v59/github"
+	"github.com/google/go-github/v61/github"
 	"golang.org/x/oauth2"
 )
 

--- a/compiler/registry/github/template.go
+++ b/compiler/registry/github/template.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/go-vela/types/library"
 
-	"github.com/google/go-github/v59/github"
+	"github.com/google/go-github/v61/github"
 )
 
 // Template captures the templated pipeline configuration from the GitHub repo.

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-vela/types v0.23.4-0.20240402153726-f16c3e4cb5fb
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/go-cmp v0.6.0
-	github.com/google/go-github/v59 v59.0.0
+	github.com/google/go-github/v61 v61.0.0
 	github.com/google/uuid v1.6.0
 	github.com/goware/urlx v0.3.2
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v59 v59.0.0 h1:7h6bgpF5as0YQLLkEiVqpgtJqjimMYhBkD4jT5aN3VA=
-github.com/google/go-github/v59 v59.0.0/go.mod h1:rJU4R0rQHFVFDOkqGWxfLNo6vEk4dv40oDjhV/gH6wM=
+github.com/google/go-github/v61 v61.0.0 h1:VwQCBwhyE9JclCI+22/7mLB1PuU9eowCXKY5pNlu1go=
+github.com/google/go-github/v61 v61.0.0/go.mod h1:0WR+KmsWX75G2EbpyGsGmradjo3IiciuI4BmdVCobQY=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/scm/github/access.go
+++ b/scm/github/access.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/go-vela/types/library"
-	"github.com/google/go-github/v59/github"
+	"github.com/google/go-github/v61/github"
 )
 
 // OrgAccess captures the user's access level for an org.

--- a/scm/github/authentication.go
+++ b/scm/github/authentication.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/go-vela/server/random"
 	"github.com/go-vela/types/library"
-	"github.com/google/go-github/v59/github"
+	"github.com/google/go-github/v61/github"
 )
 
 // Authorize uses the given access token to authorize the user.

--- a/scm/github/changeset.go
+++ b/scm/github/changeset.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/go-vela/types/library"
-	"github.com/google/go-github/v59/github"
+	"github.com/google/go-github/v61/github"
 )
 
 // Changeset captures the list of files changed for a commit.

--- a/scm/github/deployment.go
+++ b/scm/github/deployment.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/raw"
-	"github.com/google/go-github/v59/github"
+	"github.com/google/go-github/v61/github"
 )
 
 // GetDeployment gets a deployment from the GitHub repo.

--- a/scm/github/github.go
+++ b/scm/github/github.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/google/go-github/v59/github"
+	"github.com/google/go-github/v61/github"
 	"github.com/sirupsen/logrus"
 
 	"golang.org/x/oauth2"

--- a/scm/github/github_test.go
+++ b/scm/github/github_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/go-github/v59/github"
+	"github.com/google/go-github/v61/github"
 	"golang.org/x/oauth2"
 )
 

--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
-	"github.com/google/go-github/v59/github"
+	"github.com/google/go-github/v61/github"
 )
 
 // ConfigBackoff is a wrapper for Config that will retry five times if the function
@@ -122,11 +122,8 @@ func (c *client) Disable(ctx context.Context, u *library.User, org, name string)
 			continue
 		}
 
-		// cast url from hook configuration to string
-		hookURL := hook.Config["url"].(string)
-
 		// capture hook ID if the hook url matches
-		if hookURL == fmt.Sprintf("%s/webhook", c.config.ServerWebhookAddress) {
+		if strings.EqualFold(hook.GetConfig().GetURL(), fmt.Sprintf("%s/webhook", c.config.ServerWebhookAddress)) {
 			ids = append(ids, hook.GetID())
 		}
 	}
@@ -192,10 +189,10 @@ func (c *client) Enable(ctx context.Context, u *library.User, r *library.Repo, h
 	// create the hook object to make the API call
 	hook := &github.Hook{
 		Events: events,
-		Config: map[string]interface{}{
-			"url":          fmt.Sprintf("%s/webhook", c.config.ServerWebhookAddress),
-			"content_type": "form",
-			"secret":       r.GetHash(),
+		Config: &github.HookConfig{
+			URL:         github.String(fmt.Sprintf("%s/webhook", c.config.ServerWebhookAddress)),
+			ContentType: github.String("form"),
+			Secret:      github.String(r.GetHash()),
 		},
 		Active: github.Bool(true),
 	}
@@ -266,10 +263,10 @@ func (c *client) Update(ctx context.Context, u *library.User, r *library.Repo, h
 	// create the hook object to make the API call
 	hook := &github.Hook{
 		Events: events,
-		Config: map[string]interface{}{
-			"url":          fmt.Sprintf("%s/webhook", c.config.ServerWebhookAddress),
-			"content_type": "form",
-			"secret":       r.GetHash(),
+		Config: &github.HookConfig{
+			URL:         github.String(fmt.Sprintf("%s/webhook", c.config.ServerWebhookAddress)),
+			ContentType: github.String("form"),
+			Secret:      github.String(r.GetHash()),
 		},
 		Active: github.Bool(true),
 	}

--- a/scm/github/webhook.go
+++ b/scm/github/webhook.go
@@ -18,7 +18,7 @@ import (
 	"github.com/go-vela/types"
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
-	"github.com/google/go-github/v59/github"
+	"github.com/google/go-github/v61/github"
 )
 
 // ProcessWebhook parses the webhook from a repo.


### PR DESCRIPTION
Closes https://github.com/go-vela/server/pull/1099, which needs manual intervention due to the hook config breaking change.