### PR TITLE
fix(api/docs): undo deprecation

### DIFF
--- a/api/log/update_service.go
+++ b/api/log/update_service.go
@@ -22,7 +22,6 @@ import (
 // Update service logs for a build
 //
 // ---
-// deprecated: true
 // produces:
 // - application/json
 // parameters:

--- a/api/log/update_step.go
+++ b/api/log/update_step.go
@@ -22,7 +22,6 @@ import (
 // Update step logs for a build
 //
 // ---
-// deprecated: true
 // produces:
 // - application/json
 // parameters:


### PR DESCRIPTION
undo marking log update endpoints as deprecated. they are very much in use.

other endpoints marked as deprecated are creating step/service logs (POST requests). i believe those are truly deprecated and probably up for removal.