### PR TITLE
fix(oidc): image parse sha support

### DIFF
--- a/internal/token/mint.go
+++ b/internal/token/mint.go
@@ -223,6 +223,10 @@ func imageParse(image string) (string, string, error) {
 		return image, "latest", nil
 	case 2:
 		return parts[0], parts[1], nil
+	case 3:
+		_parts := strings.Split(parts[1]+parts[2], "@")
+
+		return parts[0], _parts[0], nil
 	default:
 		return "", "", fmt.Errorf("invalid image format: %s", image)
 	}

--- a/internal/token/mint_test.go
+++ b/internal/token/mint_test.go
@@ -25,6 +25,15 @@ func Test_imageParse(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name: "image with tag and sha",
+			args: args{
+				image: "alpine:1.20@sha:fc0d4410fd2343cf6f7a75d5819001a34ca3b549fbab0c231b7aab49b57e9e43",
+			},
+			wantName: "alpine",
+			wantTag:  "1.20",
+			wantErr:  false,
+		},
+		{
 			name: "image without latest tag",
 			args: args{
 				image: "alpine:latest",
@@ -45,16 +54,16 @@ func Test_imageParse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, err := imageParse(tt.args.image)
+			gotName, gotTag, err := imageParse(tt.args.image)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("imageParse() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.wantName {
-				t.Errorf("imageParse() got = %v, wantName %v", got, tt.wantName)
+			if gotName != tt.wantName {
+				t.Errorf("imageParse() gotName = %v, wantName %v", gotName, tt.wantName)
 			}
-			if got1 != tt.wantTag {
-				t.Errorf("imageParse() got1 = %v, wantName %v", got1, tt.wantTag)
+			if gotTag != tt.wantTag {
+				t.Errorf("imageParse() gotTag = %v, wantTag %v", gotTag, tt.wantTag)
 			}
 		})
 	}


### PR DESCRIPTION
tiny fix for https://github.com/go-vela/server/pull/1172 `invalid reference format` with sha tags

or should we use `reference.Parse` similar to the [worker code](https://github.com/go-vela/worker/blob/main/internal/image/image.go#L61-L75) 