### PR TITLE
fix: handle errors from CompileAndPublish

### DIFF
--- a/api/build/compile_publish.go
+++ b/api/build/compile_publish.go
@@ -426,6 +426,8 @@ func CompileAndPublish(
 		// error out the build
 		CleanBuild(c, database, b, nil, nil, retErr)
 
+		util.HandleError(c, http.StatusBadRequest, retErr)
+
 		return nil, nil, retErr
 	}
 

--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -309,6 +309,11 @@ func PostWebhook(c *gin.Context) {
 		queue.FromContext(c),
 	)
 
+	// error handling done in CompileAndPublish
+	if err != nil {
+		return
+	}
+
 	// capture the build and repo from the items
 	b, repo = item.Build, item.Repo
 


### PR DESCRIPTION
fixes a nil panic when you supply an invalid worker route, introduced in https://github.com/go-vela/server/pull/1063