### PR TITLE
fix(compiler): bust template cache on Duplicate

### DIFF
--- a/compiler/native/native.go
+++ b/compiler/native/native.go
@@ -140,7 +140,7 @@ func (c *client) Duplicate() compiler.Engine {
 	cc.CloneImage = c.CloneImage
 	cc.TemplateDepth = c.TemplateDepth
 	cc.StarlarkExecLimit = c.StarlarkExecLimit
-	cc.TemplateCache = c.TemplateCache
+	cc.TemplateCache = make(map[string][]byte)
 
 	return cc
 }


### PR DESCRIPTION
When we don't set this to an empty map, it'll use old sources of templates 