### PR TITLE
fix(dashboards): set name for deleted dashboard

### DIFF
--- a/api/dashboard/list_user.go
+++ b/api/dashboard/list_user.go
@@ -67,6 +67,7 @@ func ListUserDashboards(c *gin.Context) {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				d = new(types.Dashboard)
 				d.SetID(dashboard)
+				d.SetName("(not found)")
 
 				dashCard.Dashboard = d
 				// if user dashboard has been deleted, append empty dashboard


### PR DESCRIPTION
scenario: another user adds dashboard, you add that dashboard to your list, other user decides to delete dashboard. the dashboard remains in your list but is inaccessible. we have the id, but not the name (because it has been deleted). this will set the name to "(not found)" in the response returned to the callee. we can utilize this in the UI(s) to provide appropriate messaging for users to update their dashboard list.