### PR TITLE
fix(oidc): add expected fields

### DIFF
--- a/api/oi_config.go
+++ b/api/oi_config.go
@@ -40,7 +40,7 @@ func GetOpenIDConfig(c *gin.Context) {
 	config := types.OpenIDConfig{
 		Issuer:      fmt.Sprintf("%s/_services/token", m.Vela.Address),
 		JWKSAddress: fmt.Sprintf("%s/%s", m.Vela.Address, "_services/token/.well-known/jwks"),
-		SupportedClaims: []string{
+		ClaimsSupported: []string{
 			"sub",
 			"exp",
 			"iat",
@@ -59,8 +59,14 @@ func GetOpenIDConfig(c *gin.Context) {
 			"sha",
 			"ref",
 		},
+		ResponseTypesSupported: []string{
+			"id_token",
+		},
 		Algorithms: []string{
 			jwt.SigningMethodRS256.Name,
+		},
+		SubjectTypesSupported: []string{
+			"public",
 		},
 	}
 

--- a/api/types/oidc.go
+++ b/api/types/oidc.go
@@ -11,10 +11,12 @@ import (
 //
 // swagger:model OpenIDConfig
 type OpenIDConfig struct {
-	Issuer          string   `json:"issuer"`
-	JWKSAddress     string   `json:"jwks_uri"`
-	SupportedClaims []string `json:"supported_claims"`
-	Algorithms      []string `json:"id_token_signing_alg_values_supported"`
+	Issuer                 string   `json:"issuer"`
+	JWKSAddress            string   `json:"jwks_uri"`
+	ClaimsSupported        []string `json:"claims_supported"`
+	Algorithms             []string `json:"id_token_signing_alg_values_supported"`
+	ResponseTypesSupported []string `json:"response_types_supported"`
+	SubjectTypesSupported  []string `json:"subject_types_supported"`
 }
 
 // OpenIDClaims struct is an extension of the JWT standard claims. It


### PR DESCRIPTION
I spent some time over this weekend experimenting with the new OIDC feature and noticed that the `/_services/token/.well-known/openid-configuration` endpoint doesn't align with AWS's expected format for openid. AWS's documentation specifies the required fields, which you can find at https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html#manage-oidc-provider-prerequisites. After updating the API response to include all of these fields, the issue was resolved. 

openid documents the discovery endpoint schema within https://openid.net/specs/openid-connect-discovery-1_0.html.