### PR TITLE
fix(compiler): aggregate templates for nested pipelines

### DIFF
--- a/compiler/native/expand.go
+++ b/compiler/native/expand.go
@@ -60,6 +60,7 @@ func (c *client) ExpandSteps(s *yaml.Build, tmpls map[string]*yaml.Template, r *
 	secrets := s.Secrets
 	services := s.Services
 	environment := s.Environment
+	templates := s.Templates
 
 	if len(environment) == 0 {
 		environment = make(raw.StringSliceMap)
@@ -139,6 +140,8 @@ func (c *client) ExpandSteps(s *yaml.Build, tmpls map[string]*yaml.Template, r *
 				return s, fmt.Errorf("cannot use render_inline inside a called template (%s)", step.Template.Name)
 			}
 
+			templates = append(templates, tmplBuild.Templates...)
+
 			tmplBuild, err = c.ExpandSteps(tmplBuild, mapFromTemplates(tmplBuild.Templates), r, depth-1)
 			if err != nil {
 				return s, err
@@ -202,6 +205,7 @@ func (c *client) ExpandSteps(s *yaml.Build, tmpls map[string]*yaml.Template, r *
 	s.Secrets = secrets
 	s.Services = services
 	s.Environment = environment
+	s.Templates = templates
 
 	return s, nil
 }

--- a/compiler/native/expand_test.go
+++ b/compiler/native/expand_test.go
@@ -869,6 +869,19 @@ func TestNative_ExpandSteps_TemplateCallTemplate(t *testing.T) {
 		"star": "test3",
 	}
 
+	wantTemplates := yaml.TemplateSlice{
+		{
+			Name:   "chain",
+			Source: "github.example.com/faz/baz/template_calls_template.yml",
+			Type:   "github",
+		},
+		{
+			Name:   "test",
+			Source: "github.example.com/foo/bar/long_template.yml",
+			Type:   "github",
+		},
+	}
+
 	// run test
 	compiler, err := New(c)
 	if err != nil {
@@ -879,7 +892,7 @@ func TestNative_ExpandSteps_TemplateCallTemplate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			build, err := compiler.ExpandSteps(&yaml.Build{Steps: steps, Services: yaml.ServiceSlice{}, Environment: globalEnvironment}, test.tmpls, new(pipeline.RuleData), compiler.TemplateDepth)
+			build, err := compiler.ExpandSteps(&yaml.Build{Steps: steps, Services: yaml.ServiceSlice{}, Environment: globalEnvironment, Templates: yaml.TemplateSlice{test.tmpls["chain"]}}, test.tmpls, new(pipeline.RuleData), compiler.TemplateDepth)
 			if err != nil {
 				t.Errorf("ExpandSteps_Type%s returned err: %v", test.name, err)
 			}
@@ -897,6 +910,10 @@ func TestNative_ExpandSteps_TemplateCallTemplate(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(build.Environment, wantEnvironment); diff != "" {
+				t.Errorf("ExpandSteps()_Type%s mismatch (-want +got):\n%s", test.name, diff)
+			}
+
+			if diff := cmp.Diff(build.Templates, wantTemplates); diff != "" {
 				t.Errorf("ExpandSteps()_Type%s mismatch (-want +got):\n%s", test.name, diff)
 			}
 		})


### PR DESCRIPTION
Fixed this for [compile inline](https://github.com/go-vela/server/pull/1067) but not in normal CompileLite, which causes `vela validate` to fail on nested templates locally replaced with the error:

```sh
FATA[0000] local template with name foo not included in pipeline templates
```

Now the resulting pipeline will include all templates called and pass that validation.