### PR TITLE
fix: swagger error and golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,10 @@
 # outputs it results from the linters it executes.
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
+  formats:
+    - format: json
+      path: stderr
+    - format: colored-line-number
 
   # print lines of code with issue, default is true
   print-issued-lines: true

--- a/api/auth/validate_oauth.go
+++ b/api/auth/validate_oauth.go
@@ -30,7 +30,7 @@ import (
 //   '200':
 //     description: Successfully validated
 //     schema:
-//       "$ref": "#/definitions/Token"
+//       type: string
 //   '401':
 //     description: Unauthorized
 //     schema:


### PR DESCRIPTION
one overlooked swagger annotation issue
fix for golangci-lint config (`format` is not a valid property - see https://golangci-lint.run/usage/configuration/#output-configuration) - which also fixes error reporting locally in certain editors