### PR TITLE
enhance: add a status call for failed compilation

### DIFF
--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -405,7 +405,14 @@ func PostWebhook(c *gin.Context) {
 		h.SetStatus(constants.StatusFailure)
 		h.SetError(err.Error())
 
+		b.SetStatus(constants.StatusError)
+
 		util.HandleError(c, code, err)
+
+		err = scm.FromContext(c).Status(ctx, repo.GetOwner(), b, repo.GetOrg(), repo.GetName())
+		if err != nil {
+			l.Debugf("unable to set commit status for %s/%d: %v", repo.GetFullName(), b.GetNumber(), err)
+		}
 
 		return
 	}

--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -335,7 +335,14 @@ func (c *client) Status(ctx context.Context, u *api.User, b *api.Build, org, nam
 		description = "build was skipped as no steps/stages found"
 	default:
 		state = "error"
-		description = "there was an error"
+
+		// if there is no build, then this status update is from a failed compilation
+		if b.GetID() == 0 {
+			description = "error compiling pipeline - check audit for more information"
+			url = fmt.Sprintf("%s/%s/%s/hooks", c.config.WebUIAddress, org, name)
+		} else {
+			description = "there was an error"
+		}
 	}
 
 	// check if the build event is deployment


### PR DESCRIPTION
This will greatly ease the amount of sleuthing users have to do when they don't see a Vela status show up on their PR / commit. 

Further, the context URL will point to the hooks page, which should take users right to the error message.