### PR TITLE
fix(types): correct actions pkg for repo events

### DIFF
--- a/api/repo/create.go
+++ b/api/repo/create.go
@@ -10,13 +10,13 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/api/types/actions"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/scm"
 	"github.com/go-vela/server/util"
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
-	"github.com/go-vela/types/library/actions"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 )

--- a/api/types/events.go
+++ b/api/types/events.go
@@ -5,8 +5,8 @@ package types
 import (
 	"fmt"
 
+	"github.com/go-vela/server/api/types/actions"
 	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/library/actions"
 )
 
 // Events is the library representation of the various events that generate a

--- a/api/types/events_test.go
+++ b/api/types/events_test.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/go-vela/server/api/types/actions"
 	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/library/actions"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/database/repo/repo_test.go
+++ b/database/repo/repo_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/api/types/actions"
 	"github.com/go-vela/types/library"
-	"github.com/go-vela/types/library/actions"
 	"github.com/sirupsen/logrus"
 
 	"gorm.io/driver/postgres"


### PR DESCRIPTION
Repo.Events was still using the `go-vela/types/library/actions` package.