### PR TITLE
fix: exit hook retry loop on success

### DIFF
--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -306,10 +306,10 @@ func PostWebhook(c *gin.Context) {
 			h.SetError(retErr.Error())
 
 			return
-		} else {
-			// hook was created successfully
-			break
 		}
+
+		// hook was created successfully
+		break
 	}
 
 	l.WithFields(logrus.Fields{

--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -306,6 +306,9 @@ func PostWebhook(c *gin.Context) {
 			h.SetError(retErr.Error())
 
 			return
+		} else {
+			// hook was created successfully
+			break
 		}
 	}
 


### PR DESCRIPTION
fixes a regression introduced in #1175 where `retryLimit - 1` duplicate hooks are created after success.

cc @jbrockopp 