### PR TITLE
fix(build): ensure count/pagination links account for filter/query params

### DIFF
--- a/api/build/compile_publish.go
+++ b/api/build/compile_publish.go
@@ -119,7 +119,7 @@ func CompileAndPublish(
 	}
 
 	// send API call to capture the number of pending or running builds for the repo
-	builds, err := database.CountBuildsForRepo(ctx, r, filters)
+	builds, err := database.CountBuildsForRepo(ctx, r, filters, time.Now().Unix(), 0)
 	if err != nil {
 		retErr := fmt.Errorf("%s: unable to get count of builds for repo %s", baseErr, r.GetFullName())
 

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -30,6 +30,7 @@ func (p *Pagination) SetHeaderLink(c *gin.Context) {
 	l := []string{}
 	r := c.Request
 
+	// grab the current query params
 	q := r.URL.Query()
 
 	hl := HeaderLink{
@@ -48,6 +49,7 @@ func (p *Pagination) SetHeaderLink(c *gin.Context) {
 	q.Del("page")
 	q.Del("per_page")
 
+	// reset per config
 	q.Set("per_page", strconv.Itoa(p.PerPage))
 
 	// drop first, prev on the first page

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -45,10 +45,6 @@ func (p *Pagination) SetHeaderLink(c *gin.Context) {
 		return
 	}
 
-	// delete existing paging information
-	q.Del("page")
-	q.Del("per_page")
-
 	// reset per config
 	q.Set("per_page", strconv.Itoa(p.PerPage))
 

--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -785,7 +785,7 @@ func RenameRepository(ctx context.Context, l *logrus.Entry, db database.Interfac
 	}
 
 	// get total number of builds associated with repository
-	t, err = db.CountBuildsForRepo(ctx, dbR, nil)
+	t, err = db.CountBuildsForRepo(ctx, dbR, nil, time.Now().Unix(), 0)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get build count for repo %s: %w", dbR.GetFullName(), err)
 	}

--- a/database/build/count_repo.go
+++ b/database/build/count_repo.go
@@ -12,7 +12,7 @@ import (
 )
 
 // CountBuildsForRepo gets the count of builds by repo ID from the database.
-func (e *engine) CountBuildsForRepo(ctx context.Context, r *api.Repo, filters map[string]interface{}) (int64, error) {
+func (e *engine) CountBuildsForRepo(ctx context.Context, r *api.Repo, filters map[string]interface{}, before, after int64) (int64, error) {
 	e.logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),
@@ -26,6 +26,8 @@ func (e *engine) CountBuildsForRepo(ctx context.Context, r *api.Repo, filters ma
 		WithContext(ctx).
 		Table(constants.TableBuild).
 		Where("repo_id = ?", r.GetID()).
+		Where("created < ?", before).
+		Where("created > ?", after).
 		Where(filters).
 		Count(&b).
 		Error

--- a/database/build/interface.go
+++ b/database/build/interface.go
@@ -35,7 +35,7 @@ type BuildInterface interface {
 	// CountBuildsForOrg defines a function that gets the count of builds by org name.
 	CountBuildsForOrg(context.Context, string, map[string]interface{}) (int64, error)
 	// CountBuildsForRepo defines a function that gets the count of builds by repo ID.
-	CountBuildsForRepo(context.Context, *api.Repo, map[string]interface{}) (int64, error)
+	CountBuildsForRepo(context.Context, *api.Repo, map[string]interface{}, int64, int64) (int64, error)
 	// CountBuildsForStatus defines a function that gets the count of builds by status.
 	CountBuildsForStatus(context.Context, string, map[string]interface{}) (int64, error)
 	// CreateBuild defines a function that creates a new build.

--- a/database/build/list_repo.go
+++ b/database/build/list_repo.go
@@ -27,7 +27,7 @@ func (e *engine) ListBuildsForRepo(ctx context.Context, r *api.Repo, filters map
 	builds := []*api.Build{}
 
 	// count the results
-	count, err := e.CountBuildsForRepo(ctx, r, filters)
+	count, err := e.CountBuildsForRepo(ctx, r, filters, before, after)
 	if err != nil {
 		return builds, 0, err
 	}

--- a/database/build/list_repo_test.go
+++ b/database/build/list_repo_test.go
@@ -55,7 +55,7 @@ func TestBuild_Engine_ListBuildsForRepo(t *testing.T) {
 	_rows := sqlmock.NewRows([]string{"count"}).AddRow(2)
 
 	// ensure the mock expects the count query
-	_mock.ExpectQuery(`SELECT count(*) FROM "builds" WHERE repo_id = $1`).WithArgs(1).WillReturnRows(_rows)
+	_mock.ExpectQuery(`SELECT count(*) FROM "builds" WHERE repo_id = $1 AND created < $2 AND created > $3`).WithArgs(1, AnyArgument{}, 0).WillReturnRows(_rows)
 
 	// create expected query result in mock
 	_rows = sqlmock.NewRows(

--- a/database/integration_test.go
+++ b/database/integration_test.go
@@ -258,7 +258,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	methods["CountBuildsForOrg"] = true
 
 	// count the builds for a repo
-	count, err = db.CountBuildsForRepo(context.TODO(), resources.Repos[0], nil)
+	count, err = db.CountBuildsForRepo(context.TODO(), resources.Repos[0], nil, time.Now().Unix(), 0)
 	if err != nil {
 		t.Errorf("unable to count builds for repo %d: %v", resources.Repos[0].GetID(), err)
 	}


### PR DESCRIPTION
for listing builds, the previous implementation did a count, but always returned the total count while excluding after/before query params (but honoring other filters, if present). this resulted in incorrect header links. the header links pointing at subsequent pages also didn't honor existing query params, so if you followed the links you could end up with different results.