### PR TITLE
fix(api/dashboards): return empty list

### DIFF
--- a/api/dashboard/list_user.go
+++ b/api/dashboard/list_user.go
@@ -55,7 +55,7 @@ func ListUserDashboards(c *gin.Context) {
 
 	l.Debugf("listing dashboards for user %s", u.GetName())
 
-	var dashCards []types.DashCard
+	dashCards := []types.DashCard{}
 
 	// iterate through user dashboards and build a list of DashCards
 	for _, dashboard := range u.GetDashboards() {


### PR DESCRIPTION
when there are no dashboards we currently return 'null'. this change will return an empty list instead