### PR TITLE
fix(dashboards): add active status on repo partial

### DIFF
--- a/api/dashboard/get.go
+++ b/api/dashboard/get.go
@@ -98,6 +98,7 @@ func buildRepoPartials(c context.Context, repos []*types.DashboardRepo) ([]types
 		repo.Org = dbRepo.GetOrg()
 		repo.Name = dbRepo.GetName()
 		repo.Counter = dbRepo.GetCounter()
+		repo.Active = dbRepo.GetActive()
 
 		// list last 5 builds for repo given the branch and event filters
 		builds, err := database.FromContext(c).ListBuildsForDashboardRepo(c, dbRepo, r.GetBranches(), r.GetEvents())

--- a/api/types/dashboard.go
+++ b/api/types/dashboard.go
@@ -12,6 +12,7 @@ type RepoPartial struct {
 	Org     string         `json:"org,omitempty"`
 	Name    string         `json:"name,omitempty"`
 	Counter int            `json:"counter,omitempty"`
+	Active  bool           `json:"active,omitempty"`
 	Builds  []BuildPartial `json:"builds,omitempty"`
 }
 


### PR DESCRIPTION
If someone disables a repo that is attached to a dashboard, the UI can interpret the active status to display a message of some kind.