### PR TITLE
feat(pipeline)!: add warnings to pipelines that use legacy YAML lib or have dupl anchors in map

### DIFF
--- a/api/pipeline/template.go
+++ b/api/pipeline/template.go
@@ -101,7 +101,7 @@ func GetTemplates(c *gin.Context) {
 	compiler := compiler.FromContext(c).Duplicate().WithCommit(p.GetCommit()).WithMetadata(m).WithRepo(r).WithUser(u)
 
 	// parse the pipeline configuration
-	pipeline, _, err := compiler.Parse(p.GetData(), p.GetType(), new(yaml.Template))
+	pipeline, _, _, err := compiler.Parse(p.GetData(), p.GetType(), new(yaml.Template))
 	if err != nil {
 		util.HandleError(c, http.StatusBadRequest, fmt.Errorf("unable to parse pipeline %s: %w", entry, err))
 

--- a/api/types/pipeline.go
+++ b/api/types/pipeline.go
@@ -10,20 +10,21 @@ import (
 //
 // swagger:model Pipeline
 type Pipeline struct {
-	ID              *int64  `json:"id,omitempty"`
-	Repo            *Repo   `json:"repo,omitempty"`
-	Commit          *string `json:"commit,omitempty"`
-	Flavor          *string `json:"flavor,omitempty"`
-	Platform        *string `json:"platform,omitempty"`
-	Ref             *string `json:"ref,omitempty"`
-	Type            *string `json:"type,omitempty"`
-	Version         *string `json:"version,omitempty"`
-	ExternalSecrets *bool   `json:"external_secrets,omitempty"`
-	InternalSecrets *bool   `json:"internal_secrets,omitempty"`
-	Services        *bool   `json:"services,omitempty"`
-	Stages          *bool   `json:"stages,omitempty"`
-	Steps           *bool   `json:"steps,omitempty"`
-	Templates       *bool   `json:"templates,omitempty"`
+	ID              *int64    `json:"id,omitempty"`
+	Repo            *Repo     `json:"repo,omitempty"`
+	Commit          *string   `json:"commit,omitempty"`
+	Flavor          *string   `json:"flavor,omitempty"`
+	Platform        *string   `json:"platform,omitempty"`
+	Ref             *string   `json:"ref,omitempty"`
+	Type            *string   `json:"type,omitempty"`
+	Version         *string   `json:"version,omitempty"`
+	ExternalSecrets *bool     `json:"external_secrets,omitempty"`
+	InternalSecrets *bool     `json:"internal_secrets,omitempty"`
+	Services        *bool     `json:"services,omitempty"`
+	Stages          *bool     `json:"stages,omitempty"`
+	Steps           *bool     `json:"steps,omitempty"`
+	Templates       *bool     `json:"templates,omitempty"`
+	Warnings        *[]string `json:"warnings,omitempty"`
 	// swagger:strfmt base64
 	Data *[]byte `json:"data,omitempty"`
 }
@@ -208,6 +209,19 @@ func (p *Pipeline) GetTemplates() bool {
 	}
 
 	return *p.Templates
+}
+
+// GetWarnings returns the Warnings field.
+//
+// When the provided Pipeline type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (p *Pipeline) GetWarnings() []string {
+	// return zero value if Pipeline type or Warnings field is nil
+	if p == nil || p.Warnings == nil {
+		return []string{}
+	}
+
+	return *p.Warnings
 }
 
 // GetData returns the Data field.
@@ -405,6 +419,19 @@ func (p *Pipeline) SetTemplates(v bool) {
 	p.Templates = &v
 }
 
+// SetWarnings sets the Warnings field.
+//
+// When the provided Pipeline type is nil, it
+// will set nothing and immediately return.
+func (p *Pipeline) SetWarnings(v []string) {
+	// return if Pipeline type is nil
+	if p == nil {
+		return
+	}
+
+	p.Warnings = &v
+}
+
 // SetData sets the Data field.
 //
 // When the provided Pipeline type is nil, it
@@ -436,6 +463,7 @@ func (p *Pipeline) String() string {
   Templates: %t,
   Type: %s,
   Version: %s,
+  Warnings: %v,
 }`,
 		p.GetCommit(),
 		p.GetData(),
@@ -452,5 +480,6 @@ func (p *Pipeline) String() string {
 		p.GetTemplates(),
 		p.GetType(),
 		p.GetVersion(),
+		p.GetWarnings(),
 	)
 }

--- a/api/types/pipeline_test.go
+++ b/api/types/pipeline_test.go
@@ -82,6 +82,10 @@ func TestAPI_Pipeline_Getters(t *testing.T) {
 			t.Errorf("GetTemplates is %v, want %v", test.pipeline.GetTemplates(), test.want.GetTemplates())
 		}
 
+		if !reflect.DeepEqual(test.pipeline.GetWarnings(), test.want.GetWarnings()) {
+			t.Errorf("GetWarnings is %v, want %v", test.pipeline.GetWarnings(), test.want.GetWarnings())
+		}
+
 		if !reflect.DeepEqual(test.pipeline.GetData(), test.want.GetData()) {
 			t.Errorf("GetData is %v, want %v", test.pipeline.GetData(), test.want.GetData())
 		}
@@ -123,6 +127,7 @@ func TestAPI_Pipeline_Setters(t *testing.T) {
 		test.pipeline.SetStages(test.want.GetStages())
 		test.pipeline.SetSteps(test.want.GetSteps())
 		test.pipeline.SetTemplates(test.want.GetTemplates())
+		test.pipeline.SetWarnings(test.want.GetWarnings())
 		test.pipeline.SetData(test.want.GetData())
 
 		if test.pipeline.GetID() != test.want.GetID() {
@@ -181,6 +186,10 @@ func TestAPI_Pipeline_Setters(t *testing.T) {
 			t.Errorf("SetTemplates is %v, want %v", test.pipeline.GetTemplates(), test.want.GetTemplates())
 		}
 
+		if !reflect.DeepEqual(test.pipeline.GetWarnings(), test.want.GetWarnings()) {
+			t.Errorf("SetWarnings is %v, want %v", test.pipeline.GetWarnings(), test.want.GetWarnings())
+		}
+
 		if !reflect.DeepEqual(test.pipeline.GetData(), test.want.GetData()) {
 			t.Errorf("SetData is %v, want %v", test.pipeline.GetData(), test.want.GetData())
 		}
@@ -207,6 +216,7 @@ func TestAPI_Pipeline_String(t *testing.T) {
   Templates: %t,
   Type: %s,
   Version: %s,
+  Warnings: %v,
 }`,
 		p.GetCommit(),
 		p.GetData(),
@@ -223,6 +233,7 @@ func TestAPI_Pipeline_String(t *testing.T) {
 		p.GetTemplates(),
 		p.GetType(),
 		p.GetVersion(),
+		p.GetWarnings(),
 	)
 
 	// run test
@@ -253,6 +264,7 @@ func testPipeline() *Pipeline {
 	p.SetSteps(true)
 	p.SetTemplates(false)
 	p.SetData(testPipelineData())
+	p.SetWarnings([]string{"42:this is a warning"})
 
 	return p
 }

--- a/compiler/engine.go
+++ b/compiler/engine.go
@@ -36,7 +36,7 @@ type Engine interface {
 
 	// Parse defines a function that converts
 	// an object to a yaml configuration.
-	Parse(interface{}, string, *yaml.Template) (*yaml.Build, []byte, error)
+	Parse(interface{}, string, *yaml.Template) (*yaml.Build, []byte, []string, error)
 
 	// ParseRaw defines a function that converts
 	// an object to a string.

--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -39,7 +39,7 @@ type ModifyResponse struct {
 
 // Compile produces an executable pipeline from a yaml configuration.
 func (c *client) Compile(ctx context.Context, v interface{}) (*pipeline.Build, *api.Pipeline, error) {
-	p, data, err := c.Parse(v, c.repo.GetPipelineType(), new(yaml.Template))
+	p, data, warnings, err := c.Parse(v, c.repo.GetPipelineType(), new(yaml.Template))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -61,6 +61,7 @@ func (c *client) Compile(ctx context.Context, v interface{}) (*pipeline.Build, *
 	_pipeline := p.ToPipelineAPI()
 	_pipeline.SetData(data)
 	_pipeline.SetType(c.repo.GetPipelineType())
+	_pipeline.SetWarnings(warnings)
 
 	// create map of templates for easy lookup
 	templates := mapFromTemplates(p.Templates)
@@ -117,7 +118,7 @@ func (c *client) Compile(ctx context.Context, v interface{}) (*pipeline.Build, *
 
 // CompileLite produces a partial of an executable pipeline from a yaml configuration.
 func (c *client) CompileLite(ctx context.Context, v interface{}, ruleData *pipeline.RuleData, substitute bool) (*yaml.Build, *api.Pipeline, error) {
-	p, data, err := c.Parse(v, c.repo.GetPipelineType(), new(yaml.Template))
+	p, data, warnings, err := c.Parse(v, c.repo.GetPipelineType(), new(yaml.Template))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -126,6 +127,7 @@ func (c *client) CompileLite(ctx context.Context, v interface{}, ruleData *pipel
 	_pipeline := p.ToPipelineAPI()
 	_pipeline.SetData(data)
 	_pipeline.SetType(c.repo.GetPipelineType())
+	_pipeline.SetWarnings(warnings)
 
 	if p.Metadata.RenderInline {
 		newPipeline, err := c.compileInline(ctx, p, c.GetTemplateDepth())
@@ -267,7 +269,7 @@ func (c *client) compileInline(ctx context.Context, p *yaml.Build, depth int) (*
 		// inject template name into variables
 		template.Variables["VELA_TEMPLATE_NAME"] = template.Name
 
-		parsed, _, err := c.Parse(bytes, format, template)
+		parsed, _, _, err := c.Parse(bytes, format, template)
 		if err != nil {
 			return nil, err
 		}

--- a/compiler/native/expand.go
+++ b/compiler/native/expand.go
@@ -138,7 +138,7 @@ func (c *client) ExpandSteps(ctx context.Context, s *yaml.Build, tmpls map[strin
 		// inject template name into variables
 		step.Template.Variables["VELA_TEMPLATE_NAME"] = step.Template.Name
 
-		tmplBuild, err := c.mergeTemplate(bytes, tmpl, step)
+		tmplBuild, _, err := c.mergeTemplate(bytes, tmpl, step)
 		if err != nil {
 			return s, err
 		}
@@ -247,7 +247,7 @@ func (c *client) ExpandDeployment(ctx context.Context, b *yaml.Build, tmpls map[
 		b.Deployment.Template.Variables = make(map[string]interface{})
 	}
 
-	tmplBuild, err := c.mergeDeployTemplate(bytes, tmpl, &b.Deployment)
+	tmplBuild, _, err := c.mergeDeployTemplate(bytes, tmpl, &b.Deployment)
 	if err != nil {
 		return b, err
 	}
@@ -391,7 +391,7 @@ func (c *client) getTemplate(ctx context.Context, tmpl *yaml.Template, name stri
 }
 
 //nolint:lll // ignore long line length due to input arguments
-func (c *client) mergeTemplate(bytes []byte, tmpl *yaml.Template, step *yaml.Step) (*yaml.Build, error) {
+func (c *client) mergeTemplate(bytes []byte, tmpl *yaml.Template, step *yaml.Step) (*yaml.Build, []string, error) {
 	switch tmpl.Format {
 	case constants.PipelineTypeGo, "golang", "":
 		//nolint:lll // ignore long line length due to return
@@ -401,11 +401,11 @@ func (c *client) mergeTemplate(bytes []byte, tmpl *yaml.Template, step *yaml.Ste
 		return starlark.Render(string(bytes), step.Name, step.Template.Name, step.Environment, step.Template.Variables, c.GetStarlarkExecLimit())
 	default:
 		//nolint:lll // ignore long line length due to return
-		return &yaml.Build{}, fmt.Errorf("format of %s is unsupported", tmpl.Format)
+		return &yaml.Build{}, nil, fmt.Errorf("format of %s is unsupported", tmpl.Format)
 	}
 }
 
-func (c *client) mergeDeployTemplate(bytes []byte, tmpl *yaml.Template, d *yaml.Deployment) (*yaml.Build, error) {
+func (c *client) mergeDeployTemplate(bytes []byte, tmpl *yaml.Template, d *yaml.Deployment) (*yaml.Build, []string, error) {
 	switch tmpl.Format {
 	case constants.PipelineTypeGo, "golang", "":
 		//nolint:lll // ignore long line length due to return
@@ -415,7 +415,7 @@ func (c *client) mergeDeployTemplate(bytes []byte, tmpl *yaml.Template, d *yaml.
 		return starlark.Render(string(bytes), "", d.Template.Name, make(raw.StringSliceMap), d.Template.Variables, c.GetStarlarkExecLimit())
 	default:
 		//nolint:lll // ignore long line length due to return
-		return &yaml.Build{}, fmt.Errorf("format of %s is unsupported", tmpl.Format)
+		return &yaml.Build{}, nil, fmt.Errorf("format of %s is unsupported", tmpl.Format)
 	}
 }
 

--- a/compiler/native/parse_test.go
+++ b/compiler/native/parse_test.go
@@ -38,7 +38,7 @@ func TestNative_Parse_Metadata_Bytes(t *testing.T) {
 		t.Errorf("Reading file returned err: %v", err)
 	}
 
-	got, _, err := client.Parse(b, "", new(yaml.Template))
+	got, _, _, err := client.Parse(b, "", new(yaml.Template))
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestNative_Parse_Metadata_File(t *testing.T) {
 
 	defer f.Close()
 
-	got, _, err := client.Parse(f, "", new(yaml.Template))
+	got, _, _, err := client.Parse(f, "", new(yaml.Template))
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestNative_Parse_Metadata_Invalid(t *testing.T) {
 	client, _ := FromCLIContext(cli.NewContext(nil, flag.NewFlagSet("test", 0), nil))
 
 	// run test
-	got, _, err := client.Parse(nil, "", new(yaml.Template))
+	got, _, _, err := client.Parse(nil, "", new(yaml.Template))
 
 	if err == nil {
 		t.Error("Parse should have returned err")
@@ -109,7 +109,7 @@ func TestNative_Parse_Metadata_Path(t *testing.T) {
 	}
 
 	// run test
-	got, _, err := client.Parse("testdata/metadata.yml", "", new(yaml.Template))
+	got, _, _, err := client.Parse("testdata/metadata.yml", "", new(yaml.Template))
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestNative_Parse_Metadata_Reader(t *testing.T) {
 		t.Errorf("Reading file returned err: %v", err)
 	}
 
-	got, _, err := client.Parse(bytes.NewReader(b), "", new(yaml.Template))
+	got, _, _, err := client.Parse(bytes.NewReader(b), "", new(yaml.Template))
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}
@@ -167,7 +167,7 @@ func TestNative_Parse_Metadata_String(t *testing.T) {
 		t.Errorf("Reading file returned err: %v", err)
 	}
 
-	got, _, err := client.Parse(string(b), "", new(yaml.Template))
+	got, _, _, err := client.Parse(string(b), "", new(yaml.Template))
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}
@@ -215,7 +215,7 @@ func TestNative_Parse_Parameters(t *testing.T) {
 		t.Errorf("Reading file returned err: %v", err)
 	}
 
-	got, _, err := client.Parse(b, "", new(yaml.Template))
+	got, _, _, err := client.Parse(b, "", new(yaml.Template))
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}
@@ -343,7 +343,7 @@ func TestNative_Parse_StagesPipeline(t *testing.T) {
 		t.Errorf("Reading file returned err: %v", err)
 	}
 
-	got, _, err := client.Parse(b, "", new(yaml.Template))
+	got, _, _, err := client.Parse(b, "", new(yaml.Template))
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}
@@ -446,7 +446,7 @@ func TestNative_Parse_StepsPipeline(t *testing.T) {
 		t.Errorf("Reading file returned err: %v", err)
 	}
 
-	got, _, err := client.Parse(b, "", new(yaml.Template))
+	got, _, _, err := client.Parse(b, "", new(yaml.Template))
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}
@@ -516,7 +516,7 @@ func TestNative_Parse_Secrets(t *testing.T) {
 		t.Errorf("Reading file returned err: %v", err)
 	}
 
-	got, _, err := client.Parse(b, "", new(yaml.Template))
+	got, _, _, err := client.Parse(b, "", new(yaml.Template))
 
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
@@ -593,7 +593,7 @@ func TestNative_Parse_Stages(t *testing.T) {
 		t.Errorf("Reading file returned err: %v", err)
 	}
 
-	got, _, err := client.Parse(b, "", new(yaml.Template))
+	got, _, _, err := client.Parse(b, "", new(yaml.Template))
 
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
@@ -671,7 +671,7 @@ func TestNative_Parse_StagesLegacyMergeAnchor(t *testing.T) {
 		t.Errorf("Reading file returned err: %v", err)
 	}
 
-	got, _, err := client.Parse(b, "", new(yaml.Template))
+	got, _, _, err := client.Parse(b, "", new(yaml.Template))
 
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
@@ -730,7 +730,7 @@ func TestNative_Parse_Steps(t *testing.T) {
 		t.Errorf("Reading file returned err: %v", err)
 	}
 
-	got, _, err := client.Parse(b, "", new(yaml.Template))
+	got, _, _, err := client.Parse(b, "", new(yaml.Template))
 
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
@@ -759,7 +759,7 @@ func TestNative_ParseBytes_Metadata(t *testing.T) {
 		t.Errorf("Reading file returned err: %v", err)
 	}
 
-	got, _, err := ParseBytes(b)
+	got, _, _, err := ParseBytes(b)
 
 	if err != nil {
 		t.Errorf("ParseBytes returned err: %v", err)
@@ -777,7 +777,7 @@ func TestNative_ParseBytes_Invalid(t *testing.T) {
 		t.Errorf("Reading file returned err: %v", err)
 	}
 
-	got, _, err := ParseBytes(b)
+	got, _, _, err := ParseBytes(b)
 
 	if err == nil {
 		t.Error("ParseBytes should have returned err")
@@ -808,7 +808,7 @@ func TestNative_ParseFile_Metadata(t *testing.T) {
 
 	defer f.Close()
 
-	got, _, err := ParseFile(f)
+	got, _, _, err := ParseFile(f)
 
 	if err != nil {
 		t.Errorf("ParseFile returned err: %v", err)
@@ -828,7 +828,7 @@ func TestNative_ParseFile_Invalid(t *testing.T) {
 
 	f.Close()
 
-	got, _, err := ParseFile(f)
+	got, _, _, err := ParseFile(f)
 
 	if err == nil {
 		t.Error("ParseFile should have returned err")
@@ -852,7 +852,7 @@ func TestNative_ParsePath_Metadata(t *testing.T) {
 	}
 
 	// run test
-	got, _, err := ParsePath("testdata/metadata.yml")
+	got, _, _, err := ParsePath("testdata/metadata.yml")
 
 	if err != nil {
 		t.Errorf("ParsePath returned err: %v", err)
@@ -865,7 +865,7 @@ func TestNative_ParsePath_Metadata(t *testing.T) {
 
 func TestNative_ParsePath_Invalid(t *testing.T) {
 	// run test
-	got, _, err := ParsePath("testdata/foobar.yml")
+	got, _, _, err := ParsePath("testdata/foobar.yml")
 
 	if err == nil {
 		t.Error("ParsePath should have returned err")
@@ -894,7 +894,7 @@ func TestNative_ParseReader_Metadata(t *testing.T) {
 		t.Errorf("Reading file returned err: %v", err)
 	}
 
-	got, _, err := ParseReader(bytes.NewReader(b))
+	got, _, _, err := ParseReader(bytes.NewReader(b))
 
 	if err != nil {
 		t.Errorf("ParseReader returned err: %v", err)
@@ -907,7 +907,7 @@ func TestNative_ParseReader_Metadata(t *testing.T) {
 
 func TestNative_ParseReader_Invalid(t *testing.T) {
 	// run test
-	got, _, err := ParseReader(FailReader{})
+	got, _, _, err := ParseReader(FailReader{})
 
 	if err == nil {
 		t.Error("ParseFile should have returned err")
@@ -936,7 +936,7 @@ func TestNative_ParseString_Metadata(t *testing.T) {
 		t.Errorf("Reading file returned err: %v", err)
 	}
 
-	got, _, err := ParseString(string(b))
+	got, _, _, err := ParseString(string(b))
 
 	if err != nil {
 		t.Errorf("ParseString returned err: %v", err)
@@ -1012,7 +1012,7 @@ func Test_client_Parse(t *testing.T) {
 				}
 			}
 
-			got, _, err := c.Parse(content, tt.args.pipelineType, new(yaml.Template))
+			got, _, _, err := c.Parse(content, tt.args.pipelineType, new(yaml.Template))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/compiler/template/native/render_test.go
+++ b/compiler/template/native/render_test.go
@@ -59,7 +59,7 @@ func TestNative_Render(t *testing.T) {
 				t.Error(err)
 			}
 
-			tmplBuild, err := Render(string(tmpl), b.Steps[0].Name, b.Steps[0].Template.Name, b.Steps[0].Environment, b.Steps[0].Template.Variables)
+			tmplBuild, _, err := Render(string(tmpl), b.Steps[0].Name, b.Steps[0].Template.Name, b.Steps[0].Environment, b.Steps[0].Template.Variables)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Render() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -120,7 +120,7 @@ func TestNative_RenderBuild(t *testing.T) {
 				t.Error(err)
 			}
 
-			got, err := RenderBuild("build", string(sFile), map[string]string{
+			got, _, err := RenderBuild("build", string(sFile), map[string]string{
 				"VELA_REPO_FULL_NAME": "octocat/hello-world",
 				"VELA_BUILD_BRANCH":   "main",
 			}, map[string]interface{}{})

--- a/compiler/template/starlark/render_test.go
+++ b/compiler/template/starlark/render_test.go
@@ -92,7 +92,7 @@ func TestStarlark_Render(t *testing.T) {
 				t.Error(err)
 			}
 
-			tmplBuild, err := Render(string(tmpl), b.Steps[0].Name, b.Steps[0].Template.Name, b.Steps[0].Environment, b.Steps[0].Template.Variables, 7500)
+			tmplBuild, _, err := Render(string(tmpl), b.Steps[0].Name, b.Steps[0].Template.Name, b.Steps[0].Environment, b.Steps[0].Template.Variables, 7500)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Render() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -207,7 +207,7 @@ func TestNative_RenderBuild(t *testing.T) {
 				t.Error(err)
 			}
 
-			got, err := RenderBuild("build", string(sFile), map[string]string{
+			got, _, err := RenderBuild("build", string(sFile), map[string]string{
 				"VELA_REPO_FULL_NAME": "octocat/hello-world",
 				"VELA_BUILD_BRANCH":   "main",
 				"VELA_REPO_ORG":       "octocat",

--- a/constants/limit.go
+++ b/constants/limit.go
@@ -54,4 +54,7 @@ const (
 
 	// DashboardAdminMaxSize defines the maximum size in characters for dashboard admins.
 	DashboardAdminMaxSize = 5000
+
+	// PipelineWarningsMaxSize defines the maximum size in characters for the pipeline warnings.
+	PipelineWarningsMaxSize = 5000
 )

--- a/database/integration_test.go
+++ b/database/integration_test.go
@@ -2788,6 +2788,7 @@ func newResources() *Resources {
 	pipelineOne.SetStages(false)
 	pipelineOne.SetSteps(true)
 	pipelineOne.SetTemplates(false)
+	pipelineOne.SetWarnings([]string{})
 	pipelineOne.SetData([]byte("version: 1"))
 
 	pipelineTwo := new(api.Pipeline)
@@ -2805,6 +2806,7 @@ func newResources() *Resources {
 	pipelineTwo.SetStages(false)
 	pipelineTwo.SetSteps(true)
 	pipelineTwo.SetTemplates(false)
+	pipelineTwo.SetWarnings([]string{"42:this is a warning"})
 	pipelineTwo.SetData([]byte("version: 1"))
 
 	currTime := time.Now().UTC()

--- a/database/pipeline/create_test.go
+++ b/database/pipeline/create_test.go
@@ -34,9 +34,9 @@ func TestPipeline_Engine_CreatePipeline(t *testing.T) {
 
 	// ensure the mock expects the query
 	_mock.ExpectQuery(`INSERT INTO "pipelines"
-("repo_id","commit","flavor","platform","ref","type","version","external_secrets","internal_secrets","services","stages","steps","templates","data","id")
-VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) RETURNING "id"`).
-		WithArgs(1, "48afb5bdc41ad69bf22588491333f7cf71135163", nil, nil, "refs/heads/main", "yaml", "1", false, false, false, false, false, false, AnyArgument{}, 1).
+("repo_id","commit","flavor","platform","ref","type","version","external_secrets","internal_secrets","services","stages","steps","templates","warnings","data","id")
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16) RETURNING "id"`).
+		WithArgs(1, "48afb5bdc41ad69bf22588491333f7cf71135163", nil, nil, "refs/heads/main", "yaml", "1", false, false, false, false, false, false, nil, AnyArgument{}, 1).
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)

--- a/database/pipeline/table.go
+++ b/database/pipeline/table.go
@@ -28,6 +28,7 @@ pipelines (
 	stages           BOOLEAN,
 	steps            BOOLEAN,
 	templates        BOOLEAN,
+	warnings         VARCHAR(5000),
 	data             BYTEA,
 	UNIQUE(repo_id, commit)
 );
@@ -52,6 +53,7 @@ pipelines (
 	stages           BOOLEAN,
 	steps            BOOLEAN,
 	templates        BOOLEAN,
+	warnings         TEXT,
 	data             BLOB,
 	UNIQUE(repo_id, 'commit')
 );

--- a/database/pipeline/update_test.go
+++ b/database/pipeline/update_test.go
@@ -31,9 +31,9 @@ func TestPipeline_Engine_UpdatePipeline(t *testing.T) {
 
 	// ensure the mock expects the query
 	_mock.ExpectExec(`UPDATE "pipelines"
-SET "repo_id"=$1,"commit"=$2,"flavor"=$3,"platform"=$4,"ref"=$5,"type"=$6,"version"=$7,"external_secrets"=$8,"internal_secrets"=$9,"services"=$10,"stages"=$11,"steps"=$12,"templates"=$13,"data"=$14
-WHERE "id" = $15`).
-		WithArgs(1, "48afb5bdc41ad69bf22588491333f7cf71135163", nil, nil, "refs/heads/main", "yaml", "1", false, false, false, false, false, false, AnyArgument{}, 1).
+SET "repo_id"=$1,"commit"=$2,"flavor"=$3,"platform"=$4,"ref"=$5,"type"=$6,"version"=$7,"external_secrets"=$8,"internal_secrets"=$9,"services"=$10,"stages"=$11,"steps"=$12,"templates"=$13,"warnings"=$14,"data"=$15
+WHERE "id" = $16`).
+		WithArgs(1, "48afb5bdc41ad69bf22588491333f7cf71135163", nil, nil, "refs/heads/main", "yaml", "1", false, false, false, false, false, false, nil, AnyArgument{}, 1).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)

--- a/database/testutils/api_resources.go
+++ b/database/testutils/api_resources.go
@@ -270,6 +270,7 @@ func APIPipeline() *api.Pipeline {
 		Stages:          new(bool),
 		Steps:           new(bool),
 		Templates:       new(bool),
+		Warnings:        new([]string),
 		Data:            new([]byte),
 	}
 }

--- a/database/types/pipeline.go
+++ b/database/types/pipeline.go
@@ -202,13 +202,13 @@ func (p *Pipeline) Validate() error {
 		return ErrEmptyPipelineVersion
 	}
 
-	// calculate total size of favorites
+	// calculate total size of warnings
 	total := 0
 	for _, w := range p.Warnings {
 		total += len(w)
 	}
 
-	// verify the Favorites field is within the database constraints
+	// verify the Warnings field is within the database constraints
 	// len is to factor in number of comma separators included in the database field,
 	// removing 1 due to the last item not having an appended comma
 	if (total + len(p.Warnings) - 1) > constants.PipelineWarningsMaxSize {

--- a/database/types/pipeline.go
+++ b/database/types/pipeline.go
@@ -6,7 +6,10 @@ import (
 	"database/sql"
 	"errors"
 
+	"github.com/lib/pq"
+
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/util"
 )
 
@@ -30,6 +33,10 @@ var (
 	// ErrEmptyPipelineVersion defines the error type when a
 	// Pipeline type has an empty Version field provided.
 	ErrEmptyPipelineVersion = errors.New("empty pipeline version provided")
+
+	// ErrExceededWarningsLimit defines the error type when a
+	// Pipeline warnings field has too many total characters.
+	ErrExceededWarningsLimit = errors.New("exceeded character limit for pipeline warnings")
 )
 
 // Pipeline is the database representation of a pipeline.
@@ -48,6 +55,7 @@ type Pipeline struct {
 	Stages          sql.NullBool   `sql:"stages"`
 	Steps           sql.NullBool   `sql:"steps"`
 	Templates       sql.NullBool   `sql:"templates"`
+	Warnings        pq.StringArray `sql:"warnings"         gorm:"type:varchar(5000)"`
 	Data            []byte         `sql:"data"`
 
 	Repo Repo `gorm:"foreignKey:RepoID"`
@@ -160,6 +168,7 @@ func (p *Pipeline) ToAPI() *api.Pipeline {
 	pipeline.SetStages(p.Stages.Bool)
 	pipeline.SetSteps(p.Steps.Bool)
 	pipeline.SetTemplates(p.Templates.Bool)
+	pipeline.SetWarnings(p.Warnings)
 	pipeline.SetData(p.Data)
 
 	return pipeline
@@ -193,6 +202,19 @@ func (p *Pipeline) Validate() error {
 		return ErrEmptyPipelineVersion
 	}
 
+	// calculate total size of favorites
+	total := 0
+	for _, w := range p.Warnings {
+		total += len(w)
+	}
+
+	// verify the Favorites field is within the database constraints
+	// len is to factor in number of comma separators included in the database field,
+	// removing 1 due to the last item not having an appended comma
+	if (total + len(p.Warnings) - 1) > constants.PipelineWarningsMaxSize {
+		return ErrExceededWarningsLimit
+	}
+
 	// ensure that all Pipeline string fields
 	// that can be returned as JSON are sanitized
 	// to avoid unsafe HTML content
@@ -224,6 +246,7 @@ func PipelineFromAPI(p *api.Pipeline) *Pipeline {
 		Stages:          sql.NullBool{Bool: p.GetStages(), Valid: true},
 		Steps:           sql.NullBool{Bool: p.GetSteps(), Valid: true},
 		Templates:       sql.NullBool{Bool: p.GetTemplates(), Valid: true},
+		Warnings:        pq.StringArray(p.GetWarnings()),
 		Data:            p.GetData(),
 	}
 

--- a/database/types/pipeline_test.go
+++ b/database/types/pipeline_test.go
@@ -285,6 +285,7 @@ func TestDatabase_Pipeline_ToAPI(t *testing.T) {
 	want.SetStages(false)
 	want.SetSteps(true)
 	want.SetTemplates(false)
+	want.SetWarnings([]string{"42:this is a warning"})
 	want.SetData(testPipelineData())
 
 	// run test
@@ -393,6 +394,7 @@ func TestDatabase_PipelineFromAPI(t *testing.T) {
 		Stages:          sql.NullBool{Bool: false, Valid: true},
 		Steps:           sql.NullBool{Bool: true, Valid: true},
 		Templates:       sql.NullBool{Bool: false, Valid: true},
+		Warnings:        []string{"42:this is a warning"},
 		Data:            testPipelineData(),
 	}
 
@@ -412,6 +414,7 @@ func TestDatabase_PipelineFromAPI(t *testing.T) {
 	p.SetStages(false)
 	p.SetSteps(true)
 	p.SetTemplates(false)
+	p.SetWarnings([]string{"42:this is a warning"})
 	p.SetData(testPipelineData())
 
 	// run test
@@ -440,6 +443,7 @@ func testPipeline() *Pipeline {
 		Stages:          sql.NullBool{Bool: false, Valid: true},
 		Steps:           sql.NullBool{Bool: true, Valid: true},
 		Templates:       sql.NullBool{Bool: false, Valid: true},
+		Warnings:        []string{"42:this is a warning"},
 		Data:            testPipelineData(),
 
 		Repo: *testRepo(),

--- a/internal/yaml_test.go
+++ b/internal/yaml_test.go
@@ -4,6 +4,7 @@ package internal
 
 import (
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -35,30 +36,39 @@ func TestInternal_ParseYAML(t *testing.T) {
 
 	// set up tests
 	tests := []struct {
-		file    string
-		want    *yaml.Build
-		wantErr bool
+		name         string
+		file         string
+		wantBuild    *yaml.Build
+		wantWarnings []string
+		wantErr      bool
 	}{
 		{
-			file: "testdata/go-yaml.yml",
-			want: wantBuild,
+			name:      "go-yaml",
+			file:      "testdata/go-yaml.yml",
+			wantBuild: wantBuild,
 		},
 		{
-			file: "testdata/buildkite.yml",
-			want: wantBuild,
+			name:         "buildkite legacy",
+			file:         "testdata/buildkite.yml",
+			wantBuild:    wantBuild,
+			wantWarnings: []string{"using legacy version. Upgrade to go-yaml v3"},
 		},
 		{
-			file: "testdata/buildkite_new_version.yml",
-			want: wantBuild,
+			name:         "anchor collapse",
+			file:         "testdata/buildkite_new_version.yml",
+			wantBuild:    wantBuild,
+			wantWarnings: []string{"16:duplicate << keys in single YAML map"},
 		},
 		{
-			file: "testdata/no_version.yml",
-			want: wantBuild,
+			name:      "no version",
+			file:      "testdata/no_version.yml",
+			wantBuild: wantBuild,
 		},
 		{
-			file:    "testdata/invalid.yml",
-			want:    nil,
-			wantErr: true,
+			name:      "invalid yaml",
+			file:      "testdata/invalid.yml",
+			wantBuild: nil,
+			wantErr:   true,
 		},
 	}
 
@@ -66,16 +76,16 @@ func TestInternal_ParseYAML(t *testing.T) {
 	for _, test := range tests {
 		bytes, err := os.ReadFile(test.file)
 		if err != nil {
-			t.Errorf("unable to read file: %v", err)
+			t.Errorf("unable to read file for test %s: %v", test.name, err)
 		}
 
-		gotBuild, err := ParseYAML(bytes)
+		gotBuild, gotWarnings, err := ParseYAML(bytes)
 		if err != nil && !test.wantErr {
-			t.Errorf("ParseYAML returned err: %v", err)
+			t.Errorf("ParseYAML for test %s returned err: %v", test.name, err)
 		}
 
 		if err == nil && test.wantErr {
-			t.Errorf("ParseYAML returned nil error")
+			t.Errorf("ParseYAML for test %s returned nil error", test.name)
 		}
 
 		if err != nil && test.wantErr {
@@ -85,8 +95,12 @@ func TestInternal_ParseYAML(t *testing.T) {
 		// different versions expected
 		wantBuild.Version = gotBuild.Version
 
-		if diff := cmp.Diff(gotBuild, test.want); diff != "" {
-			t.Errorf("ParseYAML returned diff (-got +want):\n%s", diff)
+		if diff := cmp.Diff(gotBuild, test.wantBuild); diff != "" {
+			t.Errorf("ParseYAML for test %s returned diff (-got +want):\n%s", test.name, diff)
+		}
+
+		if !reflect.DeepEqual(gotWarnings, test.wantWarnings) {
+			t.Errorf("ParseYAML for test %s returned warnings %v, want %v", test.name, gotWarnings, test.wantWarnings)
 		}
 	}
 }

--- a/mock/server/pipeline.go
+++ b/mock/server/pipeline.go
@@ -169,6 +169,9 @@ templates:
   "stages": false,
   "steps": true,
   "templates": false,
+  "warnings": [
+    "42:this is a warning"
+  ],
   "data": "LS0tCnZlcnNpb246ICIxIgoKc3RlcHM6CiAgLSBuYW1lOiBlY2hvCiAgICBpbWFnZTogYWxwaW5lOmxhdGVzdAogICAgY29tbWFuZHM6IFtlY2hvIGZvb10="
 }`
 

--- a/router/middleware/pipeline/pipeline_test.go
+++ b/router/middleware/pipeline/pipeline_test.go
@@ -98,6 +98,7 @@ func TestPipeline_Establish(t *testing.T) {
 	want.SetStages(false)
 	want.SetSteps(false)
 	want.SetTemplates(false)
+	want.SetWarnings([]string{})
 	want.SetData([]byte{})
 
 	got := new(api.Pipeline)


### PR DESCRIPTION
Added `warnings` field to pipelines that will aggregate non-breaking but call-out worthy YAML transgressions.