### PR TITLE
fix(build): use item build host

### DIFF
--- a/api/build/restart.go
+++ b/api/build/restart.go
@@ -170,7 +170,7 @@ func RestartBuild(c *gin.Context) {
 			queue.FromGinContext(c),
 			database.FromContext(c),
 			item,
-			b.GetHost(),
+			item.Build.GetHost(),
 		)
 	} else {
 		err := GatekeepBuild(c, b, r)


### PR DESCRIPTION
Copy paste error when using `Enqueue` for restart.

Source: https://github.com/go-vela/server/pull/1227