### PR TITLE
enhance: surface redis ping errors

### DIFF
--- a/queue/redis/ping.go
+++ b/queue/redis/ping.go
@@ -4,7 +4,6 @@ package redis
 
 import (
 	"context"
-	"fmt"
 )
 
 // Ping contacts the queue to test its connection.
@@ -13,7 +12,7 @@ func (c *client) Ping(ctx context.Context) error {
 	err := c.Redis.Ping(ctx).Err()
 	if err != nil {
 		c.Logger.Debugf("unable to ping Redis queue.")
-		return fmt.Errorf("unable to establish connection to Redis queue")
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
when workers cant ping the queue the log/context we get back is missing everything useful.