### PR TITLE
refactor(steps/services): use server API types for steps and services

### DIFF
--- a/api/admin/clean.go
+++ b/api/admin/clean.go
@@ -11,10 +11,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/util"
 	"github.com/go-vela/types"
-	"github.com/go-vela/types/constants"
 )
 
 // swagger:operation PUT /api/v1/admin/clean admin AdminCleanResources

--- a/api/admin/service.go
+++ b/api/admin/service.go
@@ -10,9 +10,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/library"
 )
 
 // swagger:operation PUT /api/v1/admin/service admin AdminUpdateService
@@ -59,7 +59,7 @@ func UpdateService(c *gin.Context) {
 	l.Debug("platform admin: updating service")
 
 	// capture body from API request
-	input := new(library.Service)
+	input := new(types.Service)
 
 	err := c.Bind(input)
 	if err != nil {

--- a/api/admin/step.go
+++ b/api/admin/step.go
@@ -10,9 +10,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/library"
 )
 
 // swagger:operation PUT /api/v1/admin/step admin AdminUpdateStep
@@ -58,7 +58,7 @@ func UpdateStep(c *gin.Context) {
 	l.Debug("platform admin: updating step")
 
 	// capture body from API request
-	input := new(library.Step)
+	input := new(types.Step)
 
 	err := c.Bind(input)
 	if err != nil {

--- a/api/admin/worker.go
+++ b/api/admin/worker.go
@@ -9,9 +9,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/internal/token"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
 

--- a/api/auth/logout.go
+++ b/api/auth/logout.go
@@ -10,11 +10,11 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/internal"
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // swagger:operation GET /logout authenticate GetLogout

--- a/api/auth/post_token.go
+++ b/api/auth/post_token.go
@@ -9,11 +9,11 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/internal/token"
 	"github.com/go-vela/server/scm"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
 

--- a/api/badge.go
+++ b/api/badge.go
@@ -8,10 +8,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/repo"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // swagger:operation GET /badge/{org}/{repo}/status.svg base GetBadge

--- a/api/build/approve.go
+++ b/api/build/approve.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/queue"
 	"github.com/go-vela/server/queue/models"
@@ -19,7 +20,6 @@ import (
 	"github.com/go-vela/server/router/middleware/repo"
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // swagger:operation POST /api/v1/repos/{org}/{repo}/builds/{build}/approve builds ApproveBuild

--- a/api/build/auto_cancel.go
+++ b/api/build/auto_cancel.go
@@ -16,9 +16,9 @@ import (
 
 	"github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/compiler/types/pipeline"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/internal/token"
-	"github.com/go-vela/types/constants"
 )
 
 // AutoCancel is a helper function that checks to see if any pending or running

--- a/api/build/auto_cancel_test.go
+++ b/api/build/auto_cancel_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/compiler/types/pipeline"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func Test_isCancelable(t *testing.T) {

--- a/api/build/cancel.go
+++ b/api/build/cancel.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/internal/token"
 	"github.com/go-vela/server/router/middleware/build"
@@ -20,7 +21,6 @@ import (
 	"github.com/go-vela/server/router/middleware/repo"
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // swagger:operation DELETE /api/v1/repos/{org}/{repo}/builds/{build}/cancel builds CancelBuild

--- a/api/build/clean.go
+++ b/api/build/clean.go
@@ -10,15 +10,14 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/library"
 )
 
 // cleanBuild is a helper function to kill the build
 // without execution. This will kill all resources,
 // like steps and services, for the build.
-func CleanBuild(ctx context.Context, database database.Interface, b *types.Build, services []*library.Service, steps []*library.Step, e error) {
+func CleanBuild(ctx context.Context, database database.Interface, b *types.Build, services []*types.Service, steps []*types.Step, e error) {
 	l := logrus.WithFields(logrus.Fields{
 		"build":    b.GetNumber(),
 		"build_id": b.GetID(),

--- a/api/build/compile_publish.go
+++ b/api/build/compile_publish.go
@@ -16,12 +16,12 @@ import (
 	"github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/compiler"
 	"github.com/go-vela/server/compiler/types/pipeline"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/internal"
 	"github.com/go-vela/server/queue"
 	"github.com/go-vela/server/queue/models"
 	"github.com/go-vela/server/scm"
-	"github.com/go-vela/types/constants"
 )
 
 // CompileAndPublishConfig is a struct that contains information for the CompileAndPublish function.

--- a/api/build/graph.go
+++ b/api/build/graph.go
@@ -11,8 +11,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/compiler"
 	"github.com/go-vela/server/compiler/types/pipeline"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/internal"
 	"github.com/go-vela/server/router/middleware/build"
@@ -20,8 +22,6 @@ import (
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/scm"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/library"
 )
 
 // Graph contains nodes, and relationships between nodes, or edges.
@@ -46,10 +46,10 @@ type node struct {
 	Name    string `json:"name"`
 
 	// vela metadata
-	Status     string          `json:"status"`
-	StartedAt  int             `json:"started_at"`
-	FinishedAt int             `json:"finished_at"`
-	Steps      []*library.Step `json:"steps"`
+	Status     string        `json:"status"`
+	StartedAt  int           `json:"started_at"`
+	FinishedAt int           `json:"finished_at"`
+	Steps      []*types.Step `json:"steps"`
 
 	// unexported data used for building edges
 	Stage *pipeline.Stage `json:"-"`
@@ -67,7 +67,7 @@ type edge struct {
 
 // stg represents a stage's steps and some metadata for producing node/edge information.
 type stg struct {
-	steps []*library.Step
+	steps []*types.Step
 	// used for tracking stage status
 	success    int
 	running    int
@@ -241,7 +241,7 @@ func GetBuildGraph(c *gin.Context) {
 	}
 
 	// retrieve the steps for the build from the step table
-	steps := []*library.Step{}
+	steps := []*types.Step{}
 	page := 1
 	perPage := 100
 
@@ -279,7 +279,7 @@ func GetBuildGraph(c *gin.Context) {
 	}
 
 	// retrieve the services for the build from the service table
-	services := []*library.Service{}
+	services := []*types.Service{}
 	page = 1
 	perPage = 100
 
@@ -359,7 +359,7 @@ func GetBuildGraph(c *gin.Context) {
 		// initialize a stage tracker
 		if _, ok := stageMap[name]; !ok {
 			stageMap[name] = &stg{
-				steps: []*library.Step{},
+				steps: []*types.Step{},
 			}
 		}
 
@@ -615,13 +615,13 @@ func nodeFromStage(nodeID, cluster int, stage *pipeline.Stage, s *stg) *node {
 }
 
 // nodeFromService returns a new node from a service.
-func nodeFromService(nodeID int, service *library.Service) *node {
+func nodeFromService(nodeID int, service *types.Service) *node {
 	return &node{
 		ID:         nodeID,
 		Cluster:    ServiceCluster,
 		Name:       service.GetName(),
 		Stage:      nil,
-		Steps:      []*library.Step{},
+		Steps:      []*types.Step{},
 		Status:     service.GetStatus(),
 		StartedAt:  int(service.GetStarted()),
 		FinishedAt: int(service.GetFinished()),

--- a/api/build/list_org.go
+++ b/api/build/list_org.go
@@ -12,12 +12,12 @@ import (
 
 	"github.com/go-vela/server/api"
 	"github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/org"
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/scm"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // swagger:operation GET /api/v1/repos/{org}/builds builds ListBuildsForOrg

--- a/api/build/list_repo.go
+++ b/api/build/list_repo.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/go-vela/server/api"
 	"github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/repo"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // swagger:operation GET /api/v1/repos/{org}/{repo}/builds builds ListBuildsForRepo

--- a/api/build/restart.go
+++ b/api/build/restart.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/go-vela/server/compiler"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/internal"
 	"github.com/go-vela/server/queue"
@@ -21,7 +22,6 @@ import (
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/scm"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // swagger:operation POST /api/v1/repos/{org}/{repo}/builds/{build} builds RestartBuild

--- a/api/build/token.go
+++ b/api/build/token.go
@@ -11,12 +11,12 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/internal/token"
 	"github.com/go-vela/server/router/middleware/build"
 	"github.com/go-vela/server/router/middleware/claims"
 	"github.com/go-vela/server/router/middleware/repo"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
 

--- a/api/build/update.go
+++ b/api/build/update.go
@@ -10,13 +10,12 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/build"
 	"github.com/go-vela/server/router/middleware/repo"
 	"github.com/go-vela/server/scm"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/library"
 )
 
 // swagger:operation PUT /api/v1/repos/{org}/{repo}/builds/{build} builds UpdateBuild
@@ -191,7 +190,7 @@ func UpdateComponentStatuses(c *gin.Context, b *types.Build, status string) erro
 	l.Debug("updating component statuses")
 
 	// retrieve the steps for the build from the step table
-	steps := []*library.Step{}
+	steps := []*types.Step{}
 	page := 1
 	perPage := 100
 
@@ -230,7 +229,7 @@ func UpdateComponentStatuses(c *gin.Context, b *types.Build, status string) erro
 	}
 
 	// retrieve the services for the build from the service table
-	services := []*library.Service{}
+	services := []*types.Service{}
 	page = 1
 
 	for page > 0 {

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -12,9 +12,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/queue"
-	"github.com/go-vela/types/constants"
 )
 
 // MetricsQueryParameters holds query parameter information pertaining to requested metrics.

--- a/api/repo/create.go
+++ b/api/repo/create.go
@@ -14,12 +14,12 @@ import (
 
 	"github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/api/types/actions"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/settings"
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/scm"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // swagger:operation POST /api/v1/repos repos CreateRepo

--- a/api/repo/list_org.go
+++ b/api/repo/list_org.go
@@ -11,12 +11,12 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/go-vela/server/api"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/org"
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/scm"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // swagger:operation GET /api/v1/repos/{org} repos ListReposForOrg

--- a/api/repo/update.go
+++ b/api/repo/update.go
@@ -13,12 +13,12 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/repo"
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/scm"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // swagger:operation PUT /api/v1/repos/{org}/{repo} repos UpdateRepo

--- a/api/secret/create.go
+++ b/api/secret/create.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/api/types/actions"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/scm"
 	"github.com/go-vela/server/secret"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // swagger:operation POST /api/v1/secrets/{engine}/{type}/{org}/{name} secrets CreateSecret

--- a/api/secret/delete.go
+++ b/api/secret/delete.go
@@ -10,9 +10,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/secret"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // swagger:operation DELETE /api/v1/secrets/{engine}/{type}/{org}/{name}/{secret} secrets DeleteSecret

--- a/api/secret/get.go
+++ b/api/secret/get.go
@@ -10,10 +10,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/router/middleware/claims"
 	"github.com/go-vela/server/secret"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // swagger:operation GET /api/v1/secrets/{engine}/{type}/{org}/{name}/{secret} secrets GetSecret

--- a/api/secret/list.go
+++ b/api/secret/list.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/go-vela/server/api"
 	"github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/scm"
 	"github.com/go-vela/server/secret"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // swagger:operation GET /api/v1/secrets/{engine}/{type}/{org}/{name} secrets ListSecrets

--- a/api/secret/update.go
+++ b/api/secret/update.go
@@ -12,10 +12,10 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/secret"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 //

--- a/api/service/create.go
+++ b/api/service/create.go
@@ -10,12 +10,12 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/build"
 	"github.com/go-vela/server/router/middleware/repo"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/library"
 )
 
 // swagger:operation POST /api/v1/repos/{org}/{repo}/builds/{build}/services services CreateService
@@ -85,7 +85,7 @@ func CreateService(c *gin.Context) {
 	l.Debugf("creating new service for build %s", entry)
 
 	// capture body from API request
-	input := new(library.Service)
+	input := new(types.Service)
 
 	err := c.Bind(input)
 	if err != nil {

--- a/api/service/plan.go
+++ b/api/service/plan.go
@@ -11,22 +11,22 @@ import (
 
 	"github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/compiler/types/pipeline"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
 
 // PlanServices is a helper function to plan all services
 // in the build for execution. This creates the services
 // for the build.
-func PlanServices(ctx context.Context, database database.Interface, p *pipeline.Build, b *types.Build) ([]*library.Service, error) {
+func PlanServices(ctx context.Context, database database.Interface, p *pipeline.Build, b *types.Build) ([]*types.Service, error) {
 	// variable to store planned services
-	services := []*library.Service{}
+	services := []*types.Service{}
 
 	// iterate through all pipeline services
 	for _, service := range p.Services {
 		// create the service object
-		s := new(library.Service)
+		s := new(types.Service)
 		s.SetBuildID(b.GetID())
 		s.SetRepoID(b.GetRepo().GetID())
 		s.SetName(service.Name)

--- a/api/service/update.go
+++ b/api/service/update.go
@@ -9,12 +9,12 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/build"
 	"github.com/go-vela/server/router/middleware/repo"
 	"github.com/go-vela/server/router/middleware/service"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/library"
 )
 
 //
@@ -91,7 +91,7 @@ func UpdateService(c *gin.Context) {
 	l.Debugf("updating service %s", entry)
 
 	// capture body from API request
-	input := new(library.Service)
+	input := new(types.Service)
 
 	err := c.Bind(input)
 	if err != nil {

--- a/api/step/create.go
+++ b/api/step/create.go
@@ -10,12 +10,12 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/build"
 	"github.com/go-vela/server/router/middleware/repo"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/library"
 )
 
 // swagger:operation POST /api/v1/repos/{org}/{repo}/builds/{build}/steps steps CreateStep
@@ -85,7 +85,7 @@ func CreateStep(c *gin.Context) {
 	l.Debugf("creating new step for build %s", entry)
 
 	// capture body from API request
-	input := new(library.Step)
+	input := new(types.Step)
 
 	err := c.Bind(input)
 	if err != nil {

--- a/api/step/plan.go
+++ b/api/step/plan.go
@@ -11,18 +11,18 @@ import (
 
 	"github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/compiler/types/pipeline"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/scm"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
 
 // PlanSteps is a helper function to plan all steps
 // in the build for execution. This creates the steps
 // for the build.
-func PlanSteps(ctx context.Context, database database.Interface, scm scm.Service, p *pipeline.Build, b *types.Build) ([]*library.Step, error) {
+func PlanSteps(ctx context.Context, database database.Interface, scm scm.Service, p *pipeline.Build, b *types.Build) ([]*types.Step, error) {
 	// variable to store planned steps
-	steps := []*library.Step{}
+	steps := []*types.Step{}
 
 	// iterate through all pipeline stages
 	for _, stage := range p.Stages {
@@ -51,9 +51,9 @@ func PlanSteps(ctx context.Context, database database.Interface, scm scm.Service
 	return steps, nil
 }
 
-func planStep(ctx context.Context, database database.Interface, scm scm.Service, b *types.Build, c *pipeline.Container, stage string) (*library.Step, error) {
+func planStep(ctx context.Context, database database.Interface, scm scm.Service, b *types.Build, c *pipeline.Container, stage string) (*types.Step, error) {
 	// create the step object
-	s := new(library.Step)
+	s := new(types.Step)
 	s.SetBuildID(b.GetID())
 	s.SetRepoID(b.GetRepo().GetID())
 	s.SetNumber(c.Number)

--- a/api/step/update.go
+++ b/api/step/update.go
@@ -9,14 +9,14 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/build"
 	"github.com/go-vela/server/router/middleware/repo"
 	"github.com/go-vela/server/router/middleware/step"
 	"github.com/go-vela/server/scm"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/library"
 )
 
 // swagger:operation PUT /api/v1/repos/{org}/{repo}/builds/{build}/steps/{step} steps UpdateStep
@@ -92,7 +92,7 @@ func UpdateStep(c *gin.Context) {
 	l.Debugf("updating step %s", entry)
 
 	// capture body from API request
-	input := new(library.Step)
+	input := new(types.Step)
 
 	err := c.Bind(input)
 	if err != nil {

--- a/api/types/actions/comment.go
+++ b/api/types/actions/comment.go
@@ -2,7 +2,7 @@
 
 package actions
 
-import "github.com/go-vela/types/constants"
+import "github.com/go-vela/server/constants"
 
 // Comment is the API representation of the various actions associated
 // with the comment event webhook from the SCM.

--- a/api/types/actions/comment_test.go
+++ b/api/types/actions/comment_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestTypes_Comment_Getters(t *testing.T) {

--- a/api/types/actions/deploy.go
+++ b/api/types/actions/deploy.go
@@ -3,7 +3,7 @@
 //nolint:dupl // similar code to schedule.go
 package actions
 
-import "github.com/go-vela/types/constants"
+import "github.com/go-vela/server/constants"
 
 // Deploy is the API representation of the various actions associated
 // with the deploy event webhook from the SCM.

--- a/api/types/actions/deploy_test.go
+++ b/api/types/actions/deploy_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestTypes_Deploy_Getters(t *testing.T) {

--- a/api/types/actions/pull.go
+++ b/api/types/actions/pull.go
@@ -2,7 +2,7 @@
 
 package actions
 
-import "github.com/go-vela/types/constants"
+import "github.com/go-vela/server/constants"
 
 // Pull is the API representation of the various actions associated
 // with the pull_request event webhook from the SCM.

--- a/api/types/actions/pull_test.go
+++ b/api/types/actions/pull_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestActions_Pull_Getters(t *testing.T) {

--- a/api/types/actions/push.go
+++ b/api/types/actions/push.go
@@ -2,7 +2,7 @@
 
 package actions
 
-import "github.com/go-vela/types/constants"
+import "github.com/go-vela/server/constants"
 
 // Push is the API representation of the various actions associated
 // with the push event webhook from the SCM.

--- a/api/types/actions/push_test.go
+++ b/api/types/actions/push_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestTypes_Push_Getters(t *testing.T) {

--- a/api/types/actions/schedule.go
+++ b/api/types/actions/schedule.go
@@ -3,7 +3,7 @@
 //nolint:dupl // similar code to deploy.go
 package actions
 
-import "github.com/go-vela/types/constants"
+import "github.com/go-vela/server/constants"
 
 // Schedule is the API representation of the various actions associated
 // with the schedule event.

--- a/api/types/actions/schedule_test.go
+++ b/api/types/actions/schedule_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestTypes_Schedule_Getters(t *testing.T) {

--- a/api/types/build.go
+++ b/api/types/build.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/go-vela/server/compiler/types/raw"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // Build is the API types representation of a build for a pipeline.

--- a/api/types/events.go
+++ b/api/types/events.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/server/api/types/actions"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // Events is the API representation of the various events that generate a

--- a/api/types/events_test.go
+++ b/api/types/events_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/go-vela/server/api/types/actions"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestTypes_Events_Getters(t *testing.T) {

--- a/api/types/repo_test.go
+++ b/api/types/repo_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestTypes_Repo_Environment(t *testing.T) {

--- a/api/types/secret.go
+++ b/api/types/secret.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/types/pipeline"
 )
 

--- a/api/types/secret_test.go
+++ b/api/types/secret_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/go-vela/server/api/types/actions"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/types/pipeline"
 )
 

--- a/api/types/service.go
+++ b/api/types/service.go
@@ -1,0 +1,645 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/go-vela/server/compiler/types/pipeline"
+	"github.com/go-vela/server/constants"
+)
+
+// Service is the API representation of a service in a build.
+//
+// swagger:model Service
+type Service struct {
+	ID           *int64  `json:"id,omitempty"`
+	BuildID      *int64  `json:"build_id,omitempty"`
+	RepoID       *int64  `json:"repo_id,omitempty"`
+	Number       *int    `json:"number,omitempty"`
+	Name         *string `json:"name,omitempty"`
+	Image        *string `json:"image,omitempty"`
+	Status       *string `json:"status,omitempty"`
+	Error        *string `json:"error,omitempty"`
+	ExitCode     *int    `json:"exit_code,omitempty"`
+	Created      *int64  `json:"created,omitempty"`
+	Started      *int64  `json:"started,omitempty"`
+	Finished     *int64  `json:"finished,omitempty"`
+	Host         *string `json:"host,omitempty"`
+	Runtime      *string `json:"runtime,omitempty"`
+	Distribution *string `json:"distribution,omitempty"`
+}
+
+// Duration calculates and returns the total amount of
+// time the service ran for in a human-readable format.
+func (s *Service) Duration() string {
+	// check if the service doesn't have a started timestamp
+	if s.GetStarted() == 0 {
+		return "..."
+	}
+
+	// capture started unix timestamp from the service
+	started := time.Unix(s.GetStarted(), 0)
+
+	// check if the service doesn't have a finished timestamp
+	if s.GetFinished() == 0 {
+		// return the duration in a human-readable form by
+		// subtracting the service started time from the
+		// current time rounded to the nearest second
+		return time.Since(started).Round(time.Second).String()
+	}
+
+	// capture finished unix timestamp from the service
+	finished := time.Unix(s.GetFinished(), 0)
+
+	// calculate the duration by subtracting the service
+	// started time from the service finished time
+	duration := finished.Sub(started)
+
+	// return the duration in a human-readable form
+	return duration.String()
+}
+
+// Environment returns a list of environment variables
+// provided from the fields of the Service type.
+func (s *Service) Environment() map[string]string {
+	return map[string]string{
+		"VELA_SERVICE_CREATED":      ToString(s.GetCreated()),
+		"VELA_SERVICE_DISTRIBUTION": ToString(s.GetDistribution()),
+		"VELA_SERVICE_EXIT_CODE":    ToString(s.GetExitCode()),
+		"VELA_SERVICE_HOST":         ToString(s.GetHost()),
+		"VELA_SERVICE_IMAGE":        ToString(s.GetImage()),
+		"VELA_SERVICE_NAME":         ToString(s.GetName()),
+		"VELA_SERVICE_NUMBER":       ToString(s.GetNumber()),
+		"VELA_SERVICE_RUNTIME":      ToString(s.GetRuntime()),
+		"VELA_SERVICE_STARTED":      ToString(s.GetStarted()),
+		"VELA_SERVICE_STATUS":       ToString(s.GetStatus()),
+	}
+}
+
+// GetID returns the ID field.
+//
+// When the provided Service type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Service) GetID() int64 {
+	// return zero value if Service type or ID field is nil
+	if s == nil || s.ID == nil {
+		return 0
+	}
+
+	return *s.ID
+}
+
+// GetBuildID returns the BuildID field.
+//
+// When the provided Service type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Service) GetBuildID() int64 {
+	// return zero value if Service type or BuildID field is nil
+	if s == nil || s.BuildID == nil {
+		return 0
+	}
+
+	return *s.BuildID
+}
+
+// GetRepoID returns the RepoID field.
+//
+// When the provided Service type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Service) GetRepoID() int64 {
+	// return zero value if Service type or RepoID field is nil
+	if s == nil || s.RepoID == nil {
+		return 0
+	}
+
+	return *s.RepoID
+}
+
+// GetNumber returns the Number field.
+//
+// When the provided Service type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Service) GetNumber() int {
+	// return zero value if Service type or Number field is nil
+	if s == nil || s.Number == nil {
+		return 0
+	}
+
+	return *s.Number
+}
+
+// GetName returns the Name field.
+//
+// When the provided Service type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Service) GetName() string {
+	// return zero value if Service type or Name field is nil
+	if s == nil || s.Name == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+// GetImage returns the Image field.
+//
+// When the provided Service type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Service) GetImage() string {
+	// return zero value if Service type or Image field is nil
+	if s == nil || s.Image == nil {
+		return ""
+	}
+
+	return *s.Image
+}
+
+// GetStatus returns the Status field.
+//
+// When the provided Service type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Service) GetStatus() string {
+	// return zero value if Service type or Status field is nil
+	if s == nil || s.Status == nil {
+		return ""
+	}
+
+	return *s.Status
+}
+
+// GetError returns the Error field.
+//
+// When the provided Service type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Service) GetError() string {
+	// return zero value if Service type or Error field is nil
+	if s == nil || s.Error == nil {
+		return ""
+	}
+
+	return *s.Error
+}
+
+// GetExitCode returns the ExitCode field.
+//
+// When the provided Service type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Service) GetExitCode() int {
+	// return zero value if Service type or ExitCode field is nil
+	if s == nil || s.ExitCode == nil {
+		return 0
+	}
+
+	return *s.ExitCode
+}
+
+// GetCreated returns the Created field.
+//
+// When the provided Service type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Service) GetCreated() int64 {
+	// return zero value if Service type or Created field is nil
+	if s == nil || s.Created == nil {
+		return 0
+	}
+
+	return *s.Created
+}
+
+// GetStarted returns the Started field.
+//
+// When the provided Service type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Service) GetStarted() int64 {
+	// return zero value if Service type or Started field is nil
+	if s == nil || s.Started == nil {
+		return 0
+	}
+
+	return *s.Started
+}
+
+// GetFinished returns the Finished field.
+//
+// When the provided Service type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Service) GetFinished() int64 {
+	// return zero value if Service type or Finished field is nil
+	if s == nil || s.Finished == nil {
+		return 0
+	}
+
+	return *s.Finished
+}
+
+// GetHost returns the Host field.
+//
+// When the provided Service type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Service) GetHost() string {
+	// return zero value if Service type or Host field is nil
+	if s == nil || s.Host == nil {
+		return ""
+	}
+
+	return *s.Host
+}
+
+// GetRuntime returns the Runtime field.
+//
+// When the provided Service type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Service) GetRuntime() string {
+	// return zero value if Service type or Runtime field is nil
+	if s == nil || s.Runtime == nil {
+		return ""
+	}
+
+	return *s.Runtime
+}
+
+// GetDistribution returns the Runtime field.
+//
+// When the provided Service type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Service) GetDistribution() string {
+	// return zero value if Service type or Distribution field is nil
+	if s == nil || s.Distribution == nil {
+		return ""
+	}
+
+	return *s.Distribution
+}
+
+// SetID sets the ID field.
+//
+// When the provided Service type is nil, it
+// will set nothing and immediately return.
+func (s *Service) SetID(v int64) {
+	// return if Service type is nil
+	if s == nil {
+		return
+	}
+
+	s.ID = &v
+}
+
+// SetBuildID sets the BuildID field.
+//
+// When the provided Service type is nil, it
+// will set nothing and immediately return.
+func (s *Service) SetBuildID(v int64) {
+	// return if Service type is nil
+	if s == nil {
+		return
+	}
+
+	s.BuildID = &v
+}
+
+// SetRepoID sets the RepoID field.
+//
+// When the provided Service type is nil, it
+// will set nothing and immediately return.
+func (s *Service) SetRepoID(v int64) {
+	// return if Service type is nil
+	if s == nil {
+		return
+	}
+
+	s.RepoID = &v
+}
+
+// SetNumber sets the Number field.
+//
+// When the provided Service type is nil, it
+// will set nothing and immediately return.
+func (s *Service) SetNumber(v int) {
+	// return if Service type is nil
+	if s == nil {
+		return
+	}
+
+	s.Number = &v
+}
+
+// SetName sets the Name field.
+//
+// When the provided Service type is nil, it
+// will set nothing and immediately return.
+func (s *Service) SetName(v string) {
+	// return if Service type is nil
+	if s == nil {
+		return
+	}
+
+	s.Name = &v
+}
+
+// SetImage sets the Image field.
+//
+// When the provided Service type is nil, it
+// will set nothing and immediately return.
+func (s *Service) SetImage(v string) {
+	// return if Service type is nil
+	if s == nil {
+		return
+	}
+
+	s.Image = &v
+}
+
+// SetStatus sets the Status field.
+//
+// When the provided Service type is nil, it
+// will set nothing and immediately return.
+func (s *Service) SetStatus(v string) {
+	// return if Service type is nil
+	if s == nil {
+		return
+	}
+
+	s.Status = &v
+}
+
+// SetError sets the Error field.
+//
+// When the provided Service type is nil, it
+// will set nothing and immediately return.
+func (s *Service) SetError(v string) {
+	// return if Service type is nil
+	if s == nil {
+		return
+	}
+
+	s.Error = &v
+}
+
+// SetExitCode sets the ExitCode field.
+//
+// When the provided Service type is nil, it
+// will set nothing and immediately return.
+func (s *Service) SetExitCode(v int) {
+	// return if Service type is nil
+	if s == nil {
+		return
+	}
+
+	s.ExitCode = &v
+}
+
+// SetCreated sets the Created field.
+//
+// When the provided Service type is nil, it
+// will set nothing and immediately return.
+func (s *Service) SetCreated(v int64) {
+	// return if Service type is nil
+	if s == nil {
+		return
+	}
+
+	s.Created = &v
+}
+
+// SetStarted sets the Started field.
+//
+// When the provided Service type is nil, it
+// will set nothing and immediately return.
+func (s *Service) SetStarted(v int64) {
+	// return if Service type is nil
+	if s == nil {
+		return
+	}
+
+	s.Started = &v
+}
+
+// SetFinished sets the Finished field.
+//
+// When the provided Service type is nil, it
+// will set nothing and immediately return.
+func (s *Service) SetFinished(v int64) {
+	// return if Service type is nil
+	if s == nil {
+		return
+	}
+
+	s.Finished = &v
+}
+
+// SetHost sets the Host field.
+//
+// When the provided Service type is nil, it
+// will set nothing and immediately return.
+func (s *Service) SetHost(v string) {
+	// return if Service type is nil
+	if s == nil {
+		return
+	}
+
+	s.Host = &v
+}
+
+// SetRuntime sets the Runtime field.
+//
+// When the provided Service type is nil, it
+// will set nothing and immediately return.
+func (s *Service) SetRuntime(v string) {
+	// return if Service type is nil
+	if s == nil {
+		return
+	}
+
+	s.Runtime = &v
+}
+
+// SetDistribution sets the Runtime field.
+//
+// When the provided Service type is nil, it
+// will set nothing and immediately return.
+func (s *Service) SetDistribution(v string) {
+	// return if Service type is nil
+	if s == nil {
+		return
+	}
+
+	s.Distribution = &v
+}
+
+// String implements the Stringer interface for the Service type.
+func (s *Service) String() string {
+	return fmt.Sprintf(`{
+  BuildID: %d,
+  Created: %d,
+  Distribution: %s,
+  Error: %s,
+  ExitCode: %d,
+  Finished: %d,
+  Host: %s,
+  ID: %d,
+  Image: %s,
+  Name: %s,
+  Number: %d,
+  RepoID: %d,
+  Runtime: %s,
+  Started: %d,
+  Status: %s,
+}`,
+		s.GetBuildID(),
+		s.GetCreated(),
+		s.GetDistribution(),
+		s.GetError(),
+		s.GetExitCode(),
+		s.GetFinished(),
+		s.GetHost(),
+		s.GetID(),
+		s.GetImage(),
+		s.GetName(),
+		s.GetNumber(),
+		s.GetRepoID(),
+		s.GetRuntime(),
+		s.GetStarted(),
+		s.GetStatus(),
+	)
+}
+
+// ServiceFromBuildContainer creates a new Service based on a Build and pipeline Container.
+func ServiceFromBuildContainer(build *Build, ctn *pipeline.Container) *Service {
+	// create new service type we want to return
+	s := new(Service)
+
+	// default status to Pending
+	s.SetStatus(constants.StatusPending)
+
+	// copy fields from build
+	if build != nil {
+		// set values from the build
+		s.SetHost(build.GetHost())
+		s.SetRuntime(build.GetRuntime())
+		s.SetDistribution(build.GetDistribution())
+	}
+
+	// copy fields from container
+	if ctn != nil && ctn.Name != "" {
+		// set values from the container
+		s.SetName(ctn.Name)
+		s.SetNumber(ctn.Number)
+		s.SetImage(ctn.Image)
+	}
+
+	return s
+}
+
+// ServiceFromContainerEnvironment converts the pipeline Container
+// to an API Service using the container's Environment.
+func ServiceFromContainerEnvironment(ctn *pipeline.Container) *Service {
+	// check if container or container environment are nil
+	if ctn == nil || ctn.Environment == nil {
+		return nil
+	}
+
+	// create new service type we want to return
+	s := new(Service)
+
+	// check if the VELA_SERVICE_DISTRIBUTION environment variable exists
+	value, ok := ctn.Environment["VELA_SERVICE_DISTRIBUTION"]
+	if ok {
+		// set the Distribution field to the value from environment variable
+		s.SetDistribution(value)
+	}
+
+	// check if the VELA_SERVICE_HOST environment variable exists
+	value, ok = ctn.Environment["VELA_SERVICE_HOST"]
+	if ok {
+		// set the Host field to the value from environment variable
+		s.SetHost(value)
+	}
+
+	// check if the VELA_SERVICE_IMAGE environment variable exists
+	value, ok = ctn.Environment["VELA_SERVICE_IMAGE"]
+	if ok {
+		// set the Image field to the value from environment variable
+		s.SetImage(value)
+	}
+
+	// check if the VELA_SERVICE_NAME environment variable exists
+	value, ok = ctn.Environment["VELA_SERVICE_NAME"]
+	if ok {
+		// set the Name field to the value from environment variable
+		s.SetName(value)
+	}
+
+	// check if the VELA_SERVICE_RUNTIME environment variable exists
+	value, ok = ctn.Environment["VELA_SERVICE_RUNTIME"]
+	if ok {
+		// set the Runtime field to the value from environment variable
+		s.SetRuntime(value)
+	}
+
+	// check if the VELA_SERVICE_STATUS environment variable exists
+	value, ok = ctn.Environment["VELA_SERVICE_STATUS"]
+	if ok {
+		// set the Status field to the value from environment variable
+		s.SetStatus(value)
+	}
+
+	// check if the VELA_SERVICE_CREATED environment variable exists
+	value, ok = ctn.Environment["VELA_SERVICE_CREATED"]
+	if ok {
+		// parse the environment variable value into an int64
+		i, err := strconv.ParseInt(value, 10, 64)
+		if err == nil {
+			// set the Created field to the parsed int64
+			s.SetCreated(i)
+		}
+	}
+
+	// check if the VELA_SERVICE_EXIT_CODE environment variable exists
+	value, ok = ctn.Environment["VELA_SERVICE_EXIT_CODE"]
+	if ok {
+		// parse the environment variable value into an int
+		i, err := strconv.ParseInt(value, 10, 0)
+		if err == nil {
+			// set the ExitCode field to the parsed int
+			s.SetExitCode(int(i))
+		}
+	}
+
+	// check if the VELA_SERVICE_FINISHED environment variable exists
+	value, ok = ctn.Environment["VELA_SERVICE_FINISHED"]
+	if ok {
+		// parse the environment variable value into an int64
+		i, err := strconv.ParseInt(value, 10, 64)
+		if err == nil {
+			// set the Finished field to the parsed int64
+			s.SetFinished(i)
+		}
+	}
+
+	// check if the VELA_SERVICE_NUMBER environment variable exists
+	value, ok = ctn.Environment["VELA_SERVICE_NUMBER"]
+	if ok {
+		// parse the environment variable value into an int
+		i, err := strconv.ParseInt(value, 10, 0)
+		if err == nil {
+			// set the Number field to the parsed int
+			s.SetNumber(int(i))
+		}
+	}
+
+	// check if the VELA_SERVICE_STARTED environment variable exists
+	value, ok = ctn.Environment["VELA_SERVICE_STARTED"]
+	if ok {
+		// parse the environment variable value into an int64
+		i, err := strconv.ParseInt(value, 10, 64)
+		if err == nil {
+			// set the Started field to the parsed int64
+			s.SetStarted(i)
+		}
+	}
+
+	return s
+}

--- a/api/types/service_test.go
+++ b/api/types/service_test.go
@@ -1,0 +1,449 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/go-vela/server/compiler/types/pipeline"
+)
+
+func TestTypes_Service_Duration(t *testing.T) {
+	// setup types
+	unfinished := testService()
+	unfinished.SetFinished(0)
+
+	// setup tests
+	tests := []struct {
+		service *Service
+		want    string
+	}{
+		{
+			service: testService(),
+			want:    "1s",
+		},
+		{
+			service: unfinished,
+			want:    time.Since(time.Unix(unfinished.GetStarted(), 0)).Round(time.Second).String(),
+		},
+		{
+			service: new(Service),
+			want:    "...",
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := test.service.Duration()
+
+		if got != test.want {
+			t.Errorf("Duration is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestTypes_Service_Environment(t *testing.T) {
+	// setup types
+	want := map[string]string{
+		"VELA_SERVICE_CREATED":      "1563474076",
+		"VELA_SERVICE_DISTRIBUTION": "linux",
+		"VELA_SERVICE_EXIT_CODE":    "0",
+		"VELA_SERVICE_HOST":         "example.company.com",
+		"VELA_SERVICE_IMAGE":        "postgres:12-alpine",
+		"VELA_SERVICE_NAME":         "postgres",
+		"VELA_SERVICE_NUMBER":       "1",
+		"VELA_SERVICE_RUNTIME":      "docker",
+		"VELA_SERVICE_STARTED":      "1563474078",
+		"VELA_SERVICE_STATUS":       "running",
+	}
+
+	// run test
+	got := testService().Environment()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Environment is %v, want %v", got, want)
+	}
+}
+
+func TestTypes_Service_Getters(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		service *Service
+		want    *Service
+	}{
+		{
+			service: testService(),
+			want:    testService(),
+		},
+		{
+			service: new(Service),
+			want:    new(Service),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		if test.service.GetID() != test.want.GetID() {
+			t.Errorf("GetID is %v, want %v", test.service.GetID(), test.want.GetID())
+		}
+
+		if test.service.GetBuildID() != test.want.GetBuildID() {
+			t.Errorf("GetBuildID is %v, want %v", test.service.GetBuildID(), test.want.GetBuildID())
+		}
+
+		if test.service.GetRepoID() != test.want.GetRepoID() {
+			t.Errorf("GetRepoID is %v, want %v", test.service.GetRepoID(), test.want.GetRepoID())
+		}
+
+		if test.service.GetNumber() != test.want.GetNumber() {
+			t.Errorf("GetNumber is %v, want %v", test.service.GetNumber(), test.want.GetNumber())
+		}
+
+		if test.service.GetName() != test.want.GetName() {
+			t.Errorf("GetName is %v, want %v", test.service.GetName(), test.want.GetName())
+		}
+
+		if test.service.GetImage() != test.want.GetImage() {
+			t.Errorf("GetImage is %v, want %v", test.service.GetImage(), test.want.GetImage())
+		}
+
+		if test.service.GetStatus() != test.want.GetStatus() {
+			t.Errorf("GetStatus is %v, want %v", test.service.GetStatus(), test.want.GetStatus())
+		}
+
+		if test.service.GetError() != test.want.GetError() {
+			t.Errorf("GetError is %v, want %v", test.service.GetError(), test.want.GetError())
+		}
+
+		if test.service.GetExitCode() != test.want.GetExitCode() {
+			t.Errorf("GetExitCode is %v, want %v", test.service.GetExitCode(), test.want.GetExitCode())
+		}
+
+		if test.service.GetCreated() != test.want.GetCreated() {
+			t.Errorf("GetCreated is %v, want %v", test.service.GetCreated(), test.want.GetCreated())
+		}
+
+		if test.service.GetStarted() != test.want.GetStarted() {
+			t.Errorf("GetStarted is %v, want %v", test.service.GetStarted(), test.want.GetStarted())
+		}
+
+		if test.service.GetFinished() != test.want.GetFinished() {
+			t.Errorf("GetFinished is %v, want %v", test.service.GetFinished(), test.want.GetFinished())
+		}
+
+		if test.service.GetHost() != test.want.GetHost() {
+			t.Errorf("GetHost is %v, want %v", test.service.GetHost(), test.want.GetHost())
+		}
+
+		if test.service.GetRuntime() != test.want.GetRuntime() {
+			t.Errorf("GetRuntime is %v, want %v", test.service.GetRuntime(), test.want.GetRuntime())
+		}
+
+		if test.service.GetDistribution() != test.want.GetDistribution() {
+			t.Errorf("GetDistribution is %v, want %v", test.service.GetDistribution(), test.want.GetDistribution())
+		}
+	}
+}
+
+func TestTypes_Service_Setters(t *testing.T) {
+	// setup types
+	var s *Service
+
+	// setup tests
+	tests := []struct {
+		service *Service
+		want    *Service
+	}{
+		{
+			service: testService(),
+			want:    testService(),
+		},
+		{
+			service: s,
+			want:    new(Service),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		test.want.SetID(test.service.GetID())
+		test.want.SetBuildID(test.service.GetBuildID())
+		test.want.SetRepoID(test.service.GetRepoID())
+		test.want.SetNumber(test.service.GetNumber())
+		test.want.SetName(test.service.GetName())
+		test.want.SetImage(test.service.GetImage())
+		test.want.SetStatus(test.service.GetStatus())
+		test.want.SetError(test.service.GetError())
+		test.want.SetExitCode(test.service.GetExitCode())
+		test.want.SetCreated(test.service.GetCreated())
+		test.want.SetStarted(test.service.GetStarted())
+		test.want.SetFinished(test.service.GetFinished())
+		test.want.SetHost(test.service.GetHost())
+		test.want.SetRuntime(test.service.GetRuntime())
+		test.want.SetDistribution(test.service.GetDistribution())
+
+		if test.want.GetID() != test.service.GetID() {
+			t.Errorf("SetID is %v, want %v", test.service.GetID(), test.service.GetID())
+		}
+
+		if test.want.GetBuildID() != test.service.GetBuildID() {
+			t.Errorf("SetBuildID is %v, want %v", test.service.GetBuildID(), test.service.GetBuildID())
+		}
+
+		if test.want.GetRepoID() != test.service.GetRepoID() {
+			t.Errorf("SetRepoID is %v, want %v", test.service.GetRepoID(), test.service.GetRepoID())
+		}
+
+		if test.want.GetNumber() != test.service.GetNumber() {
+			t.Errorf("SetNumber is %v, want %v", test.service.GetNumber(), test.service.GetNumber())
+		}
+
+		if test.want.GetName() != test.service.GetName() {
+			t.Errorf("SetName is %v, want %v", test.service.GetName(), test.service.GetName())
+		}
+
+		if test.want.GetImage() != test.service.GetImage() {
+			t.Errorf("SetImage is %v, want %v", test.service.GetImage(), test.service.GetImage())
+		}
+
+		if test.want.GetStatus() != test.service.GetStatus() {
+			t.Errorf("SetStatus is %v, want %v", test.service.GetStatus(), test.service.GetStatus())
+		}
+
+		if test.want.GetError() != test.service.GetError() {
+			t.Errorf("SetError is %v, want %v", test.service.GetError(), test.service.GetError())
+		}
+
+		if test.want.GetExitCode() != test.service.GetExitCode() {
+			t.Errorf("SetExitCode is %v, want %v", test.service.GetExitCode(), test.service.GetExitCode())
+		}
+
+		if test.want.GetCreated() != test.service.GetCreated() {
+			t.Errorf("SetCreated is %v, want %v", test.service.GetCreated(), test.service.GetCreated())
+		}
+
+		if test.want.GetStarted() != test.service.GetStarted() {
+			t.Errorf("SetStarted is %v, want %v", test.service.GetStarted(), test.service.GetStarted())
+		}
+
+		if test.want.GetFinished() != test.service.GetFinished() {
+			t.Errorf("SetFinished is %v, want %v", test.service.GetFinished(), test.service.GetFinished())
+		}
+
+		if test.want.GetHost() != test.service.GetHost() {
+			t.Errorf("SetHost is %v, want %v", test.service.GetHost(), test.service.GetHost())
+		}
+
+		if test.want.GetRuntime() != test.service.GetRuntime() {
+			t.Errorf("SetRuntime is %v, want %v", test.service.GetRuntime(), test.service.GetRuntime())
+		}
+
+		if test.want.GetDistribution() != test.service.GetDistribution() {
+			t.Errorf("SetDistribution is %v, want %v", test.service.GetDistribution(), test.service.GetDistribution())
+		}
+	}
+}
+
+func TestTypes_Service_String(t *testing.T) {
+	// setup types
+	s := testService()
+
+	want := fmt.Sprintf(`{
+  BuildID: %d,
+  Created: %d,
+  Distribution: %s,
+  Error: %s,
+  ExitCode: %d,
+  Finished: %d,
+  Host: %s,
+  ID: %d,
+  Image: %s,
+  Name: %s,
+  Number: %d,
+  RepoID: %d,
+  Runtime: %s,
+  Started: %d,
+  Status: %s,
+}`,
+		s.GetBuildID(),
+		s.GetCreated(),
+		s.GetDistribution(),
+		s.GetError(),
+		s.GetExitCode(),
+		s.GetFinished(),
+		s.GetHost(),
+		s.GetID(),
+		s.GetImage(),
+		s.GetName(),
+		s.GetNumber(),
+		s.GetRepoID(),
+		s.GetRuntime(),
+		s.GetStarted(),
+		s.GetStatus(),
+	)
+
+	// run test
+	got := s.String()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("String is %v, want %v", got, want)
+	}
+}
+
+func TestTypes_ServiceFromBuildContainer(t *testing.T) {
+	// setup types
+	s := testService()
+	s.SetStatus("pending")
+
+	// modify fields that aren't set
+	s.ID = nil
+	s.BuildID = nil
+	s.RepoID = nil
+	s.ExitCode = nil
+	s.Created = nil
+	s.Started = nil
+	s.Finished = nil
+
+	tests := []struct {
+		name      string
+		container *pipeline.Container
+		build     *Build
+		want      *Service
+	}{
+		{
+			name:      "nil container with nil build",
+			container: nil,
+			build:     nil,
+			want:      &Service{Status: s.Status},
+		},
+		{
+			name:      "empty container with nil build",
+			container: new(pipeline.Container),
+			build:     nil,
+			want:      &Service{Status: s.Status},
+		},
+		{
+			name:      "nil container with build",
+			container: nil,
+			build:     testBuild(),
+			want: &Service{
+				Status:       s.Status,
+				Host:         s.Host,
+				Runtime:      s.Runtime,
+				Distribution: s.Distribution,
+			},
+		},
+		{
+			name:      "empty container with build",
+			container: new(pipeline.Container),
+			build:     testBuild(),
+			want: &Service{
+				Status:       s.Status,
+				Host:         s.Host,
+				Runtime:      s.Runtime,
+				Distribution: s.Distribution,
+			},
+		},
+		{
+			name: "container with build",
+			container: &pipeline.Container{
+				Name:   s.GetName(),
+				Number: s.GetNumber(),
+				Image:  s.GetImage(),
+			},
+			build: testBuild(),
+			want:  s,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := ServiceFromBuildContainer(test.build, test.container)
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("ServiceFromBuildContainer for %s is %v, want %v", test.name, got, test.want)
+		}
+	}
+}
+
+func TestTypes_ServiceFromContainerEnvironment(t *testing.T) {
+	// setup types
+	s := testService()
+
+	// modify fields that aren't set via environment variables
+	s.ID = nil
+	s.BuildID = nil
+	s.RepoID = nil
+
+	// setup tests
+	tests := []struct {
+		name      string
+		container *pipeline.Container
+		want      *Service
+	}{
+		{
+			name:      "nil container",
+			container: nil,
+			want:      nil,
+		},
+		{
+			name:      "empty container",
+			container: new(pipeline.Container),
+			want:      nil,
+		},
+		{
+			name: "container",
+			container: &pipeline.Container{
+				Environment: map[string]string{
+					"VELA_SERVICE_CREATED":      "1563474076",
+					"VELA_SERVICE_DISTRIBUTION": "linux",
+					"VELA_SERVICE_EXIT_CODE":    "0",
+					"VELA_SERVICE_FINISHED":     "1563474079",
+					"VELA_SERVICE_HOST":         "example.company.com",
+					"VELA_SERVICE_IMAGE":        "postgres:12-alpine",
+					"VELA_SERVICE_NAME":         "postgres",
+					"VELA_SERVICE_NUMBER":       "1",
+					"VELA_SERVICE_RUNTIME":      "docker",
+					"VELA_SERVICE_STARTED":      "1563474078",
+					"VELA_SERVICE_STATUS":       "running",
+				},
+			},
+			want: s,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := ServiceFromContainerEnvironment(test.container)
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("ServiceFromContainerEnvironment for %s is %v, want %v", test.name, got, test.want)
+		}
+	}
+}
+
+// testService is a test helper function to create a Service
+// type with all fields set to a fake value.
+func testService() *Service {
+	s := new(Service)
+
+	s.SetID(1)
+	s.SetBuildID(1)
+	s.SetRepoID(1)
+	s.SetNumber(1)
+	s.SetName("postgres")
+	s.SetImage("postgres:12-alpine")
+	s.SetStatus("running")
+	s.SetExitCode(0)
+	s.SetCreated(1563474076)
+	s.SetStarted(1563474078)
+	s.SetFinished(1563474079)
+	s.SetHost("example.company.com")
+	s.SetRuntime("docker")
+	s.SetDistribution("linux")
+
+	return s
+}

--- a/api/types/step.go
+++ b/api/types/step.go
@@ -1,0 +1,727 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/go-vela/server/compiler/types/pipeline"
+	"github.com/go-vela/server/constants"
+)
+
+// Step is the API representation of a step in a build.
+//
+// swagger:model Step
+type Step struct {
+	ID           *int64  `json:"id,omitempty"`
+	BuildID      *int64  `json:"build_id,omitempty"`
+	RepoID       *int64  `json:"repo_id,omitempty"`
+	Number       *int    `json:"number,omitempty"`
+	Name         *string `json:"name,omitempty"`
+	Image        *string `json:"image,omitempty"`
+	Stage        *string `json:"stage,omitempty"`
+	Status       *string `json:"status,omitempty"`
+	Error        *string `json:"error,omitempty"`
+	ExitCode     *int    `json:"exit_code,omitempty"`
+	Created      *int64  `json:"created,omitempty"`
+	Started      *int64  `json:"started,omitempty"`
+	Finished     *int64  `json:"finished,omitempty"`
+	Host         *string `json:"host,omitempty"`
+	Runtime      *string `json:"runtime,omitempty"`
+	Distribution *string `json:"distribution,omitempty"`
+	ReportAs     *string `json:"report_as,omitempty"`
+}
+
+// Duration calculates and returns the total amount of
+// time the step ran for in a human-readable format.
+func (s *Step) Duration() string {
+	// check if the step doesn't have a started timestamp
+	if s.GetStarted() == 0 {
+		return "..."
+	}
+
+	// capture started unix timestamp from the step
+	started := time.Unix(s.GetStarted(), 0)
+
+	// check if the step doesn't have a finished timestamp
+	if s.GetFinished() == 0 {
+		// return the duration in a human-readable form by
+		// subtracting the step started time from the
+		// current time rounded to the nearest second
+		return time.Since(started).Round(time.Second).String()
+	}
+
+	// capture finished unix timestamp from the step
+	finished := time.Unix(s.GetFinished(), 0)
+
+	// calculate the duration by subtracting the step
+	// started time from the step finished time
+	duration := finished.Sub(started)
+
+	// return the duration in a human-readable form
+	return duration.String()
+}
+
+// Environment returns a list of environment variables
+// provided from the fields of the Step type.
+func (s *Step) Environment() map[string]string {
+	return map[string]string{
+		"VELA_STEP_CREATED":      ToString(s.GetCreated()),
+		"VELA_STEP_DISTRIBUTION": ToString(s.GetDistribution()),
+		"VELA_STEP_EXIT_CODE":    ToString(s.GetExitCode()),
+		"VELA_STEP_HOST":         ToString(s.GetHost()),
+		"VELA_STEP_IMAGE":        ToString(s.GetImage()),
+		"VELA_STEP_NAME":         ToString(s.GetName()),
+		"VELA_STEP_NUMBER":       ToString(s.GetNumber()),
+		"VELA_STEP_RUNTIME":      ToString(s.GetRuntime()),
+		"VELA_STEP_STAGE":        ToString(s.GetStage()),
+		"VELA_STEP_STARTED":      ToString(s.GetStarted()),
+		"VELA_STEP_STATUS":       ToString(s.GetStatus()),
+		"VELA_STEP_REPORT_AS":    ToString(s.GetReportAs()),
+	}
+}
+
+// GetID returns the ID field.
+//
+// When the provided Step type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Step) GetID() int64 {
+	// return zero value if Step type or ID field is nil
+	if s == nil || s.ID == nil {
+		return 0
+	}
+
+	return *s.ID
+}
+
+// GetBuildID returns the BuildID field.
+//
+// When the provided Step type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Step) GetBuildID() int64 {
+	// return zero value if Step type or BuildID field is nil
+	if s == nil || s.BuildID == nil {
+		return 0
+	}
+
+	return *s.BuildID
+}
+
+// GetRepoID returns the RepoID field.
+//
+// When the provided Step type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Step) GetRepoID() int64 {
+	// return zero value if Step type or RepoID field is nil
+	if s == nil || s.RepoID == nil {
+		return 0
+	}
+
+	return *s.RepoID
+}
+
+// GetNumber returns the Number field.
+//
+// When the provided Step type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Step) GetNumber() int {
+	// return zero value if Step type or Number field is nil
+	if s == nil || s.Number == nil {
+		return 0
+	}
+
+	return *s.Number
+}
+
+// GetName returns the Name field.
+//
+// When the provided Step type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Step) GetName() string {
+	// return zero value if Step type or Name field is nil
+	if s == nil || s.Name == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+// GetImage returns the Image field.
+//
+// When the provided Step type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Step) GetImage() string {
+	// return zero value if Step type of Image field is nil
+	if s == nil || s.Image == nil {
+		return ""
+	}
+
+	return *s.Image
+}
+
+// GetStage returns the Stage field.
+//
+// When the provided Step type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Step) GetStage() string {
+	// return zero value if Step type or Stage field is nil
+	if s == nil || s.Stage == nil {
+		return ""
+	}
+
+	return *s.Stage
+}
+
+// GetStatus returns the Status field.
+//
+// When the provided Step type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Step) GetStatus() string {
+	// return zero value if Step type or Status field is nil
+	if s == nil || s.Status == nil {
+		return ""
+	}
+
+	return *s.Status
+}
+
+// GetError returns the Error field.
+//
+// When the provided Step type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Step) GetError() string {
+	// return zero value if Step type or Error field is nil
+	if s == nil || s.Error == nil {
+		return ""
+	}
+
+	return *s.Error
+}
+
+// GetExitCode returns the ExitCode field.
+//
+// When the provided Step type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Step) GetExitCode() int {
+	// return zero value if Step type or ExitCode field is nil
+	if s == nil || s.ExitCode == nil {
+		return 0
+	}
+
+	return *s.ExitCode
+}
+
+// GetCreated returns the Created field.
+//
+// When the provided Step type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Step) GetCreated() int64 {
+	// return zero value if Step type or Created field is nil
+	if s == nil || s.Created == nil {
+		return 0
+	}
+
+	return *s.Created
+}
+
+// GetStarted returns the Started field.
+//
+// When the provided Step type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Step) GetStarted() int64 {
+	// return zero value if Step type or Started field is nil
+	if s == nil || s.Started == nil {
+		return 0
+	}
+
+	return *s.Started
+}
+
+// GetFinished returns the Finished field.
+//
+// When the provided Step type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Step) GetFinished() int64 {
+	// return zero value if Step type or Finished field is nil
+	if s == nil || s.Finished == nil {
+		return 0
+	}
+
+	return *s.Finished
+}
+
+// GetHost returns the Host field.
+//
+// When the provided Step type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Step) GetHost() string {
+	// return zero value if Step type or Host field is nil
+	if s == nil || s.Host == nil {
+		return ""
+	}
+
+	return *s.Host
+}
+
+// GetRuntime returns the Runtime field.
+//
+// When the provided Step type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Step) GetRuntime() string {
+	// return zero value if Step type or Runtime field is nil
+	if s == nil || s.Runtime == nil {
+		return ""
+	}
+
+	return *s.Runtime
+}
+
+// GetDistribution returns the Runtime field.
+//
+// When the provided Step type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Step) GetDistribution() string {
+	// return zero value if Step type or Distribution field is nil
+	if s == nil || s.Distribution == nil {
+		return ""
+	}
+
+	return *s.Distribution
+}
+
+// GetReportAs returns the ReportAs field.
+//
+// When the provided Step type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (s *Step) GetReportAs() string {
+	// return zero value if Step type or ReportAs field is nil
+	if s == nil || s.ReportAs == nil {
+		return ""
+	}
+
+	return *s.ReportAs
+}
+
+// SetID sets the ID field.
+//
+// When the provided Step type is nil, it
+// will set nothing and immediately return.
+func (s *Step) SetID(v int64) {
+	// return if Step type is nil
+	if s == nil {
+		return
+	}
+
+	s.ID = &v
+}
+
+// SetBuildID sets the BuildID field.
+//
+// When the provided Step type is nil, it
+// will set nothing and immediately return.
+func (s *Step) SetBuildID(v int64) {
+	// return if Step type is nil
+	if s == nil {
+		return
+	}
+
+	s.BuildID = &v
+}
+
+// SetRepoID sets the RepoID field.
+//
+// When the provided Step type is nil, it
+// will set nothing and immediately return.
+func (s *Step) SetRepoID(v int64) {
+	// return if Step type is nil
+	if s == nil {
+		return
+	}
+
+	s.RepoID = &v
+}
+
+// SetNumber sets the Number field.
+//
+// When the provided Step type is nil, it
+// will set nothing and immediately return.
+func (s *Step) SetNumber(v int) {
+	// return if Step type is nil
+	if s == nil {
+		return
+	}
+
+	s.Number = &v
+}
+
+// SetName sets the Name field.
+//
+// When the provided Step type is nil, it
+// will set nothing and immediately return.
+func (s *Step) SetName(v string) {
+	// return if Step type is nil
+	if s == nil {
+		return
+	}
+
+	s.Name = &v
+}
+
+// SetImage sets the Image field.
+//
+// When the provided Step type is nil, it
+// will set nothing and immediately return.
+func (s *Step) SetImage(v string) {
+	// return if Step type is nil
+	if s == nil {
+		return
+	}
+
+	s.Image = &v
+}
+
+// SetStage sets the Stage field.
+//
+// When the provided Step type is nil, it
+// will set nothing and immediately return.
+func (s *Step) SetStage(v string) {
+	// return if Step type is nil
+	if s == nil {
+		return
+	}
+
+	s.Stage = &v
+}
+
+// SetStatus sets the Status field.
+//
+// When the provided Step type is nil, it
+// will set nothing and immediately return.
+func (s *Step) SetStatus(v string) {
+	// return if Step type is nil
+	if s == nil {
+		return
+	}
+
+	s.Status = &v
+}
+
+// SetError sets the Error field.
+//
+// When the provided Step type is nil, it
+// will set nothing and immediately return.
+func (s *Step) SetError(v string) {
+	// return if Step type is nil
+	if s == nil {
+		return
+	}
+
+	s.Error = &v
+}
+
+// SetExitCode sets the ExitCode field.
+//
+// When the provided Step type is nil, it
+// will set nothing and immediately return.
+func (s *Step) SetExitCode(v int) {
+	// return if Step type is nil
+	if s == nil {
+		return
+	}
+
+	s.ExitCode = &v
+}
+
+// SetCreated sets the Created field.
+//
+// When the provided Step type is nil, it
+// will set nothing and immediately return.
+func (s *Step) SetCreated(v int64) {
+	// return if Step type is nil
+	if s == nil {
+		return
+	}
+
+	s.Created = &v
+}
+
+// SetStarted sets the Started field.
+//
+// When the provided Step type is nil, it
+// will set nothing and immediately return.
+func (s *Step) SetStarted(v int64) {
+	// return if Step type is nil
+	if s == nil {
+		return
+	}
+
+	s.Started = &v
+}
+
+// SetFinished sets the Finished field.
+//
+// When the provided Step type is nil, it
+// will set nothing and immediately return.
+func (s *Step) SetFinished(v int64) {
+	// return if Step type is nil
+	if s == nil {
+		return
+	}
+
+	s.Finished = &v
+}
+
+// SetHost sets the Host field.
+//
+// When the provided Step type is nil, it
+// will set nothing and immediately return.
+func (s *Step) SetHost(v string) {
+	// return if Step type is nil
+	if s == nil {
+		return
+	}
+
+	s.Host = &v
+}
+
+// SetRuntime sets the Runtime field.
+//
+// When the provided Step type is nil, it
+// will set nothing and immediately return.
+func (s *Step) SetRuntime(v string) {
+	// return if Step type is nil
+	if s == nil {
+		return
+	}
+
+	s.Runtime = &v
+}
+
+// SetDistribution sets the Distribution field.
+//
+// When the provided Step type is nil, it
+// will set nothing and immediately return.
+func (s *Step) SetDistribution(v string) {
+	// return if Step type is nil
+	if s == nil {
+		return
+	}
+
+	s.Distribution = &v
+}
+
+// SetReportAs sets the ReportAs field.
+//
+// When the provided Step type is nil, it
+// will set nothing and immediately return.
+func (s *Step) SetReportAs(v string) {
+	// return if Step type is nil
+	if s == nil {
+		return
+	}
+
+	s.ReportAs = &v
+}
+
+// String implements the Stringer interface for the Step type.
+func (s *Step) String() string {
+	return fmt.Sprintf(`{
+  BuildID: %d,
+  Created: %d,
+  Distribution: %s,
+  Error: %s,
+  ExitCode: %d,
+  Finished: %d,
+  Host: %s,
+  ID: %d,
+  Image: %s,
+  Name: %s,
+  Number: %d,
+  RepoID: %d,
+  ReportAs: %s,
+  Runtime: %s,
+  Stage: %s,
+  Started: %d,
+  Status: %s,
+}`,
+		s.GetBuildID(),
+		s.GetCreated(),
+		s.GetDistribution(),
+		s.GetError(),
+		s.GetExitCode(),
+		s.GetFinished(),
+		s.GetHost(),
+		s.GetID(),
+		s.GetImage(),
+		s.GetName(),
+		s.GetNumber(),
+		s.GetRepoID(),
+		s.GetReportAs(),
+		s.GetRuntime(),
+		s.GetStage(),
+		s.GetStarted(),
+		s.GetStatus(),
+	)
+}
+
+// StepFromBuildContainer creates a new Step based on a Build and pipeline Container.
+func StepFromBuildContainer(build *Build, ctn *pipeline.Container) *Step {
+	// create new step type we want to return
+	s := new(Step)
+
+	// default status to Pending
+	s.SetStatus(constants.StatusPending)
+
+	// copy fields from build
+	if build != nil {
+		// set values from the build
+		s.SetHost(build.GetHost())
+		s.SetRuntime(build.GetRuntime())
+		s.SetDistribution(build.GetDistribution())
+	}
+
+	// copy fields from container
+	if ctn != nil && ctn.Name != "" {
+		// set values from the container
+		s.SetName(ctn.Name)
+		s.SetNumber(ctn.Number)
+		s.SetImage(ctn.Image)
+		s.SetReportAs(ctn.ReportAs)
+
+		// check if the VELA_STEP_STAGE environment variable exists
+		value, ok := ctn.Environment["VELA_STEP_STAGE"]
+		if ok {
+			// set the Stage field to the value from environment variable
+			s.SetStage(value)
+		}
+	}
+
+	return s
+}
+
+// StepFromContainerEnvironment converts the pipeline Container
+// to an API Step using the container's Environment.
+func StepFromContainerEnvironment(ctn *pipeline.Container) *Step {
+	// check if container or container environment are nil
+	if ctn == nil || ctn.Environment == nil {
+		return nil
+	}
+
+	// create new step type we want to return
+	s := new(Step)
+
+	// check if the VELA_STEP_DISTRIBUTION environment variable exists
+	value, ok := ctn.Environment["VELA_STEP_DISTRIBUTION"]
+	if ok {
+		// set the Distribution field to the value from environment variable
+		s.SetDistribution(value)
+	}
+
+	// check if the VELA_STEP_HOST environment variable exists
+	value, ok = ctn.Environment["VELA_STEP_HOST"]
+	if ok {
+		// set the Host field to the value from environment variable
+		s.SetHost(value)
+	}
+
+	// check if the VELA_STEP_IMAGE environment variable exists
+	value, ok = ctn.Environment["VELA_STEP_IMAGE"]
+	if ok {
+		// set the Image field to the value from environment variable
+		s.SetImage(value)
+	}
+
+	// check if the VELA_STEP_NAME environment variable exists
+	value, ok = ctn.Environment["VELA_STEP_NAME"]
+	if ok {
+		// set the Name field to the value from environment variable
+		s.SetName(value)
+	}
+
+	// check if the VELA_STEP_REPORT_AS environment variable exists
+	value, ok = ctn.Environment["VELA_STEP_REPORT_AS"]
+	if ok {
+		// set the ReportAs field to the value from environment variable
+		s.SetReportAs(value)
+	}
+
+	// check if the VELA_STEP_RUNTIME environment variable exists
+	value, ok = ctn.Environment["VELA_STEP_RUNTIME"]
+	if ok {
+		// set the Runtime field to the value from environment variable
+		s.SetRuntime(value)
+	}
+
+	// check if the VELA_STEP_STAGE environment variable exists
+	value, ok = ctn.Environment["VELA_STEP_STAGE"]
+	if ok {
+		// set the Stage field to the value from environment variable
+		s.SetStage(value)
+	}
+
+	// check if the VELA_STEP_STATUS environment variable exists
+	value, ok = ctn.Environment["VELA_STEP_STATUS"]
+	if ok {
+		// set the Status field to the value from environment variable
+		s.SetStatus(value)
+	}
+
+	// check if the VELA_STEP_CREATED environment variable exists
+	value, ok = ctn.Environment["VELA_STEP_CREATED"]
+	if ok {
+		// parse the environment variable value into an int64
+		i, err := strconv.ParseInt(value, 10, 64)
+		if err == nil {
+			// set the Created field to the parsed int64
+			s.SetCreated(i)
+		}
+	}
+
+	// check if the VELA_STEP_EXIT_CODE environment variable exists
+	value, ok = ctn.Environment["VELA_STEP_EXIT_CODE"]
+	if ok {
+		// parse the environment variable value into an int
+		i, err := strconv.ParseInt(value, 10, 0)
+		if err == nil {
+			// set the ExitCode field to the parsed int
+			s.SetExitCode(int(i))
+		}
+	}
+
+	// check if the VELA_STEP_FINISHED environment variable exists
+	value, ok = ctn.Environment["VELA_STEP_FINISHED"]
+	if ok {
+		// parse the environment variable value into an int64
+		i, err := strconv.ParseInt(value, 10, 64)
+		if err == nil {
+			// set the Finished field to the parsed int64
+			s.SetFinished(i)
+		}
+	}
+
+	// check if the VELA_STEP_NUMBER environment variable exists
+	value, ok = ctn.Environment["VELA_STEP_NUMBER"]
+	if ok {
+		// parse the environment variable value into an int
+		i, err := strconv.ParseInt(value, 10, 0)
+		if err == nil {
+			// set the Number field to the parsed int
+			s.SetNumber(int(i))
+		}
+	}
+
+	// check if the VELA_STEP_STARTED environment variable exists
+	value, ok = ctn.Environment["VELA_STEP_STARTED"]
+	if ok {
+		// parse the environment variable value into an int64
+		i, err := strconv.ParseInt(value, 10, 64)
+		if err == nil {
+			// set the Started field to the parsed int64
+			s.SetStarted(i)
+		}
+	}
+
+	return s
+}

--- a/api/types/step_test.go
+++ b/api/types/step_test.go
@@ -1,0 +1,482 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/go-vela/server/compiler/types/pipeline"
+)
+
+func TestTypes_Step_Duration(t *testing.T) {
+	// setup types
+	unfinished := testStep()
+	unfinished.SetFinished(0)
+
+	// setup tests
+	tests := []struct {
+		step *Step
+		want string
+	}{
+		{
+			step: testStep(),
+			want: "1s",
+		},
+		{
+			step: unfinished,
+			want: time.Since(time.Unix(unfinished.GetStarted(), 0)).Round(time.Second).String(),
+		},
+		{
+			step: new(Step),
+			want: "...",
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := test.step.Duration()
+
+		if got != test.want {
+			t.Errorf("Duration is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestTypes_Step_Environment(t *testing.T) {
+	// setup types
+	want := map[string]string{
+		"VELA_STEP_CREATED":      "1563474076",
+		"VELA_STEP_DISTRIBUTION": "linux",
+		"VELA_STEP_EXIT_CODE":    "0",
+		"VELA_STEP_HOST":         "example.company.com",
+		"VELA_STEP_IMAGE":        "target/vela-git:v0.3.0",
+		"VELA_STEP_NAME":         "clone",
+		"VELA_STEP_NUMBER":       "1",
+		"VELA_STEP_REPORT_AS":    "test",
+		"VELA_STEP_RUNTIME":      "docker",
+		"VELA_STEP_STAGE":        "",
+		"VELA_STEP_STARTED":      "1563474078",
+		"VELA_STEP_STATUS":       "running",
+	}
+
+	// run test
+	got := testStep().Environment()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Environment is %v, want %v", got, want)
+	}
+}
+
+func TestTypes_Step_Getters(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		step *Step
+		want *Step
+	}{
+		{
+			step: testStep(),
+			want: testStep(),
+		},
+		{
+			step: new(Step),
+			want: new(Step),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		if test.step.GetID() != test.want.GetID() {
+			t.Errorf("GetID is %v, want %v", test.step.GetID(), test.want.GetID())
+		}
+
+		if test.step.GetBuildID() != test.want.GetBuildID() {
+			t.Errorf("GetBuildID is %v, want %v", test.step.GetBuildID(), test.want.GetBuildID())
+		}
+
+		if test.step.GetRepoID() != test.want.GetRepoID() {
+			t.Errorf("GetRepoID is %v, want %v", test.step.GetRepoID(), test.want.GetRepoID())
+		}
+
+		if test.step.GetNumber() != test.want.GetNumber() {
+			t.Errorf("GetNumber is %v, want %v", test.step.GetNumber(), test.want.GetNumber())
+		}
+
+		if test.step.GetName() != test.want.GetName() {
+			t.Errorf("GetName is %v, want %v", test.step.GetName(), test.want.GetName())
+		}
+
+		if test.step.GetImage() != test.want.GetImage() {
+			t.Errorf("GetImage is %v, want %v", test.step.GetImage(), test.want.GetImage())
+		}
+
+		if test.step.GetStage() != test.want.GetStage() {
+			t.Errorf("GetStage is %v, want %v", test.step.GetStage(), test.want.GetStage())
+		}
+
+		if test.step.GetStatus() != test.want.GetStatus() {
+			t.Errorf("GetStatus is %v, want %v", test.step.GetStatus(), test.want.GetStatus())
+		}
+
+		if test.step.GetError() != test.want.GetError() {
+			t.Errorf("GetError is %v, want %v", test.step.GetError(), test.want.GetError())
+		}
+
+		if test.step.GetExitCode() != test.want.GetExitCode() {
+			t.Errorf("GetExitCode is %v, want %v", test.step.GetExitCode(), test.want.GetExitCode())
+		}
+
+		if test.step.GetCreated() != test.want.GetCreated() {
+			t.Errorf("GetCreated is %v, want %v", test.step.GetCreated(), test.want.GetCreated())
+		}
+
+		if test.step.GetStarted() != test.want.GetStarted() {
+			t.Errorf("GetStarted is %v, want %v", test.step.GetStarted(), test.want.GetStarted())
+		}
+
+		if test.step.GetFinished() != test.want.GetFinished() {
+			t.Errorf("GetFinished is %v, want %v", test.step.GetFinished(), test.want.GetFinished())
+		}
+
+		if test.step.GetHost() != test.want.GetHost() {
+			t.Errorf("GetHost is %v, want %v", test.step.GetHost(), test.want.GetHost())
+		}
+
+		if test.step.GetRuntime() != test.want.GetRuntime() {
+			t.Errorf("GetRuntime is %v, want %v", test.step.GetRuntime(), test.want.GetRuntime())
+		}
+
+		if test.step.GetDistribution() != test.want.GetDistribution() {
+			t.Errorf("GetDistribution is %v, want %v", test.step.GetDistribution(), test.want.GetDistribution())
+		}
+
+		if test.step.GetReportAs() != test.want.GetReportAs() {
+			t.Errorf("GetReportAs is %v, want %v", test.step.GetReportAs(), test.want.GetReportAs())
+		}
+	}
+}
+
+func TestTypes_Step_Setters(t *testing.T) {
+	// setup types
+	var s *Step
+
+	// setup tests
+	tests := []struct {
+		step *Step
+		want *Step
+	}{
+		{
+			step: testStep(),
+			want: testStep(),
+		},
+		{
+			step: s,
+			want: new(Step),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		test.step.SetID(test.want.GetID())
+		test.step.SetBuildID(test.want.GetBuildID())
+		test.step.SetRepoID(test.want.GetRepoID())
+		test.step.SetNumber(test.want.GetNumber())
+		test.step.SetName(test.want.GetName())
+		test.step.SetImage(test.want.GetImage())
+		test.step.SetStage(test.want.GetStage())
+		test.step.SetStatus(test.want.GetStatus())
+		test.step.SetError(test.want.GetError())
+		test.step.SetExitCode(test.want.GetExitCode())
+		test.step.SetCreated(test.want.GetCreated())
+		test.step.SetStarted(test.want.GetStarted())
+		test.step.SetFinished(test.want.GetFinished())
+		test.step.SetHost(test.want.GetHost())
+		test.step.SetRuntime(test.want.GetRuntime())
+		test.step.SetDistribution(test.want.GetDistribution())
+		test.step.SetReportAs(test.want.GetReportAs())
+
+		if test.step.GetID() != test.want.GetID() {
+			t.Errorf("SetID is %v, want %v", test.step.GetID(), test.want.GetID())
+		}
+
+		if test.step.GetBuildID() != test.want.GetBuildID() {
+			t.Errorf("SetBuildID is %v, want %v", test.step.GetBuildID(), test.want.GetBuildID())
+		}
+
+		if test.step.GetRepoID() != test.want.GetRepoID() {
+			t.Errorf("SetRepoID is %v, want %v", test.step.GetRepoID(), test.want.GetRepoID())
+		}
+
+		if test.step.GetNumber() != test.want.GetNumber() {
+			t.Errorf("SetNumber is %v, want %v", test.step.GetNumber(), test.want.GetNumber())
+		}
+
+		if test.step.GetName() != test.want.GetName() {
+			t.Errorf("SetName is %v, want %v", test.step.GetName(), test.want.GetName())
+		}
+
+		if test.step.GetImage() != test.want.GetImage() {
+			t.Errorf("SetImage is %v, want %v", test.step.GetImage(), test.want.GetImage())
+		}
+
+		if test.step.GetStage() != test.want.GetStage() {
+			t.Errorf("SetStage is %v, want %v", test.step.GetStage(), test.want.GetStage())
+		}
+
+		if test.step.GetStatus() != test.want.GetStatus() {
+			t.Errorf("SetStatus is %v, want %v", test.step.GetStatus(), test.want.GetStatus())
+		}
+
+		if test.step.GetError() != test.want.GetError() {
+			t.Errorf("SetError is %v, want %v", test.step.GetError(), test.want.GetError())
+		}
+
+		if test.step.GetExitCode() != test.want.GetExitCode() {
+			t.Errorf("SetExitCode is %v, want %v", test.step.GetExitCode(), test.want.GetExitCode())
+		}
+
+		if test.step.GetCreated() != test.want.GetCreated() {
+			t.Errorf("SetCreated is %v, want %v", test.step.GetCreated(), test.want.GetCreated())
+		}
+
+		if test.step.GetStarted() != test.want.GetStarted() {
+			t.Errorf("SetStarted is %v, want %v", test.step.GetStarted(), test.want.GetStarted())
+		}
+
+		if test.step.GetFinished() != test.want.GetFinished() {
+			t.Errorf("SetFinished is %v, want %v", test.step.GetFinished(), test.want.GetFinished())
+		}
+
+		if test.step.GetHost() != test.want.GetHost() {
+			t.Errorf("SetHost is %v, want %v", test.step.GetHost(), test.want.GetHost())
+		}
+
+		if test.step.GetRuntime() != test.want.GetRuntime() {
+			t.Errorf("SetRuntime is %v, want %v", test.step.GetRuntime(), test.want.GetRuntime())
+		}
+
+		if test.step.GetDistribution() != test.want.GetDistribution() {
+			t.Errorf("SetDistribution is %v, want %v", test.step.GetDistribution(), test.want.GetDistribution())
+		}
+
+		if test.step.GetReportAs() != test.want.GetReportAs() {
+			t.Errorf("SetReportAs is %v, want %v", test.step.GetReportAs(), test.want.GetReportAs())
+		}
+	}
+}
+
+func TestTypes_Step_String(t *testing.T) {
+	// setup types
+	s := testStep()
+
+	want := fmt.Sprintf(`{
+  BuildID: %d,
+  Created: %d,
+  Distribution: %s,
+  Error: %s,
+  ExitCode: %d,
+  Finished: %d,
+  Host: %s,
+  ID: %d,
+  Image: %s,
+  Name: %s,
+  Number: %d,
+  RepoID: %d,
+  ReportAs: %s,
+  Runtime: %s,
+  Stage: %s,
+  Started: %d,
+  Status: %s,
+}`,
+		s.GetBuildID(),
+		s.GetCreated(),
+		s.GetDistribution(),
+		s.GetError(),
+		s.GetExitCode(),
+		s.GetFinished(),
+		s.GetHost(),
+		s.GetID(),
+		s.GetImage(),
+		s.GetName(),
+		s.GetNumber(),
+		s.GetRepoID(),
+		s.GetReportAs(),
+		s.GetRuntime(),
+		s.GetStage(),
+		s.GetStarted(),
+		s.GetStatus(),
+	)
+
+	// run test
+	got := s.String()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("String is %v, want %v", got, want)
+	}
+}
+
+func TestTypes_StepFromBuildContainer(t *testing.T) {
+	// setup types
+	s := testStep()
+	s.SetStage("clone")
+	s.SetStatus("pending")
+
+	// modify fields that aren't set
+	s.ID = nil
+	s.BuildID = nil
+	s.RepoID = nil
+	s.ExitCode = nil
+	s.Created = nil
+	s.Started = nil
+	s.Finished = nil
+
+	tests := []struct {
+		name      string
+		container *pipeline.Container
+		build     *Build
+		want      *Step
+	}{
+		{
+			name:      "nil container with nil build",
+			container: nil,
+			build:     nil,
+			want:      &Step{Status: s.Status},
+		},
+		{
+			name:      "empty container with nil build",
+			container: new(pipeline.Container),
+			build:     nil,
+			want:      &Step{Status: s.Status},
+		},
+		{
+			name:      "nil container with build",
+			container: nil,
+			build:     testBuild(),
+			want: &Step{
+				Status:       s.Status,
+				Host:         s.Host,
+				Runtime:      s.Runtime,
+				Distribution: s.Distribution,
+			},
+		},
+		{
+			name:      "empty container with build",
+			container: new(pipeline.Container),
+			build:     testBuild(),
+			want: &Step{
+				Status:       s.Status,
+				Host:         s.Host,
+				Runtime:      s.Runtime,
+				Distribution: s.Distribution,
+			},
+		},
+		{
+			name: "container with build",
+			container: &pipeline.Container{
+				Name:     s.GetName(),
+				Number:   s.GetNumber(),
+				Image:    s.GetImage(),
+				ReportAs: s.GetReportAs(),
+				Environment: map[string]string{
+					"VELA_STEP_STAGE": "clone",
+				},
+			},
+			build: testBuild(),
+			want:  s,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := StepFromBuildContainer(test.build, test.container)
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("StepFromBuildContainer for %s is %v, want %v", test.name, got, test.want)
+		}
+	}
+}
+
+func TestTypes_StepFromContainerEnvironment(t *testing.T) {
+	// setup types
+	s := testStep()
+	s.SetStage("clone")
+
+	// modify fields that aren't set via environment variables
+	s.ID = nil
+	s.BuildID = nil
+	s.RepoID = nil
+
+	// setup tests
+	tests := []struct {
+		name      string
+		container *pipeline.Container
+		want      *Step
+	}{
+		{
+			name:      "nil container",
+			container: nil,
+			want:      nil,
+		},
+		{
+			name:      "empty container",
+			container: new(pipeline.Container),
+			want:      nil,
+		},
+		{
+			name: "container",
+			container: &pipeline.Container{
+				Environment: map[string]string{
+					"VELA_STEP_CREATED":      "1563474076",
+					"VELA_STEP_DISTRIBUTION": "linux",
+					"VELA_STEP_EXIT_CODE":    "0",
+					"VELA_STEP_FINISHED":     "1563474079",
+					"VELA_STEP_HOST":         "example.company.com",
+					"VELA_STEP_IMAGE":        "target/vela-git:v0.3.0",
+					"VELA_STEP_NAME":         "clone",
+					"VELA_STEP_NUMBER":       "1",
+					"VELA_STEP_REPORT_AS":    "test",
+					"VELA_STEP_RUNTIME":      "docker",
+					"VELA_STEP_STAGE":        "clone",
+					"VELA_STEP_STARTED":      "1563474078",
+					"VELA_STEP_STATUS":       "running",
+				},
+			},
+			want: s,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := StepFromContainerEnvironment(test.container)
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("StepFromContainerEnvironment for %s is %v, want %v", test.name, got, test.want)
+		}
+	}
+}
+
+// testStep is a test helper function to create a Step
+// type with all fields set to a fake value.
+func testStep() *Step {
+	s := new(Step)
+
+	s.SetID(1)
+	s.SetBuildID(1)
+	s.SetRepoID(1)
+	s.SetNumber(1)
+	s.SetName("clone")
+	s.SetImage("target/vela-git:v0.3.0")
+	s.SetStatus("running")
+	s.SetExitCode(0)
+	s.SetCreated(1563474076)
+	s.SetStarted(1563474078)
+	s.SetFinished(1563474079)
+	s.SetHost("example.company.com")
+	s.SetRuntime("docker")
+	s.SetDistribution("linux")
+	s.SetReportAs("test")
+
+	return s
+}

--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -20,12 +20,12 @@ import (
 	"github.com/go-vela/server/api/build"
 	"github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/compiler"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/internal"
 	"github.com/go-vela/server/queue"
 	"github.com/go-vela/server/scm"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 var baseErr = "unable to process webhook"

--- a/api/worker/create.go
+++ b/api/worker/create.go
@@ -12,11 +12,11 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/internal/token"
 	"github.com/go-vela/server/router/middleware/claims"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
 

--- a/api/worker/refresh.go
+++ b/api/worker/refresh.go
@@ -11,12 +11,12 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/internal/token"
 	"github.com/go-vela/server/router/middleware/claims"
 	"github.com/go-vela/server/router/middleware/worker"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
 

--- a/cmd/vela-server/main.go
+++ b/cmd/vela-server/main.go
@@ -13,13 +13,13 @@ import (
 
 	_ "github.com/joho/godotenv/autoload"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/queue"
 	"github.com/go-vela/server/scm"
 	"github.com/go-vela/server/secret"
 	"github.com/go-vela/server/tracing"
 	"github.com/go-vela/server/version"
-	"github.com/go-vela/types/constants"
 )
 
 //nolint:funlen // ignore line length

--- a/cmd/vela-server/schedule.go
+++ b/cmd/vela-server/schedule.go
@@ -16,12 +16,12 @@ import (
 	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/api/types/settings"
 	"github.com/go-vela/server/compiler"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/internal"
 	"github.com/go-vela/server/queue"
 	"github.com/go-vela/server/scm"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 const (

--- a/cmd/vela-server/secret.go
+++ b/cmd/vela-server/secret.go
@@ -6,9 +6,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/secret"
-	"github.com/go-vela/types/constants"
 )
 
 // helper function to setup the secrets engines from the CLI arguments.

--- a/cmd/vela-server/validate.go
+++ b/cmd/vela-server/validate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func validate(c *cli.Context) error {

--- a/compiler/native/clone.go
+++ b/compiler/native/clone.go
@@ -4,7 +4,7 @@ package native
 
 import (
 	"github.com/go-vela/server/compiler/types/yaml"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -20,7 +20,7 @@ import (
 	"github.com/go-vela/server/compiler/types/pipeline"
 	"github.com/go-vela/server/compiler/types/raw"
 	"github.com/go-vela/server/compiler/types/yaml"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // ModifyRequest contains the payload passed to the modification endpoint.

--- a/compiler/native/compile_test.go
+++ b/compiler/native/compile_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/go-vela/server/compiler/types/pipeline"
 	"github.com/go-vela/server/compiler/types/raw"
 	"github.com/go-vela/server/compiler/types/yaml"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/internal"
-	"github.com/go-vela/types/constants"
 )
 
 func TestNative_Compile_StagesPipeline(t *testing.T) {

--- a/compiler/native/environment.go
+++ b/compiler/native/environment.go
@@ -10,8 +10,8 @@ import (
 	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/compiler/types/raw"
 	"github.com/go-vela/server/compiler/types/yaml"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/internal"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
 

--- a/compiler/native/expand.go
+++ b/compiler/native/expand.go
@@ -16,7 +16,7 @@ import (
 	"github.com/go-vela/server/compiler/types/pipeline"
 	"github.com/go-vela/server/compiler/types/raw"
 	"github.com/go-vela/server/compiler/types/yaml"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // ExpandStages injects the template for each

--- a/compiler/native/initialize.go
+++ b/compiler/native/initialize.go
@@ -4,7 +4,7 @@ package native
 
 import (
 	"github.com/go-vela/server/compiler/types/yaml"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/compiler/native/parse.go
+++ b/compiler/native/parse.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-vela/server/compiler/template/starlark"
 	typesRaw "github.com/go-vela/server/compiler/types/raw"
 	types "github.com/go-vela/server/compiler/types/yaml"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // ParseRaw converts an object to a string.

--- a/compiler/native/parse_test.go
+++ b/compiler/native/parse_test.go
@@ -16,7 +16,7 @@ import (
 	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/compiler/types/raw"
 	"github.com/go-vela/server/compiler/types/yaml"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestNative_Parse_Metadata_Bytes(t *testing.T) {

--- a/compiler/native/validate.go
+++ b/compiler/native/validate.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/go-vela/server/compiler/types/yaml"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // Validate verifies the yaml configuration is valid.

--- a/compiler/types/pipeline/build.go
+++ b/compiler/types/pipeline/build.go
@@ -8,7 +8,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/go-vela/server/compiler/types/raw"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // Build is the pipeline representation of a build for a pipeline.

--- a/compiler/types/pipeline/build_test.go
+++ b/compiler/types/pipeline/build_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestPipeline_Build_Purge(t *testing.T) {

--- a/compiler/types/pipeline/container.go
+++ b/compiler/types/pipeline/container.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/drone/envsubst"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/compiler/types/pipeline/container_test.go
+++ b/compiler/types/pipeline/container_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestPipeline_ContainerSlice_Purge(t *testing.T) {

--- a/compiler/types/pipeline/ruleset.go
+++ b/compiler/types/pipeline/ruleset.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/compiler/types/pipeline/ruleset_test.go
+++ b/compiler/types/pipeline/ruleset_test.go
@@ -5,7 +5,7 @@ package pipeline
 import (
 	"testing"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestPipeline_Ruleset_Match(t *testing.T) {

--- a/compiler/types/pipeline/secret.go
+++ b/compiler/types/pipeline/secret.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/compiler/types/pipeline/stage.go
+++ b/compiler/types/pipeline/stage.go
@@ -5,7 +5,7 @@ package pipeline
 import (
 	"fmt"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/compiler/types/pipeline/stage_test.go
+++ b/compiler/types/pipeline/stage_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestPipeline_StageSlice_Purge(t *testing.T) {

--- a/compiler/types/yaml/ruleset.go
+++ b/compiler/types/yaml/ruleset.go
@@ -5,7 +5,7 @@ package yaml
 import (
 	"github.com/go-vela/server/compiler/types/pipeline"
 	"github.com/go-vela/server/compiler/types/raw"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/compiler/types/yaml/secret.go
+++ b/compiler/types/yaml/secret.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-vela/server/compiler/types/pipeline"
 	"github.com/go-vela/server/compiler/types/raw"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/compiler/types/yaml/service.go
+++ b/compiler/types/yaml/service.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/go-vela/server/compiler/types/pipeline"
 	"github.com/go-vela/server/compiler/types/raw"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/compiler/types/yaml/step.go
+++ b/compiler/types/yaml/step.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/go-vela/server/compiler/types/pipeline"
 	"github.com/go-vela/server/compiler/types/raw"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/constants/action.go
+++ b/constants/action.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+// Build and repo events.
+const (
+	// ActionOpened defines the action for opening pull requests.
+	ActionOpened = "opened"
+
+	// ActionCreated defines the action for creating deployments or issue comments.
+	ActionCreated = "created"
+
+	// ActionEdited defines the action for the editing of pull requests or issue comments.
+	ActionEdited = "edited"
+
+	// ActionRenamed defines the action for renaming a repository.
+	ActionRenamed = "renamed"
+
+	// ActionReopened defines the action for re-opening a pull request (or issue).
+	ActionReopened = "reopened"
+
+	// ActionSynchronize defines the action for the synchronizing of pull requests.
+	ActionSynchronize = "synchronize"
+
+	// ActionLabeled defines the action for the labeling of pull requests.
+	ActionLabeled = "labeled"
+
+	// ActionUnlabeled defines the action for the unlabeling of pull requests.
+	ActionUnlabeled = "unlabeled"
+
+	// ActionTransferred defines the action for transferring repository ownership.
+	ActionTransferred = "transferred"
+
+	// ActionBranch defines the action for deleting a branch.
+	ActionBranch = "branch"
+
+	// ActionTag defines the action for deleting a tag.
+	ActionTag = "tag"
+
+	// ActionRun defines the action for running a schedule.
+	ActionRun = "run"
+)

--- a/constants/allow_events.go
+++ b/constants/allow_events.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+// Allowed repo events. NOTE: these can NOT change order. New events must be added at the end.
+const (
+	AllowPushBranch = 1 << iota // 00000001 = 1
+	AllowPushTag                // 00000010 = 2
+	AllowPullOpen               // 00000100 = 4
+	AllowPullEdit               // ...
+	AllowPullSync
+	_ // AllowPullAssigned - Not Implemented
+	_ // AllowPullMilestoned - Not Implemented
+	AllowPullLabel
+	_ // AllowPullLocked - Not Implemented
+	_ // AllowPullReady - Not Implemented
+	AllowPullReopen
+	_ // AllowPullReviewRequest - Not Implemented
+	_ // AllowPullClosed - Not Implemented
+	AllowDeployCreate
+	AllowCommentCreate
+	AllowCommentEdit
+	AllowSchedule
+	AllowPushDeleteBranch
+	AllowPushDeleteTag
+	AllowPullUnlabel
+)

--- a/constants/badge.go
+++ b/constants/badge.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+// Constants for build badges.
+//
+//nolint:godot // due to providing pretty printed svgs
+const (
+	// Badge for unknown state
+	// <svg xmlns="http://www.w3.org/2000/svg" width="92" height="20">
+	//     <linearGradient id="b" x2="0" y2="100%">
+	//         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+	//         <stop offset="1" stop-opacity=".1"/>
+	//     </linearGradient>
+	//     <path d="M0 3 a3 3 0 014-3h28v20H3 a3 3 0 01-3-3V3z" fill="#555555"/>
+	//     <path d="M92 17 a3 3 0 01-3 3H32V0h56 a3 3 0 014 3v12z" fill="#9f9f9f"/>
+	//     <rect width="100%" height="100%" rx="3" fill="url(#b)"/>
+	//     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+	//         <text x="16" y="14" fill="#010101" fill-opacity=".3" textLength="24" lengthAdjust="spacing">vela</text>
+	//         <text x="16" y="13" textLength="24" lengthAdjust="spacing">vela</text>
+	//         <text x="62" y="14" fill="#010101" fill-opacity=".3" textLength="52" lengthAdjust="spacing">unknown</text>
+	//         <text x="62" y="13" textLength="52" lengthAdjust="spacing">unknown</text>
+	//     </g>
+	// </svg>
+	BadgeUnknown = `<svg xmlns="http://www.w3.org/2000/svg" width="92" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><path d="M0 3 a3 3 0 014-3h28v20H3 a3 3 0 01-3-3V3z" fill="#555555"/><path d="M92 17 a3 3 0 01-3 3H32V0h56 a3 3 0 014 3v12z" fill="#9f9f9f"/><rect width="100%" height="100%" rx="3" fill="url(#b)"/><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="16" y="14" fill="#010101" fill-opacity=".3" textLength="24" lengthAdjust="spacing">vela</text><text x="16" y="13" textLength="24" lengthAdjust="spacing">vela</text><text x="62" y="14" fill="#010101" fill-opacity=".3" textLength="52" lengthAdjust="spacing">unknown</text><text x="62" y="13" textLength="52" lengthAdjust="spacing">unknown</text></g></svg>`
+
+	// Badge for success state
+	// <svg xmlns="http://www.w3.org/2000/svg" width="85" height="20">
+	//     <linearGradient id="a" x2="0" y2="100%">
+	//         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+	//         <stop offset="1" stop-opacity=".1"/>
+	//     </linearGradient>
+	//     <path d="M0 3 a3 3 0 014-3h30v20H3 a3 3 0 01-3-3V3z" fill="#555555"/>
+	//     <path d="M85 17 a3 3 0 01-3 3H32V0h49 a3 3 0 014 3v12z" fill="#44cc11"/>
+	//     <rect width="100%" height="100%" rx="3" fill="url(#a)"/>
+	//     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+	//         <text x="16" y="14" fill="#010101" fill-opacity=".3" textLength="24" lengthAdjust="spacing">vela</text>
+	//         <text x="16" y="13" textlength="24" lengthadjust="spacing">vela</text>
+	//         <text x="58" y="14" fill="#010101" fill-opacity=".3" textlength="46" lengthadjust="spacing">success</text>
+	//         <text x="58" y="13" textlength="46" lengthadjust="spacing">success</text>
+	//     </g>
+	// </svg>
+	BadgeSuccess = `<svg xmlns="http://www.w3.org/2000/svg" width="85" height="20"><linearGradient id="a" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><path d="M0 3 a3 3 0 014-3h30v20H3 a3 3 0 01-3-3V3z" fill="#555555"/><path d="M85 17 a3 3 0 01-3 3H32V0h49 a3 3 0 014 3v12z" fill="#44cc11"/><rect width="100%" height="100%" rx="3" fill="url(#a)"/><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="16" y="14" fill="#010101" fill-opacity=".3" textLength="24" lengthAdjust="spacing">vela</text><text x="16" y="13" textlength="24" lengthadjust="spacing">vela</text><text x="58" y="14" fill="#010101" fill-opacity=".3" textlength="46" lengthadjust="spacing">success</text><text x="58" y="13" textlength="46" lengthadjust="spacing">success</text></g></svg>`
+
+	// Badge for failed state
+	// <svg xmlns="http://www.w3.org/2000/svg" width="73" height="20">
+	//     <linearGradient id="a" x2="0" y2="100%">
+	//         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+	//         <stop offset="1" stop-opacity=".1"/>
+	//     </linearGradient>
+	//     <path d="M0 3 a3 3 0 014-3h30v20H3 a3 3 0 01-3-3V3z" fill="#555555"/>
+	//     <path d="M73 17 a3 3 0 01-3 3H32V0h37 a3 3 0 014 3v12z" fill="#fe7d37"/>
+	//     <rect width="100%" height="100%" rx="3" fill="url(#a)"/>
+	//     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+	//         <text x="16" y="14" fill="#010101" fill-opacity=".3" textLength="24" lengthAdjust="spacing">vela</text>
+	//         <text x="16" y="13" textlength="24" lengthadjust="spacing">vela</text>
+	//         <text x="52" y="14" fill="#010101" fill-opacity=".3" textlength="46" lengthadjust="spacing">failed</text>
+	//         <text x="52" y="13" textlength="46" lengthadjust="spacing">failed</text>
+	//     </g>
+	// </svg>
+	BadgeFailed = `<svg xmlns="http://www.w3.org/2000/svg" width="73" height="20"><linearGradient id="a" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><path d="M0 3 a3 3 0 014-3h30v20H3 a3 3 0 01-3-3V3z" fill="#555555"/><path d="M73 17 a3 3 0 01-3 3H32V0h37 a3 3 0 014 3v12z" fill="#fe7d37"/><rect width="100%" height="100%" rx="3" fill="url(#a)"/><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="16" y="14" fill="#010101" fill-opacity=".3" textLength="24" lengthAdjust="spacing">vela</text><text x="16" y="13" textlength="24" lengthadjust="spacing">vela</text><text x="52" y="14" fill="#010101" fill-opacity=".3" textlength="46" lengthadjust="spacing">failed</text><text x="52" y="13" textlength="46" lengthadjust="spacing">failed</text></g></svg>`
+
+	// Badge for error state
+	// <svg xmlns="http://www.w3.org/2000/svg" width="69" height="20">
+	//     <linearGradient id="a" x2="0" y2="100%">
+	//         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+	//         <stop offset="1" stop-opacity=".1"/>
+	//     </linearGradient>
+	//     <path d="M0 3 a3 3 0 014-3h30v20H3 a3 3 0 01-3-3V3z" fill="#555555"/>
+	//     <path d="M69 17 a3 3 0 01-3 3H32V0h33 a3 3 0 014 3v12z" fill="#e05d44"/>
+	//     <rect width="100%" height="100%" rx="3" fill="url(#a)"/>
+	//     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+	//         <text x="16" y="14" fill="#010101" fill-opacity=".3" textLength="24" lengthAdjust="spacing">vela</text>
+	//         <text x="16" y="13" textlength="24" lengthadjust="spacing">vela</text>
+	//         <text x="50" y="14" fill="#010101" fill-opacity=".3" textlength="46" lengthadjust="spacing">error</text>
+	//         <text x="50" y="13" textlength="46" lengthadjust="spacing">error</text>
+	//     </g>
+	// </svg>
+	BadgeError = `<svg xmlns="http://www.w3.org/2000/svg" width="69" height="20"><linearGradient id="a" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><path d="M0 3 a3 3 0 014-3h30v20H3 a3 3 0 01-3-3V3z" fill="#555555"/><path d="M69 17 a3 3 0 01-3 3H32V0h33 a3 3 0 014 3v12z" fill="#e05d44"/><rect width="100%" height="100%" rx="3" fill="url(#a)"/><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="16" y="14" fill="#010101" fill-opacity=".3" textLength="24" lengthAdjust="spacing">vela</text><text x="16" y="13" textlength="24" lengthadjust="spacing">vela</text><text x="50" y="14" fill="#010101" fill-opacity=".3" textlength="46" lengthadjust="spacing">error</text><text x="50" y="13" textlength="46" lengthadjust="spacing">error</text></g></svg>`
+
+	// Badge for running status
+	// <svg xmlns="http://www.w3.org/2000/svg" width="88" height="20">
+	//     <linearGradient id="b" x2="0" y2="100%">
+	//         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+	//         <stop offset="1" stop-opacity=".1"/>
+	//     </linearGradient>
+	//     <path d="M0 3 a3 3 0 014-3h28v20H3 a3 3 0 01-3-3V3z" fill="#555555"/>
+	//     <path d="M88 17 a3 3 0 01-3 3H32V0h52 a3 3 0 014 3v12z" fill="#dfb317"/>
+	//     <rect width="100%" height="100%" rx="3" fill="url(#b)"/>
+	//     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+	//         <text x="16" y="14" fill="#010101" fill-opacity=".3" textLength="24" lengthAdjust="spacing">vela</text>
+	//         <text x="16" y="13" textLength="24" lengthAdjust="spacing">vela</text>
+	//         <text x="59" y="14" fill="#010101" fill-opacity=".3" textLength="46" lengthAdjust="spacing">running</text>
+	//         <text x="59" y="13" textLength="46" lengthAdjust="spacing">running</text>
+	//     </g>
+	// </svg>
+	BadgeRunning = `<svg xmlns="http://www.w3.org/2000/svg" width="88" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><path d="M0 3 a3 3 0 014-3h28v20H3 a3 3 0 01-3-3V3z" fill="#555555"/><path d="M88 17 a3 3 0 01-3 3H32V0h52 a3 3 0 014 3v12z" fill="#dfb317"/><rect width="100%" height="100%" rx="3" fill="url(#b)"/><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="16" y="14" fill="#010101" fill-opacity=".3" textLength="24" lengthAdjust="spacing">vela</text><text x="16" y="13" textLength="24" lengthAdjust="spacing">vela</text><text x="59" y="14" fill="#010101" fill-opacity=".3" textLength="46" lengthAdjust="spacing">running</text><text x="59" y="13" textLength="46" lengthAdjust="spacing">running</text></g></svg>`
+)

--- a/constants/compression.go
+++ b/constants/compression.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+// Log Compression Levels.
+const (
+	// The default compression level for the compress/zlib library
+	// for log data stored in the database.
+	CompressionNegOne = -1
+
+	// Enables no compression for log data stored in the database.
+	//
+	// This produces no compression for the log data.
+	CompressionZero = 0
+
+	// Enables the best speed for log data stored in the database.
+	//
+	// This produces compression for the log data the fastest but
+	// has a tradeoff of producing the largest amounts of data.
+	CompressionOne = 1
+
+	// Second compression level for log data stored in the database.
+	CompressionTwo = 2
+
+	// Third compression level for log data stored in the database.
+	CompressionThree = 3
+
+	// Fourth compression level for log data stored in the database.
+	CompressionFour = 4
+
+	// Enables an even balance of speed and compression for log
+	// data stored in the database.
+	//
+	// This produces compression for the log data with an even
+	// balance of speed while producing smaller amounts of data.
+	CompressionFive = 5
+
+	// Sixth compression level for log data stored in the database.
+	CompressionSix = 6
+
+	// Seventh compression level for log data stored in the database.
+	CompressionSeven = 7
+
+	// Eighth compression level for log data stored in the database.
+	CompressionEight = 8
+
+	// Enables the best compression for log data stored in the database.
+	//
+	// This produces compression for the log data the slowest but
+	// has a tradeoff of producing the smallest amounts of data.
+	CompressionNine = 9
+)

--- a/constants/doc.go
+++ b/constants/doc.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package constants provides the defined constant types for Vela.
+//
+// Usage:
+//
+//	import "github.com/go-vela/types/constants"
+package constants

--- a/constants/event.go
+++ b/constants/event.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+// Build and repo events.
+const (
+	// EventComment defines the event type for comments added to a pull request.
+	EventComment = "comment"
+
+	// EventDelete defines the event type for build and repo delete events.
+	EventDelete = "delete"
+
+	// EventDeploy defines the event type for build and repo deployment events.
+	EventDeploy = "deployment"
+
+	// EventPull defines the event type for build and repo pull_request events.
+	EventPull = "pull_request"
+
+	// EventPush defines the event type for build and repo push events.
+	EventPush = "push"
+
+	// EventRepository defines the general event type for repo management.
+	EventRepository = "repository"
+
+	// EventSchedule defines the event type for build and repo schedule events.
+	EventSchedule = "schedule"
+
+	// EventTag defines the event type for build and repo tag events.
+	EventTag = "tag"
+
+	// Alternates for common user inputs that do not match our set constants.
+
+	// EventPullAlternate defines the alternate event type for build and repo pull_request events.
+	EventPullAlternate = "pull"
+
+	// EventDeployAlternate defines the alternate event type for build and repo deployment events.
+	EventDeployAlternate = "deploy"
+)

--- a/constants/limit.go
+++ b/constants/limit.go
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+
 package constants
 
 // Limits and constraints.

--- a/constants/matcher.go
+++ b/constants/matcher.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+// Ruleset matchers.
+const (
+	// MatcherFilepath defines the ruleset type for the filepath matcher.
+	MatcherFilepath = "filepath"
+
+	// MatcherRegex defines the ruleset type for the regex matcher.
+	MatcherRegex = "regexp"
+)

--- a/constants/operator.go
+++ b/constants/operator.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+// Ruleset operators.
+const (
+	// OperatorAnd defines the ruleset type for the and operator.
+	OperatorAnd = "and"
+
+	// OperatorOr defines the ruleset type for the or operator.
+	OperatorOr = "or"
+)

--- a/constants/pipeline.go
+++ b/constants/pipeline.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+// Pipeline types.
+const (
+	// PipelineStages defines the type for a pipeline with stages.
+	PipelineStage = "stages"
+
+	// PipelineStep defines the type for a pipeline with steps.
+	PipelineStep = "steps"
+
+	// PipelineTemplate defines the type for a pipeline as a template.
+	PipelineTemplate = "template"
+)

--- a/constants/pull.go
+++ b/constants/pull.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+// Service and step pull policies.
+const (
+	// PullAlways defines the pull policy type for
+	// a service or step to always pull an image.
+	PullAlways = "always"
+
+	// PullNotPresent defines the pull policy type for
+	// a service or step to only pull an image if it doesn't exist.
+	PullNotPresent = "not_present"
+
+	// PullOnStart defines the pull policy type for
+	// a service or step to only pull an image before the container starts.
+	PullOnStart = "on_start"
+
+	// PullNever defines the pull policy type for
+	// a service or step to never pull an image.
+	PullNever = "never"
+)

--- a/constants/queue.go
+++ b/constants/queue.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+// Queue types.
+const (
+	// DefaultRoute defines the default route all workers listen on.
+	DefaultRoute = "vela"
+)

--- a/constants/table.go
+++ b/constants/table.go
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+
 package constants
 
 // Database tables.

--- a/constants/worker_status.go
+++ b/constants/worker_status.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+// Worker statuses.
+const (
+	// WorkerStatusIdle defines the status for a worker
+	// where worker RunningBuildIDs.length = 0.
+	WorkerStatusIdle = "idle"
+
+	// WorkerStatusAvailable defines the status type for a worker in an available state,
+	// where worker RunningBuildIDs.length > 0 and < worker BuildLimit.
+	WorkerStatusAvailable = "available"
+
+	// WorkerStatusBusy defines the status type for a worker in an unavailable state,
+	// where worker BuildLimit == worker RunningBuildIDs.length.
+	WorkerStatusBusy = "busy"
+
+	// WorkerStatusError defines the status for a worker in an error state.
+	WorkerStatusError = "error"
+)

--- a/constants/workspace.go
+++ b/constants/workspace.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+// Service and Step workspace paths.
+const (
+	// WorkspaceDefault defines the default workspace path for a service or a step.
+	WorkspaceDefault = "/vela/src"
+
+	// WorkspaceMount defines the mount workspace path for a service or a step.
+	WorkspaceMount = "/vela"
+)

--- a/database/build/build.go
+++ b/database/build/build.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/database/build/clean.go
+++ b/database/build/clean.go
@@ -9,8 +9,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // CleanBuilds updates builds to an error with a provided message with a created timestamp prior to a defined moment.

--- a/database/build/count.go
+++ b/database/build/count.go
@@ -5,7 +5,7 @@ package build
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountBuilds gets the count of all builds from the database.

--- a/database/build/count_deployment.go
+++ b/database/build/count_deployment.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountBuildsForDeployment gets the count of builds by deployment URL from the database.

--- a/database/build/count_org.go
+++ b/database/build/count_org.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountBuildsForOrg gets the count of builds by org name from the database.

--- a/database/build/count_org_test.go
+++ b/database/build/count_org_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 func TestBuild_Engine_CountBuildsForOrg(t *testing.T) {

--- a/database/build/count_repo.go
+++ b/database/build/count_repo.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountBuildsForRepo gets the count of builds by repo ID from the database.

--- a/database/build/count_status.go
+++ b/database/build/count_status.go
@@ -5,7 +5,7 @@ package build
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountBuildsForStatus gets the count of builds by status from the database.

--- a/database/build/create.go
+++ b/database/build/create.go
@@ -9,8 +9,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // CreateBuild creates a new build in the database.

--- a/database/build/delete.go
+++ b/database/build/delete.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // DeleteBuild deletes an existing build from the database.

--- a/database/build/get.go
+++ b/database/build/get.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetBuild gets a build by ID from the database.

--- a/database/build/get_repo.go
+++ b/database/build/get_repo.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetBuildForRepo gets a build by repo ID and number from the database.

--- a/database/build/get_repo_test.go
+++ b/database/build/get_repo_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestBuild_Engine_GetBuildForRepo(t *testing.T) {

--- a/database/build/get_test.go
+++ b/database/build/get_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 func TestBuild_Engine_GetBuild(t *testing.T) {

--- a/database/build/last_repo.go
+++ b/database/build/last_repo.go
@@ -10,8 +10,8 @@ import (
 	"gorm.io/gorm"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // LastBuildForRepo gets the last build by repo ID and branch from the database.

--- a/database/build/last_repo_test.go
+++ b/database/build/last_repo_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestBuild_Engine_LastBuildForRepo(t *testing.T) {

--- a/database/build/list.go
+++ b/database/build/list.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListBuilds gets a list of all builds from the database.

--- a/database/build/list_dashboard.go
+++ b/database/build/list_dashboard.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListBuildsForDashboardRepo gets a list of builds by repo ID from the database.

--- a/database/build/list_org.go
+++ b/database/build/list_org.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListBuildsForOrg gets a list of builds by org name from the database.

--- a/database/build/list_org_test.go
+++ b/database/build/list_org_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 func TestBuild_Engine_ListBuildsForOrg(t *testing.T) {

--- a/database/build/list_pending_running.go
+++ b/database/build/list_pending_running.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListPendingAndRunningBuilds gets a list of all pending and running builds in the provided timeframe from the database.

--- a/database/build/list_pending_running_repo.go
+++ b/database/build/list_pending_running_repo.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListPendingAndRunningBuilds gets a list of all pending and running builds in the provided timeframe from the database.

--- a/database/build/list_pending_running_test.go
+++ b/database/build/list_pending_running_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 func TestBuild_Engine_ListPendingAndRunningBuilds(t *testing.T) {

--- a/database/build/list_repo.go
+++ b/database/build/list_repo.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListBuildsForRepo gets a list of builds by repo ID from the database.

--- a/database/build/list_repo_test.go
+++ b/database/build/list_repo_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestBuild_Engine_ListBuildsForRepo(t *testing.T) {

--- a/database/build/list_test.go
+++ b/database/build/list_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 func TestBuild_Engine_ListBuilds(t *testing.T) {

--- a/database/build/table.go
+++ b/database/build/table.go
@@ -5,7 +5,7 @@ package build
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/database/build/update.go
+++ b/database/build/update.go
@@ -9,8 +9,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // UpdateBuild updates an existing build in the database.

--- a/database/dashboard/table.go
+++ b/database/dashboard/table.go
@@ -5,7 +5,7 @@ package dashboard
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/database/database.go
+++ b/database/database.go
@@ -13,6 +13,7 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/build"
 	"github.com/go-vela/server/database/dashboard"
 	"github.com/go-vela/server/database/deployment"
@@ -30,7 +31,6 @@ import (
 	"github.com/go-vela/server/database/user"
 	"github.com/go-vela/server/database/worker"
 	"github.com/go-vela/server/tracing"
-	"github.com/go-vela/types/constants"
 )
 
 type (

--- a/database/deployment/count.go
+++ b/database/deployment/count.go
@@ -5,7 +5,7 @@ package deployment
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountDeployments gets the count of all deployments from the database.

--- a/database/deployment/count_repo.go
+++ b/database/deployment/count_repo.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountDeploymentsForRepo gets the count of deployments by repo ID from the database.

--- a/database/deployment/create.go
+++ b/database/deployment/create.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // CreateDeployment creates a new deployment in the database.

--- a/database/deployment/delete.go
+++ b/database/deployment/delete.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // DeleteDeployment deletes an existing deployment from the database.

--- a/database/deployment/deployment.go
+++ b/database/deployment/deployment.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/database/deployment/get.go
+++ b/database/deployment/get.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetDeployment gets a deployment by ID from the database.

--- a/database/deployment/get_repo.go
+++ b/database/deployment/get_repo.go
@@ -9,8 +9,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetDeploymentForRepo gets a deployment by repo ID and number from the database.

--- a/database/deployment/list.go
+++ b/database/deployment/list.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListDeployments gets a list of all deployments from the database.

--- a/database/deployment/list_repo.go
+++ b/database/deployment/list_repo.go
@@ -9,8 +9,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListDeploymentsForRepo gets a list of deployments by repo ID from the database.

--- a/database/deployment/table.go
+++ b/database/deployment/table.go
@@ -5,7 +5,7 @@ package deployment
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/database/deployment/update.go
+++ b/database/deployment/update.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // UpdateDeployment updates an existing deployment in the database.

--- a/database/executable/clean.go
+++ b/database/executable/clean.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const CleanExecutablesPostgres = `

--- a/database/executable/clean_test.go
+++ b/database/executable/clean_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )

--- a/database/executable/create.go
+++ b/database/executable/create.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )

--- a/database/executable/executable.go
+++ b/database/executable/executable.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/database/executable/executable_test.go
+++ b/database/executable/executable_test.go
@@ -13,7 +13,7 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/types/library"
 )
 

--- a/database/executable/pop.go
+++ b/database/executable/pop.go
@@ -7,7 +7,7 @@ import (
 
 	"gorm.io/gorm/clause"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )

--- a/database/executable/table.go
+++ b/database/executable/table.go
@@ -5,7 +5,7 @@ package executable
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/database/flags.go
+++ b/database/flags.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // Flags represents all supported command line interface (CLI) flags for the database.

--- a/database/hook/last_repo.go
+++ b/database/hook/last_repo.go
@@ -10,8 +10,8 @@ import (
 	"gorm.io/gorm"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // LastHookForRepo gets the last hook by repo ID from the database.

--- a/database/integration_test.go
+++ b/database/integration_test.go
@@ -17,6 +17,7 @@ import (
 	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/api/types/settings"
 	"github.com/go-vela/server/compiler/types/raw"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/build"
 	"github.com/go-vela/server/database/dashboard"
 	"github.com/go-vela/server/database/deployment"
@@ -35,7 +36,6 @@ import (
 	"github.com/go-vela/server/database/user"
 	"github.com/go-vela/server/database/worker"
 	"github.com/go-vela/server/tracing"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
 
@@ -52,8 +52,8 @@ type Resources struct {
 	Repos       []*api.Repo
 	Schedules   []*api.Schedule
 	Secrets     []*api.Secret
-	Services    []*library.Service
-	Steps       []*library.Step
+	Services    []*api.Service
+	Steps       []*api.Step
 	Users       []*api.User
 	Workers     []*api.Worker
 	Platform    []*settings.Platform
@@ -1935,8 +1935,8 @@ func testServices(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list services for build %d: %v", resources.Builds[0].GetID(), err)
 	}
-	if !cmp.Equal(list, []*library.Service{resources.Services[1], resources.Services[0]}) {
-		t.Errorf("ListServicesForBuild() is %v, want %v", list, []*library.Service{resources.Services[1], resources.Services[0]})
+	if !cmp.Equal(list, []*api.Service{resources.Services[1], resources.Services[0]}) {
+		t.Errorf("ListServicesForBuild() is %v, want %v", list, []*api.Service{resources.Services[1], resources.Services[0]})
 	}
 	if int(count) != len(resources.Services) {
 		t.Errorf("ListServicesForBuild() is %v, want %v", count, len(resources.Services))
@@ -2090,8 +2090,8 @@ func testSteps(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list steps for build %d: %v", resources.Builds[0].GetID(), err)
 	}
-	if !cmp.Equal(list, []*library.Step{resources.Steps[1], resources.Steps[0]}) {
-		t.Errorf("ListStepsForBuild() is %v, want %v", list, []*library.Step{resources.Steps[1], resources.Steps[0]})
+	if !cmp.Equal(list, []*api.Step{resources.Steps[1], resources.Steps[0]}) {
+		t.Errorf("ListStepsForBuild() is %v, want %v", list, []*api.Step{resources.Steps[1], resources.Steps[0]})
 	}
 	if int(count) != len(resources.Steps) {
 		t.Errorf("ListStepsForBuild() is %v, want %v", count, len(resources.Steps))
@@ -2877,7 +2877,7 @@ func newResources() *Resources {
 	secretShared.SetUpdatedAt(time.Now().Add(time.Hour * 1).UTC().Unix())
 	secretShared.SetUpdatedBy("octokitty")
 
-	serviceOne := new(library.Service)
+	serviceOne := new(api.Service)
 	serviceOne.SetID(1)
 	serviceOne.SetBuildID(1)
 	serviceOne.SetRepoID(1)
@@ -2894,7 +2894,7 @@ func newResources() *Resources {
 	serviceOne.SetRuntime("docker")
 	serviceOne.SetDistribution("linux")
 
-	serviceTwo := new(library.Service)
+	serviceTwo := new(api.Service)
 	serviceTwo.SetID(2)
 	serviceTwo.SetBuildID(1)
 	serviceTwo.SetRepoID(1)
@@ -2911,7 +2911,7 @@ func newResources() *Resources {
 	serviceTwo.SetRuntime("docker")
 	serviceTwo.SetDistribution("linux")
 
-	stepOne := new(library.Step)
+	stepOne := new(api.Step)
 	stepOne.SetID(1)
 	stepOne.SetBuildID(1)
 	stepOne.SetRepoID(1)
@@ -2930,7 +2930,7 @@ func newResources() *Resources {
 	stepOne.SetDistribution("linux")
 	stepOne.SetReportAs("")
 
-	stepTwo := new(library.Step)
+	stepTwo := new(api.Step)
 	stepTwo.SetID(2)
 	stepTwo.SetBuildID(1)
 	stepTwo.SetRepoID(1)
@@ -2995,8 +2995,8 @@ func newResources() *Resources {
 		Repos:       []*api.Repo{repoOne, repoTwo},
 		Schedules:   []*api.Schedule{scheduleOne, scheduleTwo},
 		Secrets:     []*api.Secret{secretOrg, secretRepo, secretShared},
-		Services:    []*library.Service{serviceOne, serviceTwo},
-		Steps:       []*library.Step{stepOne, stepTwo},
+		Services:    []*api.Service{serviceOne, serviceTwo},
+		Steps:       []*api.Step{stepOne, stepTwo},
 		Users:       []*api.User{userOne, userTwo},
 		Workers:     []*api.Worker{workerOne, workerTwo},
 	}

--- a/database/jwk/table.go
+++ b/database/jwk/table.go
@@ -5,7 +5,7 @@ package jwk
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/database/log/count.go
+++ b/database/log/count.go
@@ -5,7 +5,7 @@ package log
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountLogs gets the count of all logs from the database.

--- a/database/log/count_build.go
+++ b/database/log/count_build.go
@@ -6,7 +6,7 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountLogsForBuild gets the count of logs by build ID from the database.

--- a/database/log/create.go
+++ b/database/log/create.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )

--- a/database/log/delete.go
+++ b/database/log/delete.go
@@ -5,7 +5,7 @@ package log
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )

--- a/database/log/get.go
+++ b/database/log/get.go
@@ -5,7 +5,7 @@ package log
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )

--- a/database/log/get_service.go
+++ b/database/log/get_service.go
@@ -6,13 +6,14 @@ package log
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )
 
 // GetLogForService gets a log by service ID from the database.
-func (e *engine) GetLogForService(ctx context.Context, s *library.Service) (*library.Log, error) {
+func (e *engine) GetLogForService(ctx context.Context, s *api.Service) (*library.Log, error) {
 	e.logger.Tracef("getting log for service %d for build %d", s.GetID(), s.GetBuildID())
 
 	// variable to store query results

--- a/database/log/get_step.go
+++ b/database/log/get_step.go
@@ -6,13 +6,14 @@ package log
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )
 
 // GetLogForStep gets a log by step ID from the database.
-func (e *engine) GetLogForStep(ctx context.Context, s *library.Step) (*library.Log, error) {
+func (e *engine) GetLogForStep(ctx context.Context, s *api.Step) (*library.Log, error) {
 	e.logger.Tracef("getting log for step %d for build %d", s.GetID(), s.GetBuildID())
 
 	// variable to store query results

--- a/database/log/interface.go
+++ b/database/log/interface.go
@@ -38,9 +38,9 @@ type LogInterface interface {
 	// GetLog defines a function that gets a log by ID.
 	GetLog(context.Context, int64) (*library.Log, error)
 	// GetLogForService defines a function that gets a log by service ID.
-	GetLogForService(context.Context, *library.Service) (*library.Log, error)
+	GetLogForService(context.Context, *api.Service) (*library.Log, error)
 	// GetLogForStep defines a function that gets a log by step ID.
-	GetLogForStep(context.Context, *library.Step) (*library.Log, error)
+	GetLogForStep(context.Context, *api.Step) (*library.Log, error)
 	// ListLogs defines a function that gets a list of all logs.
 	ListLogs(context.Context) ([]*library.Log, error)
 	// ListLogsForBuild defines a function that gets a list of logs by build ID.

--- a/database/log/list.go
+++ b/database/log/list.go
@@ -5,7 +5,7 @@ package log
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )

--- a/database/log/list_build.go
+++ b/database/log/list_build.go
@@ -6,7 +6,7 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )

--- a/database/log/log.go
+++ b/database/log/log.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/database/log/table.go
+++ b/database/log/table.go
@@ -5,7 +5,7 @@ package log
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/database/log/update.go
+++ b/database/log/update.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/types/database"
 	"github.com/go-vela/types/library"
 )

--- a/database/pipeline/count.go
+++ b/database/pipeline/count.go
@@ -5,7 +5,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountPipelines gets the count of all pipelines from the database.

--- a/database/pipeline/count_repo.go
+++ b/database/pipeline/count_repo.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountPipelinesForRepo gets the count of pipelines by repo ID from the database.

--- a/database/pipeline/create.go
+++ b/database/pipeline/create.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // CreatePipeline creates a new pipeline in the database.

--- a/database/pipeline/delete.go
+++ b/database/pipeline/delete.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // DeletePipeline deletes an existing pipeline from the database.

--- a/database/pipeline/get.go
+++ b/database/pipeline/get.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetPipeline gets a pipeline by ID from the database.

--- a/database/pipeline/get_repo.go
+++ b/database/pipeline/get_repo.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetPipelineForRepo gets a pipeline by number and repo ID from the database.

--- a/database/pipeline/list.go
+++ b/database/pipeline/list.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListPipelines gets a list of all pipelines from the database.

--- a/database/pipeline/list_repo.go
+++ b/database/pipeline/list_repo.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListPipelinesForRepo gets a list of pipelines by repo ID from the database.

--- a/database/pipeline/pipeline.go
+++ b/database/pipeline/pipeline.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/database/pipeline/table.go
+++ b/database/pipeline/table.go
@@ -5,7 +5,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/database/pipeline/update.go
+++ b/database/pipeline/update.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // UpdatePipeline updates an existing pipeline in the database.

--- a/database/repo/count.go
+++ b/database/repo/count.go
@@ -5,7 +5,7 @@ package repo
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountRepos gets the count of all repos from the database.

--- a/database/repo/count_org.go
+++ b/database/repo/count_org.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountReposForOrg gets the count of repos by org name from the database.

--- a/database/repo/count_user.go
+++ b/database/repo/count_user.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountReposForUser gets the count of repos by user ID from the database.

--- a/database/repo/create.go
+++ b/database/repo/create.go
@@ -10,8 +10,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // CreateRepo creates a new repo in the database.

--- a/database/repo/delete.go
+++ b/database/repo/delete.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // DeleteRepo deletes an existing repo from the database.

--- a/database/repo/get.go
+++ b/database/repo/get.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetRepo gets a repo by ID from the database.

--- a/database/repo/get_org.go
+++ b/database/repo/get_org.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetRepoForOrg gets a repo by org and repo name from the database.

--- a/database/repo/get_org_test.go
+++ b/database/repo/get_org_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 func TestRepo_Engine_GetRepoForOrg(t *testing.T) {

--- a/database/repo/get_test.go
+++ b/database/repo/get_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 func TestRepo_Engine_GetRepo(t *testing.T) {

--- a/database/repo/list.go
+++ b/database/repo/list.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListRepos gets a list of all repos from the database.

--- a/database/repo/list_org.go
+++ b/database/repo/list_org.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListReposForOrg gets a list of repos by org name from the database.

--- a/database/repo/list_org_test.go
+++ b/database/repo/list_org_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 func TestRepo_Engine_ListReposForOrg(t *testing.T) {

--- a/database/repo/list_test.go
+++ b/database/repo/list_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 func TestRepo_Engine_ListRepos(t *testing.T) {

--- a/database/repo/list_user.go
+++ b/database/repo/list_user.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListReposForUser gets a list of repos by user ID from the database.

--- a/database/repo/list_user_test.go
+++ b/database/repo/list_user_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 func TestRepo_Engine_ListReposForUser(t *testing.T) {

--- a/database/repo/repo.go
+++ b/database/repo/repo.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/database/repo/table.go
+++ b/database/repo/table.go
@@ -5,7 +5,7 @@ package repo
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/database/repo/update.go
+++ b/database/repo/update.go
@@ -10,8 +10,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // UpdateRepo updates an existing repo in the database.

--- a/database/repo/update_test.go
+++ b/database/repo/update_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestRepo_Engine_UpdateRepo(t *testing.T) {

--- a/database/schedule/count.go
+++ b/database/schedule/count.go
@@ -5,7 +5,7 @@ package schedule
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountSchedules gets the count of all schedules from the database.

--- a/database/schedule/count_active.go
+++ b/database/schedule/count_active.go
@@ -5,7 +5,7 @@ package schedule
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountActiveSchedules gets the count of all active schedules from the database.

--- a/database/schedule/count_active_test.go
+++ b/database/schedule/count_active_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSchedule_Engine_CountActiveSchedules(t *testing.T) {

--- a/database/schedule/count_repo.go
+++ b/database/schedule/count_repo.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountSchedulesForRepo gets the count of schedules by repo ID from the database.

--- a/database/schedule/count_repo_test.go
+++ b/database/schedule/count_repo_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSchedule_Engine_CountSchedulesForRepo(t *testing.T) {

--- a/database/schedule/count_test.go
+++ b/database/schedule/count_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSchedule_Engine_CountSchedules(t *testing.T) {

--- a/database/schedule/create.go
+++ b/database/schedule/create.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // CreateSchedule creates a new schedule in the database.

--- a/database/schedule/create_test.go
+++ b/database/schedule/create_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSchedule_Engine_CreateSchedule(t *testing.T) {

--- a/database/schedule/delete.go
+++ b/database/schedule/delete.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // DeleteSchedule deletes an existing schedule from the database.

--- a/database/schedule/delete_test.go
+++ b/database/schedule/delete_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/adhocore/gronx"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSchedule_Engine_DeleteSchedule(t *testing.T) {

--- a/database/schedule/get.go
+++ b/database/schedule/get.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetSchedule gets a schedule by ID from the database.

--- a/database/schedule/get_repo.go
+++ b/database/schedule/get_repo.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetScheduleForRepo gets a schedule by repo ID and name from the database.

--- a/database/schedule/get_repo_test.go
+++ b/database/schedule/get_repo_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSchedule_Engine_GetScheduleForRepo(t *testing.T) {

--- a/database/schedule/get_test.go
+++ b/database/schedule/get_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSchedule_Engine_GetSchedule(t *testing.T) {

--- a/database/schedule/list.go
+++ b/database/schedule/list.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListSchedules gets a list of all schedules from the database.

--- a/database/schedule/list_active.go
+++ b/database/schedule/list_active.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListActiveSchedules gets a list of all active schedules from the database.

--- a/database/schedule/list_active_test.go
+++ b/database/schedule/list_active_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSchedule_Engine_ListActiveSchedules(t *testing.T) {

--- a/database/schedule/list_repo.go
+++ b/database/schedule/list_repo.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListSchedulesForRepo gets a list of schedules by repo ID from the database.

--- a/database/schedule/list_repo_test.go
+++ b/database/schedule/list_repo_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSchedule_Engine_ListSchedulesForRepo(t *testing.T) {

--- a/database/schedule/list_test.go
+++ b/database/schedule/list_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSchedule_Engine_ListSchedules(t *testing.T) {

--- a/database/schedule/schedule.go
+++ b/database/schedule/schedule.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/database/schedule/table.go
+++ b/database/schedule/table.go
@@ -5,7 +5,7 @@ package schedule
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/database/schedule/update.go
+++ b/database/schedule/update.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // UpdateSchedule updates an existing schedule in the database.

--- a/database/schedule/update_test.go
+++ b/database/schedule/update_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSchedule_Engine_UpdateSchedule_Config(t *testing.T) {

--- a/database/secret/count.go
+++ b/database/secret/count.go
@@ -5,7 +5,7 @@ package secret
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountSecrets gets the count of all secrets from the database.

--- a/database/secret/count_org.go
+++ b/database/secret/count_org.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountSecretsForOrg gets the count of secrets by org name from the database.

--- a/database/secret/count_org_test.go
+++ b/database/secret/count_org_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSecret_Engine_CountSecretsForOrg(t *testing.T) {

--- a/database/secret/count_repo.go
+++ b/database/secret/count_repo.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountSecretsForRepo gets the count of secrets by org and repo name from the database.

--- a/database/secret/count_repo_test.go
+++ b/database/secret/count_repo_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSecret_Engine_CountSecretsForRepo(t *testing.T) {

--- a/database/secret/count_team.go
+++ b/database/secret/count_team.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountSecretsForTeam gets the count of secrets by org and team name from the database.

--- a/database/secret/count_team_test.go
+++ b/database/secret/count_team_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSecret_Engine_CountSecretsForTeam(t *testing.T) {

--- a/database/secret/count_test.go
+++ b/database/secret/count_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+
 	"github.com/go-vela/server/database/testutils"
 )
 

--- a/database/secret/create.go
+++ b/database/secret/create.go
@@ -10,8 +10,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // CreateSecret creates a new secret in the database.

--- a/database/secret/delete.go
+++ b/database/secret/delete.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // DeleteSecret deletes an existing secret from the database.

--- a/database/secret/get.go
+++ b/database/secret/get.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetSecret gets a secret by ID from the database.

--- a/database/secret/get_org.go
+++ b/database/secret/get_org.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetSecretForOrg gets a secret by org name from the database.

--- a/database/secret/get_org_test.go
+++ b/database/secret/get_org_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSecret_Engine_GetSecretForOrg(t *testing.T) {

--- a/database/secret/get_repo.go
+++ b/database/secret/get_repo.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetSecretForRepo gets a secret by org and repo name from the database.

--- a/database/secret/get_repo_test.go
+++ b/database/secret/get_repo_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSecret_Engine_GetSecretForRepo(t *testing.T) {

--- a/database/secret/get_team.go
+++ b/database/secret/get_team.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetSecretForTeam gets a secret by org and team name from the database.

--- a/database/secret/get_team_test.go
+++ b/database/secret/get_team_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSecret_Engine_GetSecretForTeam(t *testing.T) {

--- a/database/secret/list.go
+++ b/database/secret/list.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListSecrets gets a list of all secrets from the database.

--- a/database/secret/list_org.go
+++ b/database/secret/list_org.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListSecretsForOrg gets a list of secrets by org name from the database.

--- a/database/secret/list_org_test.go
+++ b/database/secret/list_org_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSecret_Engine_ListSecretsForOrg(t *testing.T) {

--- a/database/secret/list_repo.go
+++ b/database/secret/list_repo.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListSecretsForRepo gets a list of secrets by org name from the database.

--- a/database/secret/list_repo_test.go
+++ b/database/secret/list_repo_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSecret_Engine_ListSecretsForRepo(t *testing.T) {

--- a/database/secret/list_team.go
+++ b/database/secret/list_team.go
@@ -9,8 +9,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListSecretsForTeam gets a list of secrets by org and team name from the database.

--- a/database/secret/list_team_test.go
+++ b/database/secret/list_team_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestSecret_Engine_ListSecretsForTeam(t *testing.T) {

--- a/database/secret/secret.go
+++ b/database/secret/secret.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/database/secret/table.go
+++ b/database/secret/table.go
@@ -5,7 +5,7 @@ package secret
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/database/secret/update.go
+++ b/database/secret/update.go
@@ -10,8 +10,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // UpdateSecret updates an existing secret in the database.

--- a/database/service/clean.go
+++ b/database/service/clean.go
@@ -8,21 +8,21 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/database"
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
+	"github.com/go-vela/server/database/types"
 )
 
 // CleanServices updates services to an error with a created timestamp prior to a defined moment.
 func (e *engine) CleanServices(ctx context.Context, msg string, before int64) (int64, error) {
 	logrus.Tracef("cleaning pending or running steps in the database created prior to %d", before)
 
-	s := new(library.Service)
+	s := new(api.Service)
 	s.SetStatus(constants.StatusError)
 	s.SetError(msg)
 	s.SetFinished(time.Now().UTC().Unix())
 
-	service := database.ServiceFromLibrary(s)
+	service := types.ServiceFromAPI(s)
 
 	// send query to the database
 	result := e.client.

--- a/database/service/count.go
+++ b/database/service/count.go
@@ -5,7 +5,7 @@ package service
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountServices gets the count of all services from the database.

--- a/database/service/count_build.go
+++ b/database/service/count_build.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountServicesForBuild gets the count of services by build ID from the database.

--- a/database/service/create.go
+++ b/database/service/create.go
@@ -7,25 +7,19 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/database"
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
+	"github.com/go-vela/server/database/types"
 )
 
 // CreateService creates a new service in the database.
-func (e *engine) CreateService(ctx context.Context, s *library.Service) (*library.Service, error) {
+func (e *engine) CreateService(ctx context.Context, s *api.Service) (*api.Service, error) {
 	e.logger.WithFields(logrus.Fields{
 		"service": s.GetNumber(),
 	}).Tracef("creating service %s in the database", s.GetName())
 
-	// cast the library type to database type
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/database#ServiceFromLibrary
-	service := database.ServiceFromLibrary(s)
+	service := types.ServiceFromAPI(s)
 
-	// validate the necessary fields are populated
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/database#Service.Validate
 	err := service.Validate()
 	if err != nil {
 		return nil, err
@@ -37,5 +31,5 @@ func (e *engine) CreateService(ctx context.Context, s *library.Service) (*librar
 		Table(constants.TableService).
 		Create(service)
 
-	return service.ToLibrary(), result.Error
+	return service.ToAPI(), result.Error
 }

--- a/database/service/delete.go
+++ b/database/service/delete.go
@@ -7,21 +7,18 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/database"
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
+	"github.com/go-vela/server/database/types"
 )
 
 // DeleteService deletes an existing service from the database.
-func (e *engine) DeleteService(ctx context.Context, s *library.Service) error {
+func (e *engine) DeleteService(ctx context.Context, s *api.Service) error {
 	e.logger.WithFields(logrus.Fields{
 		"service": s.GetNumber(),
 	}).Tracef("deleting service %s", s.GetName())
 
-	// cast the library type to database type
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/database#ServiceFromLibrary
-	service := database.ServiceFromLibrary(s)
+	service := types.ServiceFromAPI(s)
 
 	// send query to the database
 	return e.client.

--- a/database/service/get.go
+++ b/database/service/get.go
@@ -5,17 +5,17 @@ package service
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/database"
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
+	"github.com/go-vela/server/database/types"
 )
 
 // GetService gets a service by ID from the database.
-func (e *engine) GetService(ctx context.Context, id int64) (*library.Service, error) {
+func (e *engine) GetService(ctx context.Context, id int64) (*api.Service, error) {
 	e.logger.Tracef("getting service %d", id)
 
 	// variable to store query results
-	s := new(database.Service)
+	s := new(types.Service)
 
 	// send query to the database and store result in variable
 	err := e.client.
@@ -28,8 +28,5 @@ func (e *engine) GetService(ctx context.Context, id int64) (*library.Service, er
 		return nil, err
 	}
 
-	// return the service
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/database#Service.ToLibrary
-	return s.ToLibrary(), nil
+	return s.ToAPI(), nil
 }

--- a/database/service/get_build.go
+++ b/database/service/get_build.go
@@ -8,20 +8,19 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/database"
-	"github.com/go-vela/types/library"
+	"github.com/go-vela/server/constants"
+	"github.com/go-vela/server/database/types"
 )
 
 // GetServiceForBuild gets a service by number and build ID from the database.
-func (e *engine) GetServiceForBuild(ctx context.Context, b *api.Build, number int) (*library.Service, error) {
+func (e *engine) GetServiceForBuild(ctx context.Context, b *api.Build, number int) (*api.Service, error) {
 	e.logger.WithFields(logrus.Fields{
 		"build":   b.GetNumber(),
 		"service": number,
 	}).Tracef("getting service %d", number)
 
 	// variable to store query results
-	s := new(database.Service)
+	s := new(types.Service)
 
 	// send query to the database and store result in variable
 	err := e.client.
@@ -35,8 +34,5 @@ func (e *engine) GetServiceForBuild(ctx context.Context, b *api.Build, number in
 		return nil, err
 	}
 
-	// return the service
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/database#Service.ToLibrary
-	return s.ToLibrary(), nil
+	return s.ToAPI(), nil
 }

--- a/database/service/get_build_test.go
+++ b/database/service/get_build_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 
+	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/library"
 )
 
 func TestService_Engine_GetServiceForBuild(t *testing.T) {
@@ -52,7 +52,7 @@ func TestService_Engine_GetServiceForBuild(t *testing.T) {
 		failure  bool
 		name     string
 		database *engine
-		want     *library.Service
+		want     *api.Service
 	}{
 		{
 			failure:  false,

--- a/database/service/get_test.go
+++ b/database/service/get_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 
+	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/library"
 )
 
 func TestService_Engine_GetService(t *testing.T) {
@@ -47,7 +47,7 @@ func TestService_Engine_GetService(t *testing.T) {
 		failure  bool
 		name     string
 		database *engine
-		want     *library.Service
+		want     *api.Service
 	}{
 		{
 			failure:  false,

--- a/database/service/interface.go
+++ b/database/service/interface.go
@@ -6,7 +6,6 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/library"
 )
 
 // ServiceInterface represents the Vela interface for service
@@ -32,21 +31,21 @@ type ServiceInterface interface {
 	// CountServicesForBuild defines a function that gets the count of services by build ID.
 	CountServicesForBuild(context.Context, *api.Build, map[string]interface{}) (int64, error)
 	// CreateService defines a function that creates a new service.
-	CreateService(context.Context, *library.Service) (*library.Service, error)
+	CreateService(context.Context, *api.Service) (*api.Service, error)
 	// DeleteService defines a function that deletes an existing service.
-	DeleteService(context.Context, *library.Service) error
+	DeleteService(context.Context, *api.Service) error
 	// GetService defines a function that gets a service by ID.
-	GetService(context.Context, int64) (*library.Service, error)
+	GetService(context.Context, int64) (*api.Service, error)
 	// GetServiceForBuild defines a function that gets a service by number and build ID.
-	GetServiceForBuild(context.Context, *api.Build, int) (*library.Service, error)
+	GetServiceForBuild(context.Context, *api.Build, int) (*api.Service, error)
 	// ListServices defines a function that gets a list of all services.
-	ListServices(context.Context) ([]*library.Service, error)
+	ListServices(context.Context) ([]*api.Service, error)
 	// ListServicesForBuild defines a function that gets a list of services by build ID.
-	ListServicesForBuild(context.Context, *api.Build, map[string]interface{}, int, int) ([]*library.Service, int64, error)
+	ListServicesForBuild(context.Context, *api.Build, map[string]interface{}, int, int) ([]*api.Service, int64, error)
 	// ListServiceImageCount defines a function that gets a list of all service images and the count of their occurrence.
 	ListServiceImageCount(context.Context) (map[string]float64, error)
 	// ListServiceStatusCount defines a function that gets a list of all service statuses and the count of their occurrence.
 	ListServiceStatusCount(context.Context) (map[string]float64, error)
 	// UpdateService defines a function that updates an existing service.
-	UpdateService(context.Context, *library.Service) (*library.Service, error)
+	UpdateService(context.Context, *api.Service) (*api.Service, error)
 }

--- a/database/service/list.go
+++ b/database/service/list.go
@@ -5,19 +5,19 @@ package service
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/database"
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
+	"github.com/go-vela/server/database/types"
 )
 
 // ListServices gets a list of all services from the database.
-func (e *engine) ListServices(ctx context.Context) ([]*library.Service, error) {
+func (e *engine) ListServices(ctx context.Context) ([]*api.Service, error) {
 	e.logger.Trace("listing all services")
 
 	// variables to store query results and return value
 	count := int64(0)
-	w := new([]database.Service)
-	services := []*library.Service{}
+	w := new([]types.Service)
+	services := []*api.Service{}
 
 	// count the results
 	count, err := e.CountServices(ctx)
@@ -45,10 +45,7 @@ func (e *engine) ListServices(ctx context.Context) ([]*library.Service, error) {
 		// https://golang.org/doc/faq#closures_and_goroutines
 		tmp := service
 
-		// convert query result to library type
-		//
-		// https://pkg.go.dev/github.com/go-vela/types/database#Service.ToLibrary
-		services = append(services, tmp.ToLibrary())
+		services = append(services, tmp.ToAPI())
 	}
 
 	return services, nil

--- a/database/service/list_build.go
+++ b/database/service/list_build.go
@@ -8,21 +8,20 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/database"
-	"github.com/go-vela/types/library"
+	"github.com/go-vela/server/constants"
+	"github.com/go-vela/server/database/types"
 )
 
 // ListServicesForBuild gets a list of all services from the database.
-func (e *engine) ListServicesForBuild(ctx context.Context, b *api.Build, filters map[string]interface{}, page int, perPage int) ([]*library.Service, int64, error) {
+func (e *engine) ListServicesForBuild(ctx context.Context, b *api.Build, filters map[string]interface{}, page int, perPage int) ([]*api.Service, int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"build": b.GetNumber(),
 	}).Tracef("listing services for build %d", b.GetNumber())
 
 	// variables to store query results and return value
 	count := int64(0)
-	s := new([]database.Service)
-	services := []*library.Service{}
+	s := new([]types.Service)
+	services := []*api.Service{}
 
 	// count the results
 	count, err := e.CountServicesForBuild(ctx, b, filters)
@@ -58,10 +57,7 @@ func (e *engine) ListServicesForBuild(ctx context.Context, b *api.Build, filters
 		// https://golang.org/doc/faq#closures_and_goroutines
 		tmp := service
 
-		// convert query result to library type
-		//
-		// https://pkg.go.dev/github.com/go-vela/types/database#Service.ToLibrary
-		services = append(services, tmp.ToLibrary())
+		services = append(services, tmp.ToAPI())
 	}
 
 	return services, count, nil

--- a/database/service/list_build_test.go
+++ b/database/service/list_build_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 
+	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/library"
 )
 
 func TestService_Engine_ListServicesForBuild(t *testing.T) {
@@ -72,19 +72,19 @@ func TestService_Engine_ListServicesForBuild(t *testing.T) {
 		failure  bool
 		name     string
 		database *engine
-		want     []*library.Service
+		want     []*api.Service
 	}{
 		{
 			failure:  false,
 			name:     "postgres",
 			database: _postgres,
-			want:     []*library.Service{_serviceTwo, _serviceOne},
+			want:     []*api.Service{_serviceTwo, _serviceOne},
 		},
 		{
 			failure:  false,
 			name:     "sqlite3",
 			database: _sqlite,
-			want:     []*library.Service{_serviceTwo, _serviceOne},
+			want:     []*api.Service{_serviceTwo, _serviceOne},
 		},
 	}
 

--- a/database/service/list_image.go
+++ b/database/service/list_image.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // ListServiceImageCount gets a list of all service images and the count of their occurrence from the database.

--- a/database/service/list_status.go
+++ b/database/service/list_status.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // ListServiceStatusCount gets a list of all service statuses and the count of their occurrence from the database.

--- a/database/service/list_test.go
+++ b/database/service/list_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 
+	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/library"
 )
 
 func TestService_Engine_ListServices(t *testing.T) {
@@ -67,19 +67,19 @@ func TestService_Engine_ListServices(t *testing.T) {
 		failure  bool
 		name     string
 		database *engine
-		want     []*library.Service
+		want     []*api.Service
 	}{
 		{
 			failure:  false,
 			name:     "postgres",
 			database: _postgres,
-			want:     []*library.Service{_serviceOne, _serviceTwo},
+			want:     []*api.Service{_serviceOne, _serviceTwo},
 		},
 		{
 			failure:  false,
 			name:     "sqlite3",
 			database: _sqlite,
-			want:     []*library.Service{_serviceOne, _serviceTwo},
+			want:     []*api.Service{_serviceOne, _serviceTwo},
 		},
 	}
 

--- a/database/service/service.go
+++ b/database/service/service.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/database/service/table.go
+++ b/database/service/table.go
@@ -5,7 +5,7 @@ package service
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/database/service/update.go
+++ b/database/service/update.go
@@ -7,25 +7,19 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/database"
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
+	"github.com/go-vela/server/database/types"
 )
 
 // UpdateService updates an existing service in the database.
-func (e *engine) UpdateService(ctx context.Context, s *library.Service) (*library.Service, error) {
+func (e *engine) UpdateService(ctx context.Context, s *api.Service) (*api.Service, error) {
 	e.logger.WithFields(logrus.Fields{
 		"service": s.GetNumber(),
 	}).Tracef("updating service %s", s.GetName())
 
-	// cast the library type to database type
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/database#ServiceFromLibrary
-	service := database.ServiceFromLibrary(s)
+	service := types.ServiceFromAPI(s)
 
-	// validate the necessary fields are populated
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/database#Service.Validate
 	err := service.Validate()
 	if err != nil {
 		return nil, err
@@ -37,5 +31,5 @@ func (e *engine) UpdateService(ctx context.Context, s *library.Service) (*librar
 		Table(constants.TableService).
 		Save(service)
 
-	return service.ToLibrary(), result.Error
+	return service.ToAPI(), result.Error
 }

--- a/database/settings/table.go
+++ b/database/settings/table.go
@@ -5,7 +5,7 @@ package settings
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/database/step/clean.go
+++ b/database/step/clean.go
@@ -8,21 +8,21 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/database"
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
+	"github.com/go-vela/server/database/types"
 )
 
 // CleanSteps updates steps to an error with a created timestamp prior to a defined moment.
 func (e *engine) CleanSteps(ctx context.Context, msg string, before int64) (int64, error) {
 	logrus.Tracef("cleaning pending or running steps in the database created prior to %d", before)
 
-	s := new(library.Step)
+	s := new(api.Step)
 	s.SetStatus(constants.StatusError)
 	s.SetError(msg)
 	s.SetFinished(time.Now().UTC().Unix())
 
-	step := database.StepFromLibrary(s)
+	step := types.StepFromAPI(s)
 
 	// send query to the database
 	result := e.client.

--- a/database/step/count.go
+++ b/database/step/count.go
@@ -5,7 +5,7 @@ package step
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountSteps gets the count of all steps from the database.

--- a/database/step/count_build.go
+++ b/database/step/count_build.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountStepsForBuild gets the count of steps by build ID from the database.

--- a/database/step/create.go
+++ b/database/step/create.go
@@ -7,25 +7,19 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/database"
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
+	"github.com/go-vela/server/database/types"
 )
 
 // CreateStep creates a new step in the database.
-func (e *engine) CreateStep(ctx context.Context, s *library.Step) (*library.Step, error) {
+func (e *engine) CreateStep(ctx context.Context, s *api.Step) (*api.Step, error) {
 	e.logger.WithFields(logrus.Fields{
 		"step": s.GetNumber(),
 	}).Tracef("creating step %s in the database", s.GetName())
 
-	// cast the library type to database type
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/database#StepFromLibrary
-	step := database.StepFromLibrary(s)
+	step := types.StepFromAPI(s)
 
-	// validate the necessary fields are populated
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/database#Step.Validate
 	err := step.Validate()
 	if err != nil {
 		return nil, err
@@ -37,5 +31,5 @@ func (e *engine) CreateStep(ctx context.Context, s *library.Step) (*library.Step
 		Table(constants.TableStep).
 		Create(step)
 
-	return step.ToLibrary(), result.Error
+	return step.ToAPI(), result.Error
 }

--- a/database/step/delete.go
+++ b/database/step/delete.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/database"
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
+	"github.com/go-vela/server/database/types"
 )
 
 // DeleteStep deletes an existing step from the database.
-func (e *engine) DeleteStep(ctx context.Context, s *library.Step) error {
+func (e *engine) DeleteStep(ctx context.Context, s *api.Step) error {
 	e.logger.WithFields(logrus.Fields{
 		"step": s.GetNumber(),
 	}).Tracef("deleting step %s", s.GetName())
@@ -21,7 +21,7 @@ func (e *engine) DeleteStep(ctx context.Context, s *library.Step) error {
 	// cast the library type to database type
 	//
 	// https://pkg.go.dev/github.com/go-vela/types/database#StepFromLibrary
-	step := database.StepFromLibrary(s)
+	step := types.StepFromAPI(s)
 
 	// send query to the database
 	return e.client.

--- a/database/step/get.go
+++ b/database/step/get.go
@@ -5,17 +5,17 @@ package step
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/database"
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
+	"github.com/go-vela/server/database/types"
 )
 
 // GetStep gets a step by ID from the database.
-func (e *engine) GetStep(ctx context.Context, id int64) (*library.Step, error) {
+func (e *engine) GetStep(ctx context.Context, id int64) (*api.Step, error) {
 	e.logger.Tracef("getting step %d", id)
 
 	// variable to store query results
-	s := new(database.Step)
+	s := new(types.Step)
 
 	// send query to the database and store result in variable
 	err := e.client.
@@ -28,8 +28,5 @@ func (e *engine) GetStep(ctx context.Context, id int64) (*library.Step, error) {
 		return nil, err
 	}
 
-	// return the step
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/database#Step.ToLibrary
-	return s.ToLibrary(), nil
+	return s.ToAPI(), nil
 }

--- a/database/step/get_build.go
+++ b/database/step/get_build.go
@@ -8,20 +8,19 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/database"
-	"github.com/go-vela/types/library"
+	"github.com/go-vela/server/constants"
+	"github.com/go-vela/server/database/types"
 )
 
 // GetStepForBuild gets a step by number and build ID from the database.
-func (e *engine) GetStepForBuild(ctx context.Context, b *api.Build, number int) (*library.Step, error) {
+func (e *engine) GetStepForBuild(ctx context.Context, b *api.Build, number int) (*api.Step, error) {
 	e.logger.WithFields(logrus.Fields{
 		"build": b.GetNumber(),
 		"step":  number,
 	}).Tracef("getting step %d", number)
 
 	// variable to store query results
-	s := new(database.Step)
+	s := new(types.Step)
 
 	// send query to the database and store result in variable
 	err := e.client.
@@ -35,8 +34,5 @@ func (e *engine) GetStepForBuild(ctx context.Context, b *api.Build, number int) 
 		return nil, err
 	}
 
-	// return the step
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/database#Step.ToLibrary
-	return s.ToLibrary(), nil
+	return s.ToAPI(), nil
 }

--- a/database/step/get_build_test.go
+++ b/database/step/get_build_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/go-cmp/cmp"
 
+	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/library"
 )
 
 func TestStep_Engine_GetStepForBuild(t *testing.T) {
@@ -54,7 +54,7 @@ func TestStep_Engine_GetStepForBuild(t *testing.T) {
 		failure  bool
 		name     string
 		database *engine
-		want     *library.Step
+		want     *api.Step
 	}{
 		{
 			failure:  false,

--- a/database/step/get_test.go
+++ b/database/step/get_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 
+	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/library"
 )
 
 func TestStep_Engine_GetStep(t *testing.T) {
@@ -49,7 +49,7 @@ func TestStep_Engine_GetStep(t *testing.T) {
 		failure  bool
 		name     string
 		database *engine
-		want     *library.Step
+		want     *api.Step
 	}{
 		{
 			failure:  false,

--- a/database/step/interface.go
+++ b/database/step/interface.go
@@ -6,7 +6,6 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/library"
 )
 
 // StepInterface represents the Vela interface for step
@@ -32,21 +31,21 @@ type StepInterface interface {
 	// CountStepsForBuild defines a function that gets the count of steps by build ID.
 	CountStepsForBuild(context.Context, *api.Build, map[string]interface{}) (int64, error)
 	// CreateStep defines a function that creates a new step.
-	CreateStep(context.Context, *library.Step) (*library.Step, error)
+	CreateStep(context.Context, *api.Step) (*api.Step, error)
 	// DeleteStep defines a function that deletes an existing step.
-	DeleteStep(context.Context, *library.Step) error
+	DeleteStep(context.Context, *api.Step) error
 	// GetStep defines a function that gets a step by ID.
-	GetStep(context.Context, int64) (*library.Step, error)
+	GetStep(context.Context, int64) (*api.Step, error)
 	// GetStepForBuild defines a function that gets a step by number and build ID.
-	GetStepForBuild(context.Context, *api.Build, int) (*library.Step, error)
+	GetStepForBuild(context.Context, *api.Build, int) (*api.Step, error)
 	// ListSteps defines a function that gets a list of all steps.
-	ListSteps(ctx context.Context) ([]*library.Step, error)
+	ListSteps(ctx context.Context) ([]*api.Step, error)
 	// ListStepsForBuild defines a function that gets a list of steps by build ID.
-	ListStepsForBuild(context.Context, *api.Build, map[string]interface{}, int, int) ([]*library.Step, int64, error)
+	ListStepsForBuild(context.Context, *api.Build, map[string]interface{}, int, int) ([]*api.Step, int64, error)
 	// ListStepImageCount defines a function that gets a list of all step images and the count of their occurrence.
 	ListStepImageCount(context.Context) (map[string]float64, error)
 	// ListStepStatusCount defines a function that gets a list of all step statuses and the count of their occurrence.
 	ListStepStatusCount(context.Context) (map[string]float64, error)
 	// UpdateStep defines a function that updates an existing step.
-	UpdateStep(context.Context, *library.Step) (*library.Step, error)
+	UpdateStep(context.Context, *api.Step) (*api.Step, error)
 }

--- a/database/step/list.go
+++ b/database/step/list.go
@@ -5,19 +5,19 @@ package step
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/database"
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
+	"github.com/go-vela/server/database/types"
 )
 
 // ListSteps gets a list of all steps from the database.
-func (e *engine) ListSteps(ctx context.Context) ([]*library.Step, error) {
+func (e *engine) ListSteps(ctx context.Context) ([]*api.Step, error) {
 	e.logger.Trace("listing all steps")
 
 	// variables to store query results and return value
 	count := int64(0)
-	w := new([]database.Step)
-	steps := []*library.Step{}
+	w := new([]types.Step)
+	steps := []*api.Step{}
 
 	// count the results
 	count, err := e.CountSteps(ctx)
@@ -45,10 +45,7 @@ func (e *engine) ListSteps(ctx context.Context) ([]*library.Step, error) {
 		// https://golang.org/doc/faq#closures_and_goroutines
 		tmp := step
 
-		// convert query result to library type
-		//
-		// https://pkg.go.dev/github.com/go-vela/types/database#Step.ToLibrary
-		steps = append(steps, tmp.ToLibrary())
+		steps = append(steps, tmp.ToAPI())
 	}
 
 	return steps, nil

--- a/database/step/list_build.go
+++ b/database/step/list_build.go
@@ -8,21 +8,20 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/database"
-	"github.com/go-vela/types/library"
+	"github.com/go-vela/server/constants"
+	"github.com/go-vela/server/database/types"
 )
 
 // ListStepsForBuild gets a list of all steps from the database.
-func (e *engine) ListStepsForBuild(ctx context.Context, b *api.Build, filters map[string]interface{}, page int, perPage int) ([]*library.Step, int64, error) {
+func (e *engine) ListStepsForBuild(ctx context.Context, b *api.Build, filters map[string]interface{}, page int, perPage int) ([]*api.Step, int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"build": b.GetNumber(),
 	}).Tracef("listing steps for build %d", b.GetNumber())
 
 	// variables to store query results and return value
 	count := int64(0)
-	s := new([]database.Step)
-	steps := []*library.Step{}
+	s := new([]types.Step)
+	steps := []*api.Step{}
 
 	// count the results
 	count, err := e.CountStepsForBuild(ctx, b, filters)
@@ -58,10 +57,7 @@ func (e *engine) ListStepsForBuild(ctx context.Context, b *api.Build, filters ma
 		// https://golang.org/doc/faq#closures_and_goroutines
 		tmp := step
 
-		// convert query result to library type
-		//
-		// https://pkg.go.dev/github.com/go-vela/types/database#Step.ToLibrary
-		steps = append(steps, tmp.ToLibrary())
+		steps = append(steps, tmp.ToAPI())
 	}
 
 	return steps, count, nil

--- a/database/step/list_build_test.go
+++ b/database/step/list_build_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 
+	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/library"
 )
 
 func TestStep_Engine_ListStepsForBuild(t *testing.T) {
@@ -75,19 +75,19 @@ func TestStep_Engine_ListStepsForBuild(t *testing.T) {
 		failure  bool
 		name     string
 		database *engine
-		want     []*library.Step
+		want     []*api.Step
 	}{
 		{
 			failure:  false,
 			name:     "postgres",
 			database: _postgres,
-			want:     []*library.Step{_stepTwo, _stepOne},
+			want:     []*api.Step{_stepTwo, _stepOne},
 		},
 		{
 			failure:  false,
 			name:     "sqlite3",
 			database: _sqlite,
-			want:     []*library.Step{_stepTwo, _stepOne},
+			want:     []*api.Step{_stepTwo, _stepOne},
 		},
 	}
 

--- a/database/step/list_image.go
+++ b/database/step/list_image.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // ListStepImageCount gets a list of all step images and the count of their occurrence from the database.

--- a/database/step/list_status.go
+++ b/database/step/list_status.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // ListStepStatusCount gets a list of all step statuses and the count of their occurrence from the database.

--- a/database/step/list_test.go
+++ b/database/step/list_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 
+	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/library"
 )
 
 func TestStep_Engine_ListSteps(t *testing.T) {
@@ -69,19 +69,19 @@ func TestStep_Engine_ListSteps(t *testing.T) {
 		failure  bool
 		name     string
 		database *engine
-		want     []*library.Step
+		want     []*api.Step
 	}{
 		{
 			failure:  false,
 			name:     "postgres",
 			database: _postgres,
-			want:     []*library.Step{_stepOne, _stepTwo},
+			want:     []*api.Step{_stepOne, _stepTwo},
 		},
 		{
 			failure:  false,
 			name:     "sqlite3",
 			database: _sqlite,
-			want:     []*library.Step{_stepOne, _stepTwo},
+			want:     []*api.Step{_stepOne, _stepTwo},
 		},
 	}
 

--- a/database/step/step.go
+++ b/database/step/step.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/database/step/table.go
+++ b/database/step/table.go
@@ -5,7 +5,7 @@ package step
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/database/step/update.go
+++ b/database/step/update.go
@@ -7,25 +7,19 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/database"
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
+	"github.com/go-vela/server/database/types"
 )
 
 // UpdateStep updates an existing step in the database.
-func (e *engine) UpdateStep(ctx context.Context, s *library.Step) (*library.Step, error) {
+func (e *engine) UpdateStep(ctx context.Context, s *api.Step) (*api.Step, error) {
 	e.logger.WithFields(logrus.Fields{
 		"step": s.GetNumber(),
 	}).Tracef("updating step %s in the database", s.GetName())
 
-	// cast the library type to database type
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/database#StepFromLibrary
-	step := database.StepFromLibrary(s)
+	step := types.StepFromAPI(s)
 
-	// validate the necessary fields are populated
-	//
-	// https://pkg.go.dev/github.com/go-vela/types/database#Step.Validate
 	err := step.Validate()
 	if err != nil {
 		return nil, err
@@ -37,5 +31,5 @@ func (e *engine) UpdateStep(ctx context.Context, s *library.Step) (*library.Step
 		Table(constants.TableStep).
 		Save(step)
 
-	return step.ToLibrary(), result.Error
+	return step.ToAPI(), result.Error
 }

--- a/database/testutils/api_resources.go
+++ b/database/testutils/api_resources.go
@@ -210,8 +210,8 @@ func APISecret() *api.Secret {
 	}
 }
 
-func APIService() *library.Service {
-	return &library.Service{
+func APIService() *api.Service {
+	return &api.Service{
 		ID:           new(int64),
 		BuildID:      new(int64),
 		RepoID:       new(int64),
@@ -230,8 +230,8 @@ func APIService() *library.Service {
 	}
 }
 
-func APIStep() *library.Step {
-	return &library.Step{
+func APIStep() *api.Step {
+	return &api.Step{
 		ID:           new(int64),
 		BuildID:      new(int64),
 		RepoID:       new(int64),

--- a/database/types/deployment.go
+++ b/database/types/deployment.go
@@ -11,8 +11,8 @@ import (
 
 	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/compiler/types/raw"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 var (

--- a/database/types/pipeline_test.go
+++ b/database/types/pipeline_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestDatabase_Pipeline_Compress(t *testing.T) {

--- a/database/types/repo.go
+++ b/database/types/repo.go
@@ -10,8 +10,8 @@ import (
 	"github.com/lib/pq"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 var (

--- a/database/types/repo_test.go
+++ b/database/types/repo_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestTypes_Repo_Decrypt(t *testing.T) {

--- a/database/types/schedule_test.go
+++ b/database/types/schedule_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/adhocore/gronx"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/testutils"
-	"github.com/go-vela/types/constants"
 )
 
 func TestTypes_Schedule_Nullify(t *testing.T) {

--- a/database/types/secret.go
+++ b/database/types/secret.go
@@ -11,8 +11,8 @@ import (
 	"github.com/lib/pq"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 var (

--- a/database/types/service.go
+++ b/database/types/service.go
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"database/sql"
+	"errors"
+
+	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/util"
+)
+
+var (
+	// ErrEmptyServiceBuildID defines the error type when a
+	// Service type has an empty BuildID field provided.
+	ErrEmptyServiceBuildID = errors.New("empty service build_id provided")
+
+	// ErrEmptyServiceName defines the error type when a
+	// Service type has an empty Name field provided.
+	ErrEmptyServiceName = errors.New("empty service name provided")
+
+	// ErrEmptyServiceImage defines the error type when a
+	// Service type has an empty Image field provided.
+	ErrEmptyServiceImage = errors.New("empty service image provided")
+
+	// ErrEmptyServiceNumber defines the error type when a
+	// Service type has an empty Number field provided.
+	ErrEmptyServiceNumber = errors.New("empty service number provided")
+
+	// ErrEmptyServiceRepoID defines the error type when a
+	// Service type has an empty RepoID field provided.
+	ErrEmptyServiceRepoID = errors.New("empty service repo_id provided")
+)
+
+// Service is the database representation of a service in a build.
+type Service struct {
+	ID           sql.NullInt64  `sql:"id"`
+	BuildID      sql.NullInt64  `sql:"build_id"`
+	RepoID       sql.NullInt64  `sql:"repo_id"`
+	Number       sql.NullInt32  `sql:"number"`
+	Name         sql.NullString `sql:"name"`
+	Image        sql.NullString `sql:"image"`
+	Status       sql.NullString `sql:"status"`
+	Error        sql.NullString `sql:"error"`
+	ExitCode     sql.NullInt32  `sql:"exit_code"`
+	Created      sql.NullInt64  `sql:"created"`
+	Started      sql.NullInt64  `sql:"started"`
+	Finished     sql.NullInt64  `sql:"finished"`
+	Host         sql.NullString `sql:"host"`
+	Runtime      sql.NullString `sql:"runtime"`
+	Distribution sql.NullString `sql:"distribution"`
+}
+
+// Nullify ensures the valid flag for
+// the sql.Null types are properly set.
+//
+// When a field within the Service type is the zero
+// value for the field, the valid flag is set to
+// false causing it to be NULL in the database.
+func (s *Service) Nullify() *Service {
+	if s == nil {
+		return nil
+	}
+
+	// check if the ID field should be false
+	if s.ID.Int64 == 0 {
+		s.ID.Valid = false
+	}
+
+	// check if the BuildID field should be false
+	if s.BuildID.Int64 == 0 {
+		s.BuildID.Valid = false
+	}
+
+	// check if the RepoID field should be false
+	if s.RepoID.Int64 == 0 {
+		s.RepoID.Valid = false
+	}
+
+	// check if the Number field should be false
+	if s.Number.Int32 == 0 {
+		s.Number.Valid = false
+	}
+
+	// check if the Name field should be false
+	if len(s.Name.String) == 0 {
+		s.Name.Valid = false
+	}
+
+	// check if the Image field should be false
+	if len(s.Image.String) == 0 {
+		s.Image.Valid = false
+	}
+
+	// check if the Status field should be false
+	if len(s.Status.String) == 0 {
+		s.Status.Valid = false
+	}
+
+	// check if the Error field should be false
+	if len(s.Error.String) == 0 {
+		s.Error.Valid = false
+	}
+
+	// check if the ExitCode field should be false
+	if s.ExitCode.Int32 == 0 {
+		s.ExitCode.Valid = false
+	}
+
+	// check if Created field should be false
+	if s.Created.Int64 == 0 {
+		s.Created.Valid = false
+	}
+
+	// check if Started field should be false
+	if s.Started.Int64 == 0 {
+		s.Started.Valid = false
+	}
+
+	// check if Finished field should be false
+	if s.Finished.Int64 == 0 {
+		s.Finished.Valid = false
+	}
+
+	// check if the Host field should be false
+	if len(s.Host.String) == 0 {
+		s.Host.Valid = false
+	}
+
+	// check if the Runtime field should be false
+	if len(s.Runtime.String) == 0 {
+		s.Runtime.Valid = false
+	}
+
+	// check if the Distribution field should be false
+	if len(s.Distribution.String) == 0 {
+		s.Distribution.Valid = false
+	}
+
+	return s
+}
+
+// ToAPI converts the Service type
+// to a API Service type.
+func (s *Service) ToAPI() *api.Service {
+	service := new(api.Service)
+
+	service.SetID(s.ID.Int64)
+	service.SetBuildID(s.BuildID.Int64)
+	service.SetRepoID(s.RepoID.Int64)
+	service.SetNumber(int(s.Number.Int32))
+	service.SetName(s.Name.String)
+	service.SetImage(s.Image.String)
+	service.SetStatus(s.Status.String)
+	service.SetError(s.Error.String)
+	service.SetExitCode(int(s.ExitCode.Int32))
+	service.SetCreated(s.Created.Int64)
+	service.SetStarted(s.Started.Int64)
+	service.SetFinished(s.Finished.Int64)
+	service.SetHost(s.Host.String)
+	service.SetRuntime(s.Runtime.String)
+	service.SetDistribution(s.Distribution.String)
+
+	return service
+}
+
+// Validate verifies the necessary fields for
+// the Service type are populated correctly.
+func (s *Service) Validate() error {
+	// verify the BuildID field is populated
+	if s.BuildID.Int64 <= 0 {
+		return ErrEmptyServiceBuildID
+	}
+
+	// verify the RepoID field is populated
+	if s.RepoID.Int64 <= 0 {
+		return ErrEmptyServiceRepoID
+	}
+
+	// verify the Number field is populated
+	if s.Number.Int32 <= 0 {
+		return ErrEmptyServiceNumber
+	}
+
+	// verify the Name field is populated
+	if len(s.Name.String) == 0 {
+		return ErrEmptyServiceName
+	}
+
+	// verify the Image field is populated
+	if len(s.Image.String) == 0 {
+		return ErrEmptyServiceImage
+	}
+
+	// ensure that all Service string fields
+	// that can be returned as JSON are sanitized
+	// to avoid unsafe HTML content
+	s.Name = sql.NullString{String: util.Sanitize(s.Name.String), Valid: s.Name.Valid}
+	s.Image = sql.NullString{String: util.Sanitize(s.Image.String), Valid: s.Image.Valid}
+	s.Status = sql.NullString{String: util.Sanitize(s.Status.String), Valid: s.Status.Valid}
+	s.Error = sql.NullString{String: util.Sanitize(s.Error.String), Valid: s.Error.Valid}
+	s.Host = sql.NullString{String: util.Sanitize(s.Host.String), Valid: s.Host.Valid}
+	s.Runtime = sql.NullString{String: util.Sanitize(s.Runtime.String), Valid: s.Runtime.Valid}
+	s.Distribution = sql.NullString{String: util.Sanitize(s.Distribution.String), Valid: s.Distribution.Valid}
+
+	return nil
+}
+
+// ServiceFromAPI converts the API Service type
+// to a database Service type.
+func ServiceFromAPI(s *api.Service) *Service {
+	service := &Service{
+		ID:           sql.NullInt64{Int64: s.GetID(), Valid: true},
+		BuildID:      sql.NullInt64{Int64: s.GetBuildID(), Valid: true},
+		RepoID:       sql.NullInt64{Int64: s.GetRepoID(), Valid: true},
+		Number:       sql.NullInt32{Int32: int32(s.GetNumber()), Valid: true},
+		Name:         sql.NullString{String: s.GetName(), Valid: true},
+		Image:        sql.NullString{String: s.GetImage(), Valid: true},
+		Status:       sql.NullString{String: s.GetStatus(), Valid: true},
+		Error:        sql.NullString{String: s.GetError(), Valid: true},
+		ExitCode:     sql.NullInt32{Int32: int32(s.GetExitCode()), Valid: true},
+		Created:      sql.NullInt64{Int64: s.GetCreated(), Valid: true},
+		Started:      sql.NullInt64{Int64: s.GetStarted(), Valid: true},
+		Finished:     sql.NullInt64{Int64: s.GetFinished(), Valid: true},
+		Host:         sql.NullString{String: s.GetHost(), Valid: true},
+		Runtime:      sql.NullString{String: s.GetRuntime(), Valid: true},
+		Distribution: sql.NullString{String: s.GetDistribution(), Valid: true},
+	}
+
+	return service.Nullify()
+}

--- a/database/types/service_test.go
+++ b/database/types/service_test.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"database/sql"
+	"reflect"
+	"testing"
+
+	api "github.com/go-vela/server/api/types"
+)
+
+func TestDatabase_Service_Nullify(t *testing.T) {
+	// setup types
+	var s *Service
+
+	want := &Service{
+		ID:           sql.NullInt64{Int64: 0, Valid: false},
+		BuildID:      sql.NullInt64{Int64: 0, Valid: false},
+		RepoID:       sql.NullInt64{Int64: 0, Valid: false},
+		Number:       sql.NullInt32{Int32: 0, Valid: false},
+		Name:         sql.NullString{String: "", Valid: false},
+		Image:        sql.NullString{String: "", Valid: false},
+		Status:       sql.NullString{String: "", Valid: false},
+		Error:        sql.NullString{String: "", Valid: false},
+		ExitCode:     sql.NullInt32{Int32: 0, Valid: false},
+		Created:      sql.NullInt64{Int64: 0, Valid: false},
+		Started:      sql.NullInt64{Int64: 0, Valid: false},
+		Finished:     sql.NullInt64{Int64: 0, Valid: false},
+		Host:         sql.NullString{String: "", Valid: false},
+		Runtime:      sql.NullString{String: "", Valid: false},
+		Distribution: sql.NullString{String: "", Valid: false},
+	}
+
+	// setup tests
+	tests := []struct {
+		service *Service
+		want    *Service
+	}{
+		{
+			service: testService(),
+			want:    testService(),
+		},
+		{
+			service: s,
+			want:    nil,
+		},
+		{
+			service: new(Service),
+			want:    want,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := test.service.Nullify()
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("Nullify is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestDatabase_Service_ToAPI(t *testing.T) {
+	// setup types
+	want := new(api.Service)
+
+	want.SetID(1)
+	want.SetBuildID(1)
+	want.SetRepoID(1)
+	want.SetNumber(1)
+	want.SetName("postgres")
+	want.SetImage("postgres:12-alpine")
+	want.SetStatus("running")
+	want.SetError("")
+	want.SetExitCode(0)
+	want.SetCreated(1563474076)
+	want.SetStarted(1563474078)
+	want.SetFinished(1563474079)
+	want.SetHost("example.company.com")
+	want.SetRuntime("docker")
+	want.SetDistribution("linux")
+
+	// run test
+	got := testService().ToAPI()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ToAPI is %v, want %v", got, want)
+	}
+}
+
+func TestDatabase_Service_Validate(t *testing.T) {
+	tests := []struct {
+		failure bool
+		service *Service
+	}{
+		{
+			failure: false,
+			service: testService(),
+		},
+		{ // no build_id set for service
+			failure: true,
+			service: &Service{
+				ID:     sql.NullInt64{Int64: 1, Valid: true},
+				RepoID: sql.NullInt64{Int64: 1, Valid: true},
+				Number: sql.NullInt32{Int32: 1, Valid: true},
+				Name:   sql.NullString{String: "postgres", Valid: true},
+				Image:  sql.NullString{String: "postgres:12-alpine", Valid: true},
+			},
+		},
+		{ // no repo_id set for service
+			failure: true,
+			service: &Service{
+				ID:      sql.NullInt64{Int64: 1, Valid: true},
+				BuildID: sql.NullInt64{Int64: 1, Valid: true},
+				Number:  sql.NullInt32{Int32: 1, Valid: true},
+				Name:    sql.NullString{String: "postgres", Valid: true},
+				Image:   sql.NullString{String: "postgres:12-alpine", Valid: true},
+			},
+		},
+		{ // no number set for service
+			failure: true,
+			service: &Service{
+				ID:      sql.NullInt64{Int64: 1, Valid: true},
+				BuildID: sql.NullInt64{Int64: 1, Valid: true},
+				RepoID:  sql.NullInt64{Int64: 1, Valid: true},
+				Name:    sql.NullString{String: "postgres", Valid: true},
+				Image:   sql.NullString{String: "postgres:12-alpine", Valid: true},
+			},
+		},
+		{ // no name set for service
+			failure: true,
+			service: &Service{
+				ID:      sql.NullInt64{Int64: 1, Valid: true},
+				BuildID: sql.NullInt64{Int64: 1, Valid: true},
+				RepoID:  sql.NullInt64{Int64: 1, Valid: true},
+				Number:  sql.NullInt32{Int32: 1, Valid: true},
+				Image:   sql.NullString{String: "postgres:12-alpine", Valid: true},
+			},
+		},
+		{ // no image set for service
+			failure: true,
+			service: &Service{
+				ID:      sql.NullInt64{Int64: 1, Valid: true},
+				BuildID: sql.NullInt64{Int64: 1, Valid: true},
+				RepoID:  sql.NullInt64{Int64: 1, Valid: true},
+				Number:  sql.NullInt32{Int32: 1, Valid: true},
+				Name:    sql.NullString{String: "postgres", Valid: true},
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := test.service.Validate()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("Validate should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("Validate returned err: %v", err)
+		}
+	}
+}
+
+func TestDatabase_ServiceFromAPI(t *testing.T) {
+	// setup types
+	s := new(api.Service)
+
+	s.SetID(1)
+	s.SetBuildID(1)
+	s.SetRepoID(1)
+	s.SetNumber(1)
+	s.SetName("postgres")
+	s.SetImage("postgres:12-alpine")
+	s.SetStatus("running")
+	s.SetError("")
+	s.SetExitCode(0)
+	s.SetCreated(1563474076)
+	s.SetStarted(1563474078)
+	s.SetFinished(1563474079)
+	s.SetHost("example.company.com")
+	s.SetRuntime("docker")
+	s.SetDistribution("linux")
+
+	want := testService()
+
+	// run test
+	got := ServiceFromAPI(s)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ServiceFromAPI is %v, want %v", got, want)
+	}
+}
+
+// testService is a test helper function to create a Service
+// type with all fields set to a fake value.
+func testService() *Service {
+	return &Service{
+		ID:           sql.NullInt64{Int64: 1, Valid: true},
+		BuildID:      sql.NullInt64{Int64: 1, Valid: true},
+		RepoID:       sql.NullInt64{Int64: 1, Valid: true},
+		Number:       sql.NullInt32{Int32: 1, Valid: true},
+		Name:         sql.NullString{String: "postgres", Valid: true},
+		Image:        sql.NullString{String: "postgres:12-alpine", Valid: true},
+		Status:       sql.NullString{String: "running", Valid: true},
+		Error:        sql.NullString{String: "", Valid: false},
+		ExitCode:     sql.NullInt32{Int32: 0, Valid: false},
+		Created:      sql.NullInt64{Int64: 1563474076, Valid: true},
+		Started:      sql.NullInt64{Int64: 1563474078, Valid: true},
+		Finished:     sql.NullInt64{Int64: 1563474079, Valid: true},
+		Host:         sql.NullString{String: "example.company.com", Valid: true},
+		Runtime:      sql.NullString{String: "docker", Valid: true},
+		Distribution: sql.NullString{String: "linux", Valid: true},
+	}
+}

--- a/database/types/step.go
+++ b/database/types/step.go
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"database/sql"
+	"errors"
+
+	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/util"
+)
+
+var (
+	// ErrEmptyStepBuildID defines the error type when a
+	// Step type has an empty BuildID field provided.
+	ErrEmptyStepBuildID = errors.New("empty step build_id provided")
+
+	// ErrEmptyStepName defines the error type when a
+	// Step type has an empty Name field provided.
+	ErrEmptyStepName = errors.New("empty step name provided")
+
+	// ErrEmptyStepImage defines the error type when a
+	// Step type has an empty Image field provided.
+	ErrEmptyStepImage = errors.New("empty step image provided")
+
+	// ErrEmptyStepNumber defines the error type when a
+	// Step type has an empty Number field provided.
+	ErrEmptyStepNumber = errors.New("empty step number provided")
+
+	// ErrEmptyStepRepoID defines the error type when a
+	// Step type has an empty RepoID field provided.
+	ErrEmptyStepRepoID = errors.New("empty step repo_id provided")
+)
+
+// Step is the database representation of a step in a build.
+type Step struct {
+	ID           sql.NullInt64  `sql:"id"`
+	BuildID      sql.NullInt64  `sql:"build_id"`
+	RepoID       sql.NullInt64  `sql:"repo_id"`
+	Number       sql.NullInt32  `sql:"number"`
+	Name         sql.NullString `sql:"name"`
+	Image        sql.NullString `sql:"image"`
+	Stage        sql.NullString `sql:"stage"`
+	Status       sql.NullString `sql:"status"`
+	Error        sql.NullString `sql:"error"`
+	ExitCode     sql.NullInt32  `sql:"exit_code"`
+	Created      sql.NullInt64  `sql:"created"`
+	Started      sql.NullInt64  `sql:"started"`
+	Finished     sql.NullInt64  `sql:"finished"`
+	Host         sql.NullString `sql:"host"`
+	Runtime      sql.NullString `sql:"runtime"`
+	Distribution sql.NullString `sql:"distribution"`
+	ReportAs     sql.NullString `sql:"report_as"`
+}
+
+// Nullify ensures the valid flag for
+// the sql.Null types are properly set.
+//
+// When a field within the Step type is the zero
+// value for the field, the valid flag is set to
+// false causing it to be NULL in the database.
+func (s *Step) Nullify() *Step {
+	if s == nil {
+		return nil
+	}
+
+	// check if the ID field should be false
+	if s.ID.Int64 == 0 {
+		s.ID.Valid = false
+	}
+
+	// check if the BuildID field should be false
+	if s.BuildID.Int64 == 0 {
+		s.BuildID.Valid = false
+	}
+
+	// check if the RepoID field should be false
+	if s.RepoID.Int64 == 0 {
+		s.RepoID.Valid = false
+	}
+
+	// check if the Number field should be false
+	if s.Number.Int32 == 0 {
+		s.Number.Valid = false
+	}
+
+	// check if the Name field should be false
+	if len(s.Name.String) == 0 {
+		s.Name.Valid = false
+	}
+
+	// check if the Image field should be false
+	if len(s.Image.String) == 0 {
+		s.Image.Valid = false
+	}
+
+	// check if the Stage field should be false
+	if len(s.Stage.String) == 0 {
+		s.Stage.Valid = false
+	}
+
+	// check if the Status field should be false
+	if len(s.Status.String) == 0 {
+		s.Status.Valid = false
+	}
+
+	// check if the Error field should be false
+	if len(s.Error.String) == 0 {
+		s.Error.Valid = false
+	}
+
+	// check if the ExitCode field should be false
+	if s.ExitCode.Int32 == 0 {
+		s.ExitCode.Valid = false
+	}
+
+	// check if Created field should be false
+	if s.Created.Int64 == 0 {
+		s.Created.Valid = false
+	}
+
+	// check if Started field should be false
+	if s.Started.Int64 == 0 {
+		s.Started.Valid = false
+	}
+
+	// check if Finished field should be false
+	if s.Finished.Int64 == 0 {
+		s.Finished.Valid = false
+	}
+
+	// check if the Host field should be false
+	if len(s.Host.String) == 0 {
+		s.Host.Valid = false
+	}
+
+	// check if the Runtime field should be false
+	if len(s.Runtime.String) == 0 {
+		s.Runtime.Valid = false
+	}
+
+	// check if the Distribution field should be false
+	if len(s.Distribution.String) == 0 {
+		s.Distribution.Valid = false
+	}
+
+	// check if the ReportAs field should be false
+	if len(s.ReportAs.String) == 0 {
+		s.ReportAs.Valid = false
+	}
+
+	return s
+}
+
+// ToAPI converts the Step type
+// to a API Step type.
+func (s *Step) ToAPI() *api.Step {
+	step := new(api.Step)
+
+	step.SetID(s.ID.Int64)
+	step.SetBuildID(s.BuildID.Int64)
+	step.SetRepoID(s.RepoID.Int64)
+	step.SetNumber(int(s.Number.Int32))
+	step.SetName(s.Name.String)
+	step.SetImage(s.Image.String)
+	step.SetStage(s.Stage.String)
+	step.SetStatus(s.Status.String)
+	step.SetError(s.Error.String)
+	step.SetExitCode(int(s.ExitCode.Int32))
+	step.SetCreated(s.Created.Int64)
+	step.SetStarted(s.Started.Int64)
+	step.SetFinished(s.Finished.Int64)
+	step.SetHost(s.Host.String)
+	step.SetRuntime(s.Runtime.String)
+	step.SetDistribution(s.Distribution.String)
+	step.SetReportAs(s.ReportAs.String)
+
+	return step
+}
+
+// Validate verifies the necessary fields for
+// the Step type are populated correctly.
+func (s *Step) Validate() error {
+	// verify the BuildID field is populated
+	if s.BuildID.Int64 <= 0 {
+		return ErrEmptyStepBuildID
+	}
+
+	// verify the RepoID field is populated
+	if s.RepoID.Int64 <= 0 {
+		return ErrEmptyStepRepoID
+	}
+
+	// verify the Number field is populated
+	if s.Number.Int32 <= 0 {
+		return ErrEmptyStepNumber
+	}
+
+	// verify the Name field is populated
+	if len(s.Name.String) == 0 {
+		return ErrEmptyStepName
+	}
+
+	// verify the Image field is populated
+	if len(s.Image.String) == 0 {
+		return ErrEmptyStepImage
+	}
+
+	// ensure that all Step string fields
+	// that can be returned as JSON are sanitized
+	// to avoid unsafe HTML content
+	s.Name = sql.NullString{String: util.Sanitize(s.Name.String), Valid: s.Name.Valid}
+	s.Image = sql.NullString{String: util.Sanitize(s.Image.String), Valid: s.Image.Valid}
+	s.Stage = sql.NullString{String: util.Sanitize(s.Stage.String), Valid: s.Stage.Valid}
+	s.Status = sql.NullString{String: util.Sanitize(s.Status.String), Valid: s.Status.Valid}
+	s.Error = sql.NullString{String: util.Sanitize(s.Error.String), Valid: s.Error.Valid}
+	s.Host = sql.NullString{String: util.Sanitize(s.Host.String), Valid: s.Host.Valid}
+	s.Runtime = sql.NullString{String: util.Sanitize(s.Runtime.String), Valid: s.Runtime.Valid}
+	s.Distribution = sql.NullString{String: util.Sanitize(s.Distribution.String), Valid: s.Distribution.Valid}
+	s.ReportAs = sql.NullString{String: util.Sanitize(s.ReportAs.String), Valid: s.ReportAs.Valid}
+
+	return nil
+}
+
+// StepFromAPI converts the API Step type
+// to a database Step type.
+func StepFromAPI(s *api.Step) *Step {
+	step := &Step{
+		ID:           sql.NullInt64{Int64: s.GetID(), Valid: true},
+		BuildID:      sql.NullInt64{Int64: s.GetBuildID(), Valid: true},
+		RepoID:       sql.NullInt64{Int64: s.GetRepoID(), Valid: true},
+		Number:       sql.NullInt32{Int32: int32(s.GetNumber()), Valid: true},
+		Name:         sql.NullString{String: s.GetName(), Valid: true},
+		Image:        sql.NullString{String: s.GetImage(), Valid: true},
+		Stage:        sql.NullString{String: s.GetStage(), Valid: true},
+		Status:       sql.NullString{String: s.GetStatus(), Valid: true},
+		Error:        sql.NullString{String: s.GetError(), Valid: true},
+		ExitCode:     sql.NullInt32{Int32: int32(s.GetExitCode()), Valid: true},
+		Created:      sql.NullInt64{Int64: s.GetCreated(), Valid: true},
+		Started:      sql.NullInt64{Int64: s.GetStarted(), Valid: true},
+		Finished:     sql.NullInt64{Int64: s.GetFinished(), Valid: true},
+		Host:         sql.NullString{String: s.GetHost(), Valid: true},
+		Runtime:      sql.NullString{String: s.GetRuntime(), Valid: true},
+		Distribution: sql.NullString{String: s.GetDistribution(), Valid: true},
+		ReportAs:     sql.NullString{String: s.GetReportAs(), Valid: true},
+	}
+
+	return step.Nullify()
+}

--- a/database/types/step_test.go
+++ b/database/types/step_test.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"database/sql"
+	"reflect"
+	"testing"
+
+	api "github.com/go-vela/server/api/types"
+)
+
+func TestDatabase_Step_Nullify(t *testing.T) {
+	// setup types
+	var s *Step
+
+	want := &Step{
+		ID:           sql.NullInt64{Int64: 0, Valid: false},
+		BuildID:      sql.NullInt64{Int64: 0, Valid: false},
+		RepoID:       sql.NullInt64{Int64: 0, Valid: false},
+		Number:       sql.NullInt32{Int32: 0, Valid: false},
+		Name:         sql.NullString{String: "", Valid: false},
+		Image:        sql.NullString{String: "", Valid: false},
+		Stage:        sql.NullString{String: "", Valid: false},
+		Status:       sql.NullString{String: "", Valid: false},
+		Error:        sql.NullString{String: "", Valid: false},
+		ExitCode:     sql.NullInt32{Int32: 0, Valid: false},
+		Created:      sql.NullInt64{Int64: 0, Valid: false},
+		Started:      sql.NullInt64{Int64: 0, Valid: false},
+		Finished:     sql.NullInt64{Int64: 0, Valid: false},
+		Host:         sql.NullString{String: "", Valid: false},
+		Runtime:      sql.NullString{String: "", Valid: false},
+		Distribution: sql.NullString{String: "", Valid: false},
+		ReportAs:     sql.NullString{String: "", Valid: false},
+	}
+
+	// setup tests
+	tests := []struct {
+		step *Step
+		want *Step
+	}{
+		{
+			step: testStep(),
+			want: testStep(),
+		},
+		{
+			step: s,
+			want: nil,
+		},
+		{
+			step: new(Step),
+			want: want,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := test.step.Nullify()
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("Nullify is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestDatabase_Step_ToAPI(t *testing.T) {
+	// setup types
+	want := new(api.Step)
+
+	want.SetID(1)
+	want.SetBuildID(1)
+	want.SetRepoID(1)
+	want.SetNumber(1)
+	want.SetName("clone")
+	want.SetImage("target/vela-git:v0.3.0")
+	want.SetStage("")
+	want.SetStatus("running")
+	want.SetError("")
+	want.SetExitCode(0)
+	want.SetCreated(1563474076)
+	want.SetStarted(1563474078)
+	want.SetFinished(1563474079)
+	want.SetHost("example.company.com")
+	want.SetRuntime("docker")
+	want.SetDistribution("linux")
+	want.SetReportAs("test")
+
+	// run test
+	got := testStep().ToAPI()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ToLibrary is %v, want %v", got, want)
+	}
+}
+
+func TestDatabase_Step_Validate(t *testing.T) {
+	// setup types
+	tests := []struct {
+		failure bool
+		step    *Step
+	}{
+		{
+			failure: false,
+			step:    testStep(),
+		},
+		{ // no build_id set for step
+			failure: true,
+			step: &Step{
+				ID:     sql.NullInt64{Int64: 1, Valid: true},
+				RepoID: sql.NullInt64{Int64: 1, Valid: true},
+				Number: sql.NullInt32{Int32: 1, Valid: true},
+				Name:   sql.NullString{String: "clone", Valid: true},
+				Image:  sql.NullString{String: "target/vela-git:v0.3.0", Valid: true},
+			},
+		},
+		{ // no repo_id set for step
+			failure: true,
+			step: &Step{
+				ID:      sql.NullInt64{Int64: 1, Valid: true},
+				BuildID: sql.NullInt64{Int64: 1, Valid: true},
+				Number:  sql.NullInt32{Int32: 1, Valid: true},
+				Name:    sql.NullString{String: "clone", Valid: true},
+				Image:   sql.NullString{String: "target/vela-git:v0.3.0", Valid: true},
+			},
+		},
+		{ // no name set for step
+			failure: true,
+			step: &Step{
+				ID:      sql.NullInt64{Int64: 1, Valid: true},
+				BuildID: sql.NullInt64{Int64: 1, Valid: true},
+				RepoID:  sql.NullInt64{Int64: 1, Valid: true},
+				Number:  sql.NullInt32{Int32: 1, Valid: true},
+				Image:   sql.NullString{String: "target/vela-git:v0.3.0", Valid: true},
+			},
+		},
+		{ // no number set for step
+			failure: true,
+			step: &Step{
+				ID:      sql.NullInt64{Int64: 1, Valid: true},
+				BuildID: sql.NullInt64{Int64: 1, Valid: true},
+				RepoID:  sql.NullInt64{Int64: 1, Valid: true},
+				Name:    sql.NullString{String: "clone", Valid: true},
+				Image:   sql.NullString{String: "target/vela-git:v0.3.0", Valid: true},
+			},
+		},
+		{ // no image set for step
+			failure: true,
+			step: &Step{
+				ID:      sql.NullInt64{Int64: 1, Valid: true},
+				BuildID: sql.NullInt64{Int64: 1, Valid: true},
+				RepoID:  sql.NullInt64{Int64: 1, Valid: true},
+				Number:  sql.NullInt32{Int32: 1, Valid: true},
+				Name:    sql.NullString{String: "clone", Valid: true},
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := test.step.Validate()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("Validate should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("Validate returned err: %v", err)
+		}
+	}
+}
+
+func TestDatabase_StepFromAPI(t *testing.T) {
+	// setup types
+	s := new(api.Step)
+
+	s.SetID(1)
+	s.SetBuildID(1)
+	s.SetRepoID(1)
+	s.SetNumber(1)
+	s.SetName("clone")
+	s.SetImage("target/vela-git:v0.3.0")
+	s.SetStage("")
+	s.SetStatus("running")
+	s.SetError("")
+	s.SetExitCode(0)
+	s.SetCreated(1563474076)
+	s.SetStarted(1563474078)
+	s.SetFinished(1563474079)
+	s.SetHost("example.company.com")
+	s.SetRuntime("docker")
+	s.SetDistribution("linux")
+	s.SetReportAs("test")
+
+	want := testStep()
+
+	// run test
+	got := StepFromAPI(s)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("StepFromLibrary is %v, want %v", got, want)
+	}
+}
+
+// testStep is a test helper function to create a Step
+// type with all fields set to a fake value.
+func testStep() *Step {
+	return &Step{
+		ID:           sql.NullInt64{Int64: 1, Valid: true},
+		BuildID:      sql.NullInt64{Int64: 1, Valid: true},
+		RepoID:       sql.NullInt64{Int64: 1, Valid: true},
+		Number:       sql.NullInt32{Int32: 1, Valid: true},
+		Name:         sql.NullString{String: "clone", Valid: true},
+		Image:        sql.NullString{String: "target/vela-git:v0.3.0", Valid: true},
+		Stage:        sql.NullString{String: "", Valid: false},
+		Status:       sql.NullString{String: "running", Valid: true},
+		Error:        sql.NullString{String: "", Valid: false},
+		ExitCode:     sql.NullInt32{Int32: 0, Valid: false},
+		Created:      sql.NullInt64{Int64: 1563474076, Valid: true},
+		Started:      sql.NullInt64{Int64: 1563474078, Valid: true},
+		Finished:     sql.NullInt64{Int64: 1563474079, Valid: true},
+		Host:         sql.NullString{String: "example.company.com", Valid: true},
+		Runtime:      sql.NullString{String: "docker", Valid: true},
+		Distribution: sql.NullString{String: "linux", Valid: true},
+		ReportAs:     sql.NullString{String: "test", Valid: true},
+	}
+}

--- a/database/types/worker.go
+++ b/database/types/worker.go
@@ -10,8 +10,8 @@ import (
 	"github.com/lib/pq"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 var (

--- a/database/user/count.go
+++ b/database/user/count.go
@@ -5,7 +5,7 @@ package user
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountUsers gets the count of all users from the database.

--- a/database/user/create.go
+++ b/database/user/create.go
@@ -10,8 +10,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // CreateUser creates a new user in the database.

--- a/database/user/delete.go
+++ b/database/user/delete.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // DeleteUser deletes an existing user from the database.

--- a/database/user/get.go
+++ b/database/user/get.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetUser gets a user by ID from the database.

--- a/database/user/get_name.go
+++ b/database/user/get_name.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetUserForName gets a user by name from the database.

--- a/database/user/list.go
+++ b/database/user/list.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListUsers gets a list of all users from the database.

--- a/database/user/list_lite.go
+++ b/database/user/list_lite.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListLiteUsers gets a lite (only: id, name) list of users from the database.

--- a/database/user/table.go
+++ b/database/user/table.go
@@ -5,7 +5,7 @@ package user
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/database/user/update.go
+++ b/database/user/update.go
@@ -10,8 +10,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // UpdateUser updates an existing user in the database.

--- a/database/user/user.go
+++ b/database/user/user.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/database/validate.go
+++ b/database/validate.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // Validate verifies the required fields from the provided configuration are populated correctly.

--- a/database/worker/count.go
+++ b/database/worker/count.go
@@ -5,7 +5,7 @@ package worker
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // CountWorkers gets the count of all workers from the database.

--- a/database/worker/create.go
+++ b/database/worker/create.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // CreateWorker creates a new worker in the database.

--- a/database/worker/delete.go
+++ b/database/worker/delete.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // DeleteWorker deletes an existing worker from the database.

--- a/database/worker/get.go
+++ b/database/worker/get.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetWorker gets a worker by ID from the database.

--- a/database/worker/get_hostname.go
+++ b/database/worker/get_hostname.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // GetWorkerForHostname gets a worker by hostname from the database.

--- a/database/worker/list.go
+++ b/database/worker/list.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // ListWorkers gets a list of all workers from the database.

--- a/database/worker/table.go
+++ b/database/worker/table.go
@@ -5,7 +5,7 @@ package worker
 import (
 	"context"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/database/worker/update.go
+++ b/database/worker/update.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // UpdateWorker updates an existing worker in the database.

--- a/database/worker/worker.go
+++ b/database/worker/worker.go
@@ -11,7 +11,7 @@ import (
 	"gorm.io/gorm"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 type (

--- a/internal/token/compose.go
+++ b/internal/token/compose.go
@@ -9,8 +9,8 @@ import (
 	"github.com/gin-gonic/gin"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/internal"
-	"github.com/go-vela/types/constants"
 )
 
 // Compose generates a refresh and access token pair unique

--- a/internal/token/compose_test.go
+++ b/internal/token/compose_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/internal"
-	"github.com/go-vela/types/constants"
 )
 
 func TestToken_Compose(t *testing.T) {

--- a/internal/token/parse_test.go
+++ b/internal/token/parse_test.go
@@ -11,7 +11,7 @@ import (
 	jwt "github.com/golang-jwt/jwt/v5"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestTokenManager_ParseToken(t *testing.T) {

--- a/internal/token/refresh.go
+++ b/internal/token/refresh.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
-	"github.com/go-vela/types/constants"
 )
 
 // Refresh returns a new access token, if the provided refreshToken is valid.

--- a/internal/token/refresh_test.go
+++ b/internal/token/refresh_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/gin-gonic/gin"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
-	"github.com/go-vela/types/constants"
 )
 
 func TestTokenManager_Refresh(t *testing.T) {

--- a/internal/webhook.go
+++ b/internal/webhook.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 var (

--- a/internal/webhook_test.go
+++ b/internal/webhook_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestWebhook_ShouldSkip(t *testing.T) {

--- a/mock/server/authentication.go
+++ b/mock/server/authentication.go
@@ -10,8 +10,8 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/types"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
 

--- a/mock/server/service.go
+++ b/mock/server/service.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/types"
-	"github.com/go-vela/types/library"
 )
 
 const (
@@ -70,7 +70,7 @@ const (
 func getServices(c *gin.Context) {
 	data := []byte(ServicesResp)
 
-	var body []library.Service
+	var body []api.Service
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -92,7 +92,7 @@ func getService(c *gin.Context) {
 
 	data := []byte(ServiceResp)
 
-	var body library.Service
+	var body api.Service
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -102,7 +102,7 @@ func getService(c *gin.Context) {
 func addService(c *gin.Context) {
 	data := []byte(ServiceResp)
 
-	var body library.Service
+	var body api.Service
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusCreated, body)
@@ -126,7 +126,7 @@ func updateService(c *gin.Context) {
 
 	data := []byte(ServiceResp)
 
-	var body library.Service
+	var body api.Service
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)

--- a/mock/server/service_test.go
+++ b/mock/server/service_test.go
@@ -7,11 +7,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
 )
 
 func TestService_ActiveServiceResp(t *testing.T) {
-	testService := library.Service{}
+	testService := api.Service{}
 
 	err := json.Unmarshal([]byte(ServiceResp), &testService)
 	if err != nil {

--- a/mock/server/step.go
+++ b/mock/server/step.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/types"
-	"github.com/go-vela/types/library"
 )
 
 const (
@@ -80,7 +80,7 @@ const (
 func getSteps(c *gin.Context) {
 	data := []byte(StepsResp)
 
-	var body []library.Step
+	var body []api.Step
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -102,7 +102,7 @@ func getStep(c *gin.Context) {
 
 	data := []byte(StepResp)
 
-	var body library.Step
+	var body api.Step
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -112,7 +112,7 @@ func getStep(c *gin.Context) {
 func addStep(c *gin.Context) {
 	data := []byte(StepResp)
 
-	var body library.Step
+	var body api.Step
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusCreated, body)
@@ -136,7 +136,7 @@ func updateStep(c *gin.Context) {
 
 	data := []byte(StepResp)
 
-	var body library.Step
+	var body api.Step
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)

--- a/mock/server/step_test.go
+++ b/mock/server/step_test.go
@@ -7,11 +7,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
 )
 
 func TestStep_ActiveStepResp(t *testing.T) {
-	testStep := library.Step{}
+	testStep := api.Step{}
 
 	err := json.Unmarshal([]byte(StepResp), &testStep)
 	if err != nil {

--- a/queue/flags.go
+++ b/queue/flags.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // Flags represents all supported command line

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // FromCLIContext helper function to setup the queue from the CLI arguments.

--- a/queue/redis/driver.go
+++ b/queue/redis/driver.go
@@ -2,7 +2,7 @@
 
 package redis
 
-import "github.com/go-vela/types/constants"
+import "github.com/go-vela/server/constants"
 
 // Driver outputs the configured queue driver.
 func (c *client) Driver() string {

--- a/queue/redis/driver_test.go
+++ b/queue/redis/driver_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestRedis_Driver(t *testing.T) {

--- a/queue/redis/route.go
+++ b/queue/redis/route.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/go-vela/server/compiler/types/pipeline"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // Route decides which route a build gets placed within the queue.

--- a/queue/redis/route_test.go
+++ b/queue/redis/route_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-vela/server/compiler/types/pipeline"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestRedis_Client_Route(t *testing.T) {

--- a/queue/setup.go
+++ b/queue/setup.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/queue/redis"
-	"github.com/go-vela/types/constants"
 )
 
 // Setup represents the configuration necessary for

--- a/router/middleware/auth/auth.go
+++ b/router/middleware/auth/auth.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5/request"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // RetrieveAccessToken gets the passed in access token from the header in the request.

--- a/router/middleware/auth/auth_test.go
+++ b/router/middleware/auth/auth_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestToken_Retrieve_Refresh(t *testing.T) {

--- a/router/middleware/claims/claims.go
+++ b/router/middleware/claims/claims.go
@@ -9,10 +9,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/internal/token"
 	"github.com/go-vela/server/router/middleware/auth"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // Retrieve gets the claims in the given context.

--- a/router/middleware/claims/claims_test.go
+++ b/router/middleware/claims/claims_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/internal/token"
-	"github.com/go-vela/types/constants"
 )
 
 func TestClaims_Retrieve(t *testing.T) {

--- a/router/middleware/claims/context_test.go
+++ b/router/middleware/claims/context_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/internal/token"
-	"github.com/go-vela/types/constants"
 )
 
 func TestClaims_FromContext(t *testing.T) {

--- a/router/middleware/default_repo_settings_test.go
+++ b/router/middleware/default_repo_settings_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestMiddleware_DefaultRepoEvents(t *testing.T) {

--- a/router/middleware/executors/executors.go
+++ b/router/middleware/executors/executors.go
@@ -14,11 +14,11 @@ import (
 	"github.com/gin-gonic/gin"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/internal/token"
 	"github.com/go-vela/server/router/middleware/build"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // Retrieve gets the executors in the given context.

--- a/router/middleware/logger.go
+++ b/router/middleware/logger.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/router/middleware/build"
 	"github.com/go-vela/server/router/middleware/claims"
 	"github.com/go-vela/server/router/middleware/dashboard"
@@ -21,7 +22,6 @@ import (
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/router/middleware/worker"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // This file, in part, reproduces portions of

--- a/router/middleware/logger_test.go
+++ b/router/middleware/logger_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/go-vela/server/router/middleware/step"
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/router/middleware/worker"
-	"github.com/go-vela/types/library"
 )
 
 func TestMiddleware_Logger(t *testing.T) {
@@ -41,14 +40,14 @@ func TestMiddleware_Logger(t *testing.T) {
 	b.SetRepo(r)
 	b.SetNumber(1)
 
-	svc := new(library.Service)
+	svc := new(api.Service)
 	svc.SetID(1)
 	svc.SetRepoID(1)
 	svc.SetBuildID(1)
 	svc.SetNumber(1)
 	svc.SetName("foo")
 
-	s := new(library.Step)
+	s := new(api.Step)
 	s.SetID(1)
 	s.SetRepoID(1)
 	s.SetBuildID(1)

--- a/router/middleware/pipeline/pipeline_test.go
+++ b/router/middleware/pipeline/pipeline_test.go
@@ -20,6 +20,7 @@ import (
 	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/compiler"
 	"github.com/go-vela/server/compiler/native"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/database/testutils"
 	"github.com/go-vela/server/internal"
@@ -30,7 +31,6 @@ import (
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/scm"
 	"github.com/go-vela/server/scm/github"
-	"github.com/go-vela/types/constants"
 )
 
 func TestPipeline_Retrieve(t *testing.T) {

--- a/router/middleware/service/context.go
+++ b/router/middleware/service/context.go
@@ -5,7 +5,7 @@ package service
 import (
 	"context"
 
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
 )
 
 const key = "service"
@@ -16,13 +16,13 @@ type Setter interface {
 }
 
 // FromContext returns the Service associated with this context.
-func FromContext(c context.Context) *library.Service {
+func FromContext(c context.Context) *api.Service {
 	value := c.Value(key)
 	if value == nil {
 		return nil
 	}
 
-	s, ok := value.(*library.Service)
+	s, ok := value.(*api.Service)
 	if !ok {
 		return nil
 	}
@@ -32,6 +32,6 @@ func FromContext(c context.Context) *library.Service {
 
 // ToContext adds the Service to this context if it supports
 // the Setter interface.
-func ToContext(c Setter, s *library.Service) {
+func ToContext(c Setter, s *api.Service) {
 	c.Set(key, s)
 }

--- a/router/middleware/service/context_test.go
+++ b/router/middleware/service/context_test.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
 )
 
 func TestService_FromContext(t *testing.T) {
 	// setup types
 	num := int64(1)
-	want := &library.Service{ID: &num}
+	want := &api.Service{ID: &num}
 
 	// setup context
 	gin.SetMode(gin.TestMode)
@@ -72,7 +72,7 @@ func TestService_FromContext_Empty(t *testing.T) {
 func TestService_ToContext(t *testing.T) {
 	// setup types
 	num := int64(1)
-	want := &library.Service{ID: &num}
+	want := &api.Service{ID: &num}
 
 	// setup context
 	gin.SetMode(gin.TestMode)

--- a/router/middleware/service/service.go
+++ b/router/middleware/service/service.go
@@ -10,16 +10,16 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/build"
 	"github.com/go-vela/server/router/middleware/org"
 	"github.com/go-vela/server/router/middleware/repo"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/library"
 )
 
 // Retrieve gets the service in the given context.
-func Retrieve(c *gin.Context) *library.Service {
+func Retrieve(c *gin.Context) *api.Service {
 	return FromContext(c)
 }
 

--- a/router/middleware/service/service_test.go
+++ b/router/middleware/service/service_test.go
@@ -17,12 +17,11 @@ import (
 	"github.com/go-vela/server/router/middleware/build"
 	"github.com/go-vela/server/router/middleware/org"
 	"github.com/go-vela/server/router/middleware/repo"
-	"github.com/go-vela/types/library"
 )
 
 func TestService_Retrieve(t *testing.T) {
 	// setup types
-	want := new(library.Service)
+	want := new(api.Service)
 	want.SetID(1)
 
 	// setup context
@@ -57,7 +56,7 @@ func TestService_Establish(t *testing.T) {
 	b.SetRepo(r)
 	b.SetNumber(1)
 
-	want := new(library.Service)
+	want := new(api.Service)
 	want.SetID(1)
 	want.SetRepoID(1)
 	want.SetBuildID(1)
@@ -74,7 +73,7 @@ func TestService_Establish(t *testing.T) {
 	want.SetRuntime("")
 	want.SetDistribution("")
 
-	got := new(library.Service)
+	got := new(api.Service)
 
 	// setup database
 	db, err := database.NewTest()

--- a/router/middleware/step/context.go
+++ b/router/middleware/step/context.go
@@ -5,7 +5,7 @@ package step
 import (
 	"context"
 
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
 )
 
 const key = "step"
@@ -16,13 +16,13 @@ type Setter interface {
 }
 
 // FromContext returns the Step associated with this context.
-func FromContext(c context.Context) *library.Step {
+func FromContext(c context.Context) *api.Step {
 	value := c.Value(key)
 	if value == nil {
 		return nil
 	}
 
-	s, ok := value.(*library.Step)
+	s, ok := value.(*api.Step)
 	if !ok {
 		return nil
 	}
@@ -32,6 +32,6 @@ func FromContext(c context.Context) *library.Step {
 
 // ToContext adds the Step to this context if it supports
 // the Setter interface.
-func ToContext(c Setter, s *library.Step) {
+func ToContext(c Setter, s *api.Step) {
 	c.Set(key, s)
 }

--- a/router/middleware/step/context_test.go
+++ b/router/middleware/step/context_test.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
 )
 
 func TestStep_FromContext(t *testing.T) {
 	// setup types
 	num := int64(1)
-	want := &library.Step{ID: &num}
+	want := &api.Step{ID: &num}
 
 	// setup context
 	gin.SetMode(gin.TestMode)
@@ -72,7 +72,7 @@ func TestStep_FromContext_Empty(t *testing.T) {
 func TestStep_ToContext(t *testing.T) {
 	// setup types
 	num := int64(1)
-	want := &library.Step{ID: &num}
+	want := &api.Step{ID: &num}
 
 	// setup context
 	gin.SetMode(gin.TestMode)

--- a/router/middleware/step/step.go
+++ b/router/middleware/step/step.go
@@ -10,16 +10,16 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/build"
 	"github.com/go-vela/server/router/middleware/org"
 	"github.com/go-vela/server/router/middleware/repo"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/library"
 )
 
 // Retrieve gets the step in the given context.
-func Retrieve(c *gin.Context) *library.Step {
+func Retrieve(c *gin.Context) *api.Step {
 	return FromContext(c)
 }
 

--- a/router/middleware/step/step_test.go
+++ b/router/middleware/step/step_test.go
@@ -17,12 +17,11 @@ import (
 	"github.com/go-vela/server/router/middleware/build"
 	"github.com/go-vela/server/router/middleware/org"
 	"github.com/go-vela/server/router/middleware/repo"
-	"github.com/go-vela/types/library"
 )
 
 func TestStep_Retrieve(t *testing.T) {
 	// setup types
-	want := new(library.Step)
+	want := new(api.Step)
 	want.SetID(1)
 
 	// setup context
@@ -58,7 +57,7 @@ func TestStep_Establish(t *testing.T) {
 	b.SetRepo(r)
 	b.SetNumber(1)
 
-	want := new(library.Step)
+	want := new(api.Step)
 	want.SetID(1)
 	want.SetRepoID(1)
 	want.SetBuildID(1)
@@ -77,7 +76,7 @@ func TestStep_Establish(t *testing.T) {
 	want.SetDistribution("")
 	want.SetReportAs("")
 
-	got := new(library.Step)
+	got := new(api.Step)
 
 	// setup database
 	db, err := database.NewTest()

--- a/router/middleware/user/user.go
+++ b/router/middleware/user/user.go
@@ -10,10 +10,10 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/claims"
 	"github.com/go-vela/server/util"
-	"github.com/go-vela/types/constants"
 )
 
 // Retrieve gets the user in the given context.

--- a/router/middleware/user/user_test.go
+++ b/router/middleware/user/user_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/internal/token"
 	"github.com/go-vela/server/router/middleware/claims"
 	"github.com/go-vela/server/scm"
 	"github.com/go-vela/server/scm/github"
-	"github.com/go-vela/types/constants"
 )
 
 func TestUser_Retrieve(t *testing.T) {

--- a/scm/flags.go
+++ b/scm/flags.go
@@ -5,7 +5,7 @@ package scm
 import (
 	"github.com/urfave/cli/v2"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // Flags represents all supported command line

--- a/scm/github/driver.go
+++ b/scm/github/driver.go
@@ -2,7 +2,7 @@
 
 package github
 
-import "github.com/go-vela/types/constants"
+import "github.com/go-vela/server/constants"
 
 // Driver outputs the configured scm driver.
 func (c *client) Driver() string {

--- a/scm/github/driver_test.go
+++ b/scm/github/driver_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestGitHub_Driver(t *testing.T) {

--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -14,8 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/library"
+	"github.com/go-vela/server/constants"
 )
 
 // ConfigBackoff is a wrapper for Config that will retry five times if the function
@@ -401,7 +400,7 @@ func (c *client) Status(ctx context.Context, u *api.User, b *api.Build, org, nam
 }
 
 // StepStatus sends the commit status for the given SHA to the GitHub repo with the step as the context.
-func (c *client) StepStatus(ctx context.Context, u *api.User, b *api.Build, s *library.Step, org, name string) error {
+func (c *client) StepStatus(ctx context.Context, u *api.User, b *api.Build, s *api.Step, org, name string) error {
 	c.Logger.WithFields(logrus.Fields{
 		"build": b.GetNumber(),
 		"org":   org,

--- a/scm/github/repo_test.go
+++ b/scm/github/repo_test.go
@@ -15,8 +15,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/library"
+	"github.com/go-vela/server/constants"
 )
 
 func TestGithub_Config_YML(t *testing.T) {
@@ -909,7 +908,7 @@ func TestGithub_Status_Running(t *testing.T) {
 	b.SetStatus(constants.StatusRunning)
 	b.SetCommit("abcd1234")
 
-	step := new(library.Step)
+	step := new(api.Step)
 	step.SetID(1)
 	step.SetNumber(1)
 	step.SetName("test")
@@ -973,7 +972,7 @@ func TestGithub_Status_Success(t *testing.T) {
 	b.SetStatus(constants.StatusRunning)
 	b.SetCommit("abcd1234")
 
-	step := new(library.Step)
+	step := new(api.Step)
 	step.SetID(1)
 	step.SetNumber(1)
 	step.SetName("test")
@@ -1037,7 +1036,7 @@ func TestGithub_Status_Failure(t *testing.T) {
 	b.SetStatus(constants.StatusRunning)
 	b.SetCommit("abcd1234")
 
-	step := new(library.Step)
+	step := new(api.Step)
 	step.SetID(1)
 	step.SetNumber(1)
 	step.SetName("test")
@@ -1101,7 +1100,7 @@ func TestGithub_Status_Killed(t *testing.T) {
 	b.SetStatus(constants.StatusRunning)
 	b.SetCommit("abcd1234")
 
-	step := new(library.Step)
+	step := new(api.Step)
 	step.SetID(1)
 	step.SetNumber(1)
 	step.SetName("test")
@@ -1165,7 +1164,7 @@ func TestGithub_Status_Skipped(t *testing.T) {
 	b.SetStatus(constants.StatusSkipped)
 	b.SetCommit("abcd1234")
 
-	step := new(library.Step)
+	step := new(api.Step)
 	step.SetID(1)
 	step.SetNumber(1)
 	step.SetName("test")
@@ -1229,7 +1228,7 @@ func TestGithub_Status_Error(t *testing.T) {
 	b.SetStatus(constants.StatusRunning)
 	b.SetCommit("abcd1234")
 
-	step := new(library.Step)
+	step := new(api.Step)
 	step.SetID(1)
 	step.SetNumber(1)
 	step.SetName("test")

--- a/scm/github/webhook.go
+++ b/scm/github/webhook.go
@@ -17,8 +17,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/internal"
-	"github.com/go-vela/types/constants"
 )
 
 // ProcessWebhook parses the webhook from a repo.

--- a/scm/github/webhook_test.go
+++ b/scm/github/webhook_test.go
@@ -17,8 +17,8 @@ import (
 
 	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/compiler/types/raw"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/internal"
-	"github.com/go-vela/types/constants"
 )
 
 func TestGithub_ProcessWebhook_Push(t *testing.T) {

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // New creates and returns a Vela service capable of

--- a/scm/service.go
+++ b/scm/service.go
@@ -8,7 +8,6 @@ import (
 
 	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/internal"
-	"github.com/go-vela/types/library"
 )
 
 // Service represents the interface for Vela integrating
@@ -119,7 +118,7 @@ type Service interface {
 	Status(context.Context, *api.User, *api.Build, string, string) error
 	// StepStatus defines a function that sends the
 	// commit status for the given SHA for a specified step context.
-	StepStatus(context.Context, *api.User, *api.Build, *library.Step, string, string) error
+	StepStatus(context.Context, *api.User, *api.Build, *api.Step, string, string) error
 	// ListUserRepos defines a function that retrieves
 	// all repos with admin rights for the user.
 	ListUserRepos(context.Context, *api.User) ([]*api.Repo, error)

--- a/scm/setup.go
+++ b/scm/setup.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/scm/github"
 	"github.com/go-vela/server/tracing"
-	"github.com/go-vela/types/constants"
 )
 
 // Setup represents the configuration necessary for

--- a/secret/native/count.go
+++ b/secret/native/count.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // Count counts a list of secrets.

--- a/secret/native/create.go
+++ b/secret/native/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // Create creates a new secret.

--- a/secret/native/delete.go
+++ b/secret/native/delete.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // Delete deletes a secret.

--- a/secret/native/driver.go
+++ b/secret/native/driver.go
@@ -2,7 +2,7 @@
 
 package native
 
-import "github.com/go-vela/types/constants"
+import "github.com/go-vela/server/constants"
 
 // Driver outputs the configured secret driver.
 func (c *client) Driver() string {

--- a/secret/native/driver_test.go
+++ b/secret/native/driver_test.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
-	"github.com/go-vela/types/constants"
 )
 
 func TestNative_Driver(t *testing.T) {

--- a/secret/native/get.go
+++ b/secret/native/get.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // Get captures a secret.

--- a/secret/native/list.go
+++ b/secret/native/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // List captures a list of secrets.

--- a/secret/native/update.go
+++ b/secret/native/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // Update updates an existing secret.

--- a/secret/secret.go
+++ b/secret/secret.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // New creates and returns a Vela service capable of

--- a/secret/setup.go
+++ b/secret/setup.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/secret/native"
 	"github.com/go-vela/server/secret/vault"
-	"github.com/go-vela/types/constants"
 )
 
 // Setup represents the configuration necessary for

--- a/secret/vault/count.go
+++ b/secret/vault/count.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // Count counts a list of secrets.

--- a/secret/vault/create.go
+++ b/secret/vault/create.go
@@ -10,8 +10,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	database "github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // Create creates a new secret.

--- a/secret/vault/delete.go
+++ b/secret/vault/delete.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // Delete deletes a secret.

--- a/secret/vault/driver.go
+++ b/secret/vault/driver.go
@@ -2,7 +2,7 @@
 
 package vault
 
-import "github.com/go-vela/types/constants"
+import "github.com/go-vela/server/constants"
 
 // Driver outputs the configured secret driver.
 func (c *client) Driver() string {

--- a/secret/vault/driver_test.go
+++ b/secret/vault/driver_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestVault_Driver(t *testing.T) {

--- a/secret/vault/get.go
+++ b/secret/vault/get.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	velaAPI "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // Get captures a secret.

--- a/secret/vault/list.go
+++ b/secret/vault/list.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	velaAPI "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 // List captures a list of secrets.

--- a/secret/vault/update.go
+++ b/secret/vault/update.go
@@ -10,8 +10,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	database "github.com/go-vela/server/database/types"
-	"github.com/go-vela/types/constants"
 )
 
 // Update updates a secret.

--- a/secret/vault/vault.go
+++ b/secret/vault/vault.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	velaAPI "github.com/go-vela/server/api/types"
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 const (

--- a/util/compression_test.go
+++ b/util/compression_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/types/constants"
+	"github.com/go-vela/server/constants"
 )
 
 func TestDatabase_compress(t *testing.T) {


### PR DESCRIPTION
Also added missing constants. All that remain after this is `log`, `build_executable`, and a few other stray types from outside the `library` and `database` packages.