### PR TITLE
feat: status endpoints

### DIFF
--- a/api/build/status.go
+++ b/api/build/status.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-vela/server/router/middleware/build"
 )
 
-// swagger:operation GET /status/{org}/{repo}/{build} builds GetStatus
+// swagger:operation GET /status/{org}/{repo}/{build} builds GetBuildStatus
 //
 // Get a build status
 //
@@ -54,8 +54,8 @@ import (
 //     schema:
 //       "$ref": "#/definitions/Build"
 
-// GetStatus represents the API handler to return "status", a lite representation of the resource with limited fields for unauthenticated access.
-func GetStatus(c *gin.Context) {
+// GetBuildStatus represents the API handler to return "status", a lite representation of the resource with limited fields for unauthenticated access.
+func GetBuildStatus(c *gin.Context) {
 	// capture middleware values
 	l := c.MustGet("logger").(*logrus.Entry)
 	b := build.Retrieve(c)

--- a/api/build/status.go
+++ b/api/build/status.go
@@ -61,5 +61,10 @@ func GetStatus(c *gin.Context) {
 
 	l.Debug("reading status for build")
 
+	// sanitize fields for the unauthenticated response
+	if b.Repo != nil {
+		b.Repo.StatusSanitize()
+	}
+
 	c.JSON(http.StatusOK, b)
 }

--- a/api/build/status.go
+++ b/api/build/status.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package build
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-vela/server/router/middleware/build"
+	"github.com/sirupsen/logrus"
+)
+
+// swagger:operation GET /status/{org}/{repo}/{build} builds GetStatus
+//
+// Get a build status
+//
+// ---
+// produces:
+// - application/json
+// parameters:
+// - in: path
+//   name: org
+//   description: Name of the organization
+//   required: true
+//   type: string
+// - in: path
+//   name: repo
+//   description: Name of the repository
+//   required: true
+//   type: string
+// - in: path
+//   name: build
+//   description: Build number
+//   required: true
+//   type: integer
+// security:
+//   - ApiKeyAuth: []
+// responses:
+//   '200':
+//     description: Successfully retrieved the build
+//     schema:
+//       "$ref": "#/definitions/Build"
+//   '400':
+//     description: Invalid request payload or path
+//     schema:
+//       "$ref": "#/definitions/Build"
+//   '401':
+//     description: Unauthorized
+//     schema:
+//       "$ref": "#/definitions/Build"
+//   '404':
+//     description: Not found
+//     schema:
+//       "$ref": "#/definitions/Build"
+
+// GetStatus represents the API handler to return "status", a lite representation of the resource with limited fields for unauthenticated access.
+func GetStatus(c *gin.Context) {
+	// capture middleware values
+	l := c.MustGet("logger").(*logrus.Entry)
+	b := build.Retrieve(c)
+
+	l.Debug("reading status for build")
+
+	c.JSON(http.StatusOK, b)
+}

--- a/api/build/status.go
+++ b/api/build/status.go
@@ -62,9 +62,7 @@ func GetStatus(c *gin.Context) {
 	l.Debug("reading status for build")
 
 	// sanitize fields for the unauthenticated response
-	if b.Repo != nil {
-		b.Repo.StatusSanitize()
-	}
+	b.StatusSanitize()
 
 	c.JSON(http.StatusOK, b)
 }

--- a/api/build/status.go
+++ b/api/build/status.go
@@ -6,8 +6,9 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/go-vela/server/router/middleware/build"
 	"github.com/sirupsen/logrus"
+
+	"github.com/go-vela/server/router/middleware/build"
 )
 
 // swagger:operation GET /status/{org}/{repo}/{build} builds GetStatus

--- a/api/repo/status.go
+++ b/api/repo/status.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package repo
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+
+	"github.com/go-vela/server/router/middleware/repo"
+)
+
+// swagger:operation GET /status/{org}/{repo} repos GetStatus
+//
+// Get a repository status
+//
+// ---
+// produces:
+// - application/json
+// parameters:
+// - in: path
+//   name: org
+//   description: Name of the organization
+//   required: true
+//   type: string
+// - in: path
+//   name: repo
+//   description: Name of the repository
+//   required: true
+//   type: string
+// security:
+//   - ApiKeyAuth: []
+// responses:
+//   '200':
+//     description: Successfully retrieved the repo
+//     schema:
+//       "$ref": "#/definitions/Repo"
+//   '400':
+//     description: Invalid request payload or path
+//     schema:
+//       "$ref": "#/definitions/Repo"
+//   '401':
+//     description: Unauthorized
+//     schema:
+//       "$ref": "#/definitions/Repo"
+//   '404':
+//     description: Not found
+//     schema:
+//       "$ref": "#/definitions/Repo"
+
+// GetStatus represents the API handler to return "status", a lite representation of the resource with limited fields for unauthenticated access.
+func GetStatus(c *gin.Context) {
+	// capture middleware values
+	l := c.MustGet("logger").(*logrus.Entry)
+	r := repo.Retrieve(c)
+
+	l.Debug("reading status for repo")
+
+	c.JSON(http.StatusOK, r)
+}

