### PR TITLE
chore: Correct the register worker token swagger path

### DIFF
--- a/api/admin/worker.go
+++ b/api/admin/worker.go
@@ -16,7 +16,7 @@ import (
 	"github.com/go-vela/types/library"
 )
 
-// swagger:operation POST /api/v1/admin/workers/{worker}/register-token admin RegisterToken
+// swagger:operation POST /api/v1/admin/workers/{worker}/register admin RegisterToken
 //
 // Get a worker registration token
 //


### PR DESCRIPTION
Noticed in the [admin router](https://github.com/go-vela/server/blob/v0.23.4/router/admin.go#L61) that this endpoint is wired up  under `[...]/workers/:worker/register` but it's currently documented as `[...]/workers/:worker/register-token`