### PR TITLE
fix(repo): sanitize owner information

### DIFF
--- a/api/types/user.go
+++ b/api/types/user.go
@@ -33,9 +33,7 @@ func (u *User) Sanitize() *User {
 		Name:         u.Name,
 		RefreshToken: &value,
 		Token:        &value,
-		Favorites:    u.Favorites,
 		Active:       u.Active,
-		Admin:        u.Admin,
 	}
 }
 

--- a/api/types/user_test.go
+++ b/api/types/user_test.go
@@ -14,7 +14,10 @@ func TestTypes_User_Sanitize(t *testing.T) {
 	// setup types
 	u := testUser()
 
-	want := testUser()
+	want := new(User)
+	want.SetID(1)
+	want.SetName("octocat")
+	want.SetActive(true)
 	want.SetToken(constants.SecretMask)
 	want.SetRefreshToken(constants.SecretMask)
 

--- a/database/integration_test.go
+++ b/database/integration_test.go
@@ -2256,7 +2256,7 @@ func newResources() *Resources {
 
 	repoOne := new(api.Repo)
 	repoOne.SetID(1)
-	repoOne.SetOwner(userOne)
+	repoOne.SetOwner(userOne.Sanitize())
 	repoOne.SetHash("MzM4N2MzMDAtNmY4Mi00OTA5LWFhZDAtNWIzMTlkNTJkODMy")
 	repoOne.SetOrg("github")
 	repoOne.SetName("octocat")
@@ -2279,7 +2279,7 @@ func newResources() *Resources {
 
 	repoTwo := new(api.Repo)
 	repoTwo.SetID(2)
-	repoTwo.SetOwner(userOne)
+	repoTwo.SetOwner(userOne.Sanitize())
 	repoTwo.SetHash("MzM4N2MzMDAtNmY4Mi00OTA5LWFhZDAtNWIzMTlkNTJkODMy")
 	repoTwo.SetOrg("github")
 	repoTwo.SetName("octokitty")

--- a/database/repo/count_user_test.go
+++ b/database/repo/count_user_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-
-	api "github.com/go-vela/server/api/types"
 )
 
 func TestRepo_Engine_CountReposForUser(t *testing.T) {
@@ -32,10 +30,9 @@ func TestRepo_Engine_CountReposForUser(t *testing.T) {
 	_repoTwo.SetFullName("bar/foo")
 	_repoTwo.SetVisibility("public")
 
-	_user := new(api.User)
+	_user := testOwner()
 	_user.SetID(1)
 	_user.SetName("foo")
-	_user.SetToken("bar")
 
 	_postgres, _mock := testPostgres(t)
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()

--- a/database/repo/get_org_test.go
+++ b/database/repo/get_org_test.go
@@ -31,7 +31,6 @@ func TestRepo_Engine_GetRepoForOrg(t *testing.T) {
 	_owner := testOwner()
 	_owner.SetID(1)
 	_owner.SetName("foo")
-	_owner.SetToken("bar")
 
 	_repo.SetOwner(_owner)
 

--- a/database/repo/get_test.go
+++ b/database/repo/get_test.go
@@ -31,7 +31,6 @@ func TestRepo_Engine_GetRepo(t *testing.T) {
 	_owner := testOwner()
 	_owner.SetID(1)
 	_owner.SetName("foo")
-	_owner.SetToken("bar")
 
 	_repo.SetOwner(_owner)
 

--- a/database/repo/list_org_test.go
+++ b/database/repo/list_org_test.go
@@ -56,7 +56,6 @@ func TestRepo_Engine_ListReposForOrg(t *testing.T) {
 	_owner := testOwner()
 	_owner.SetID(1)
 	_owner.SetName("foo")
-	_owner.SetToken("bar")
 
 	_repoOne.SetOwner(_owner)
 	_repoTwo.SetOwner(_owner)

--- a/database/repo/list_test.go
+++ b/database/repo/list_test.go
@@ -42,7 +42,6 @@ func TestRepo_Engine_ListRepos(t *testing.T) {
 	_owner := testOwner()
 	_owner.SetID(1)
 	_owner.SetName("foo")
-	_owner.SetToken("bar")
 
 	_repoOne.SetOwner(_owner)
 	_repoTwo.SetOwner(_owner)

--- a/database/repo/list_user_test.go
+++ b/database/repo/list_user_test.go
@@ -58,7 +58,6 @@ func TestRepo_Engine_ListReposForUser(t *testing.T) {
 	_owner := testOwner()
 	_owner.SetID(1)
 	_owner.SetName("foo")
-	_owner.SetToken("bar")
 
 	_repoOne.SetOwner(_owner)
 	_repoTwo.SetOwner(_owner)

--- a/database/repo/repo.go
+++ b/database/repo/repo.go
@@ -293,7 +293,7 @@ func (r *Repo) ToAPI() *api.Repo {
 	repo := new(api.Repo)
 
 	repo.SetID(r.ID.Int64)
-	repo.SetOwner(r.Owner.ToAPI())
+	repo.SetOwner(r.Owner.ToAPI().Sanitize())
 	repo.SetHash(r.Hash.String)
 	repo.SetOrg(r.Org.String)
 	repo.SetName(r.Name.String)

--- a/database/repo/repo_test.go
+++ b/database/repo/repo_test.go
@@ -230,15 +230,16 @@ func testEvents() *api.Events {
 	}
 }
 
+// testOwner is a helper function that returns a sanitized user.
 func testOwner() *api.User {
+	mask := constants.SecretMask
+
 	return &api.User{
 		ID:           new(int64),
 		Name:         new(string),
-		RefreshToken: new(string),
-		Token:        new(string),
-		Favorites:    new([]string),
+		RefreshToken: &mask,
+		Token:        &mask,
 		Active:       new(bool),
-		Admin:        new(bool),
 	}
 }
 
@@ -426,8 +427,8 @@ func TestRepo_ToAPI(t *testing.T) {
 	// run test
 	got := testRepo().ToAPI()
 
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("ToAPI is %v, want %v", got, want)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("ToAPI() mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/router/middleware/repo/repo_test.go
+++ b/router/middleware/repo/repo_test.go
@@ -14,6 +14,7 @@ import (
 	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/org"
+	"github.com/go-vela/types/constants"
 )
 
 func TestRepo_Retrieve(t *testing.T) {
@@ -40,10 +41,8 @@ func TestRepo_Establish(t *testing.T) {
 	owner.SetID(1)
 	owner.SetName("foo")
 	owner.SetActive(false)
-	owner.SetAdmin(false)
-	owner.SetFavorites([]string{})
-	owner.SetToken("baz")
-	owner.SetRefreshToken("fresh")
+	owner.SetToken(constants.SecretMask)
+	owner.SetRefreshToken(constants.SecretMask)
 
 	want := new(api.Repo)
 	want.SetID(1)


### PR DESCRIPTION
Even though we have the JSON tag of `-` to prevent marshaling of token / refresh token, we may want to further censor information.

This `Sanitize()` function is actually never used, so I slapped it on the `ToAPI()` call for repo owners and extended it to exclude `favorites` and `admin` because not only can favorites get huge, they also shouldn't really be public info.