--- a/api/repo/status.go
+++ b/api/repo/status.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-vela/server/router/middleware/repo"
 )
 
-// swagger:operation GET /status/{org}/{repo} repos GetStatus
+// swagger:operation GET /status/{org}/{repo} repos GetRepoStatus
 //
 // Get a repository status
 //
@@ -49,8 +49,8 @@ import (
 //     schema:
 //       "$ref": "#/definitions/Repo"
 
-// GetStatus represents the API handler to return "status", a lite representation of the resource with limited fields for unauthenticated access.
-func GetStatus(c *gin.Context) {
+// GetRepoStatus represents the API handler to return "status", a lite representation of the resource with limited fields for unauthenticated access.
+func GetRepoStatus(c *gin.Context) {
 	// capture middleware values
 	l := c.MustGet("logger").(*logrus.Entry)
 	r := repo.Retrieve(c)

--- a/api/repo/status.go
+++ b/api/repo/status.go
@@ -57,5 +57,8 @@ func GetStatus(c *gin.Context) {
 
 	l.Debug("reading status for repo")
 
+	// sanitize fields for the unauthenticated response
+	r.StatusSanitize()
+
 	c.JSON(http.StatusOK, r)
 }

--- a/api/types/build.go
+++ b/api/types/build.go
@@ -1233,3 +1233,11 @@ func (b *Build) String() string {
 		b.GetTitle(),
 	)
 }
+
+// StatusSanitize removes sensitive information before producing a "status".
+func (b *Build) StatusSanitize() {
+	// sanitize repo
+	if b.Repo != nil {
+		b.Repo.StatusSanitize()
+	}
+}

--- a/api/types/build.go
+++ b/api/types/build.go
@@ -1240,4 +1240,7 @@ func (b *Build) StatusSanitize() {
 	if b.Repo != nil {
 		b.Repo.StatusSanitize()
 	}
+
+	b.Email = nil
+	b.DeployPayload = nil
 }

--- a/api/types/repo.go
+++ b/api/types/repo.go
@@ -723,3 +723,9 @@ func (r *Repo) String() string {
 		r.GetInstallID(),
 	)
 }
+
+// StatusSanitize removes sensitive information before producing a "status".
+func (r *Repo) StatusSanitize() {
+	// remove allowed events
+	r.AllowEvents = nil
+}

--- a/router/router.go
+++ b/router/router.go
@@ -68,8 +68,8 @@ func Load(options ...gin.HandlerFunc) *gin.Engine {
 	// Status endpoints
 	status := r.Group("/status/:org/:repo", org.Establish(), repo.Establish())
 	{
-		status.GET("", org.Establish(), repo.Establish(), apiRepo.GetStatus)
-		status.GET("/:build", org.Establish(), repo.Establish(), build.Establish(), apiBuild.GetStatus)
+		status.GET("", org.Establish(), repo.Establish(), apiRepo.GetRepoStatus)
+		status.GET("/:build", org.Establish(), repo.Establish(), build.Establish(), apiBuild.GetBuildStatus)
 	}
 
 	// Health endpoint

--- a/router/router.go
+++ b/router/router.go
@@ -34,8 +34,11 @@ import (
 
 	"github.com/go-vela/server/api"
 	"github.com/go-vela/server/api/auth"
+	apiBuild "github.com/go-vela/server/api/build"
+	apiRepo "github.com/go-vela/server/api/repo"
 	"github.com/go-vela/server/api/webhook"
 	"github.com/go-vela/server/router/middleware"
+	"github.com/go-vela/server/router/middleware/build"
 	"github.com/go-vela/server/router/middleware/claims"
 	"github.com/go-vela/server/router/middleware/org"
 	"github.com/go-vela/server/router/middleware/repo"
@@ -61,6 +64,13 @@ func Load(options ...gin.HandlerFunc) *gin.Engine {
 
 	// Badge endpoint
 	r.GET("/badge/:org/:repo/status.svg", org.Establish(), repo.Establish(), api.GetBadge)
+
+	// Status endpoints
+	status := r.Group("/status/:org/:repo", org.Establish(), repo.Establish())
+	{
+		status.GET("", org.Establish(), repo.Establish(), apiRepo.GetStatus)
+		status.GET("/:build", org.Establish(), repo.Establish(), build.Establish(), apiBuild.GetStatus)
+	}
 
 	// Health endpoint
 	r.GET("/health", api.Health)


### PR DESCRIPTION
implements https://github.com/go-vela/community/issues/749 in a way that doesnt impact current status svg responses.

instead, two new endpoints to get unauthenticated access to "lite" versions of repo and builds.

### Concerns
- potential impact to the database from unauthenticated and untrackable spam. but... this is not a new problem. could easily do it elsewhere (dashboards, pat auth, etc) if you were determined, but still.
- the `/badge` endpoint for "private repos" have never been protected, but this is obviously opening the door much wider.