### PR TITLE
fix: use correct build links to steps for commit status updates

### DIFF
--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -411,7 +411,7 @@ func (c *client) StepStatus(ctx context.Context, u *api.User, b *api.Build, s *l
 	client := c.newClientToken(*u.Token)
 
 	context := fmt.Sprintf("%s/%s/%s", c.config.StatusContext, b.GetEvent(), s.GetReportAs())
-	url := fmt.Sprintf("%s/%s/%s/%d#step:%d", c.config.WebUIAddress, org, name, b.GetNumber(), s.GetNumber())
+	url := fmt.Sprintf("%s/%s/%s/%d#%d", c.config.WebUIAddress, org, name, b.GetNumber(), s.GetNumber())
 
 	var (
 		state       string


### PR DESCRIPTION
this was modified in the UI with the refactor but not updated for sending step specific commit statuses to the SCM. "Details" links shown in the GitHub UI will still bring you to the right build, it just won't auto-expand any targeted step.

old format: `<domain>/org/repo/1#step:3`
new format: `<domain>/org/repo/1#3`