### PR TITLE
fix(ci): remove deprecated linter rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,7 +71,6 @@ linters:
     - bidichk # checks for dangerous unicode character sequences
     - bodyclose # checks whether HTTP response body is closed successfully
     - contextcheck # check the function whether use a non-inherited context
-    - deadcode # finds unused code
     - dupl # code clone detection
     - errcheck # checks for unchecked errors
     - errorlint # find misuses of errors
@@ -97,14 +96,12 @@ linters:
     - nolintlint # reports ill-formed or insufficient nolint directives
     - revive # linter for go
     - staticcheck # applies static analysis checks, go vet on steroids
-    - structcheck # finds unused struct fields
     - stylecheck # replacement for golint
     - tenv # analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
     - typecheck # parses and type-checks go code, like the front-end of a go compiler
     - unconvert # remove unnecessary type conversions
     - unparam # reports unused function parameters
     - unused # checks for unused constants, variables, functions and types
-    - varcheck # finds unused global variables and constants
     - whitespace # detects leading and trailing whitespace
     - wsl # forces code to use empty lines
 


### PR DESCRIPTION
`structcheck`, `varcheck`, and `deadcode` are all replaced by `unused`, which we already have enabled.

The newer versions of `golangci-lint` are now throwing errors when these are used.