### PR TITLE
fix: only convert commands query param when provided

### DIFF
--- a/api/build/id_request_token.go
+++ b/api/build/id_request_token.go
@@ -113,13 +113,18 @@ func GetIDRequestToken(c *gin.Context) {
 		return
 	}
 
-	commands, err := strconv.ParseBool(c.Query("commands"))
-	if err != nil {
-		retErr := fmt.Errorf("unable to parse 'commands' query parameter as boolean %s: %w", c.Query("commands"), err)
+	commands := false
+	var err error
 
-		util.HandleError(c, http.StatusBadRequest, retErr)
+	if len(c.Query("commands")) > 0 {
+		commands, err = strconv.ParseBool(c.Query("commands"))
+		if err != nil {
+			retErr := fmt.Errorf("unable to parse 'commands' query parameter as boolean %s: %w", c.Query("commands"), err)
 
-		return
+			util.HandleError(c, http.StatusBadRequest, retErr)
+
+			return
+		}
 	}
 
 	// retrieve token manager from context

--- a/api/build/id_request_token.go
+++ b/api/build/id_request_token.go
@@ -114,6 +114,7 @@ func GetIDRequestToken(c *gin.Context) {
 	}
 
 	commands := false
+
 	var err error
 
 	if len(c.Query("commands")) > 0 {


### PR DESCRIPTION
commands=false in the sdk is actually not applying the query param at all. makes sense, but my bad on the strict validation.

fixes this worker error when using `id_request: write`
```
error:unable to parse 'commands' query parameter as boolean : strconv.ParseBool: parsing "": invalid syntax
```