### PR TITLE
chore(tracing): rename cli key

### DIFF
--- a/tracing/config.go
+++ b/tracing/config.go
@@ -69,7 +69,7 @@ func FromCLIContext(c *cli.Context) (*Client, error) {
 	}
 
 	// read per-endpoint configurations from file
-	endpointsConfigPath := c.String("tracing.sampler.endpoints")
+	endpointsConfigPath := c.String("tracing.sampler.tasks")
 	if len(endpointsConfigPath) > 0 {
 		f, err := os.ReadFile(endpointsConfigPath)
 		if err != nil {

--- a/tracing/flags.go
+++ b/tracing/flags.go
@@ -76,7 +76,7 @@ var Flags = []cli.Flag{
 
 	&cli.StringFlag{
 		EnvVars: []string{"VELA_OTEL_TRACING_SAMPLER_TASKS_CONFIG_FILEPATH"},
-		Name:    "tracing.sampler.endpoints",
+		Name:    "tracing.sampler.tasks",
 		Usage:   "set an (optional) filepath to the otel tracing head-sampler configurations json to alter how certain tasks (endpoints, queries, etc) are sampled. when no path is provided all tasks are recorded using default parameters. see: https://opentelemetry.io/docs/concepts/sampling/",
 	},
 }


### PR DESCRIPTION
leftover naming from when i pictured the tracing config would only apply to api endpoints
see: #1184 