### PR TITLE
fix(compiler): treat top level anchors like nested anchors

### DIFF
--- a/internal/testdata/buildkite.yml
+++ b/internal/testdata/buildkite.yml
@@ -6,13 +6,13 @@ aliases:
       image: alpine:latest
 
   env:
-    dev-env: &dev-environment
-      environment:
+    dev-env: &dev-parameters
+      parameters:
         REGION: dev 
 
 steps:
   - name: example
     <<: *alpine-image
-    <<: *dev-environment
+    <<: *dev-parameters
     commands:
       - echo $REGION

--- a/internal/testdata/buildkite_new_version.yml
+++ b/internal/testdata/buildkite_new_version.yml
@@ -6,13 +6,13 @@ aliases:
       image: alpine:latest
 
   env:
-    dev-env: &dev-environment
-      environment:
+    dev-env: &dev-parameters
+      parameters:
         REGION: dev 
 
 steps:
   - name: example
     <<: *alpine-image
-    <<: *dev-environment
+    <<: *dev-parameters
     commands:
       - echo $REGION

--- a/internal/testdata/go-yaml.yml
+++ b/internal/testdata/go-yaml.yml
@@ -6,14 +6,14 @@ aliases:
       image: alpine:latest
 
   env:
-    dev-env: &dev-environment
-      environment:
+    dev-env: &dev-parameters
+      parameters:
         REGION: dev 
 
 steps:
   - name: example
     <<:
       - *alpine-image
-      - *dev-environment
+      - *dev-parameters
     commands:
       - echo $REGION

--- a/internal/testdata/top_level_anchor.yml
+++ b/internal/testdata/top_level_anchor.yml
@@ -1,10 +1,9 @@
-aliases:
-  images:
-    alpine: &alpine-image
+version: "1"
+
+<<: &alpine-image
       image: alpine:latest
 
-  env:
-    dev-env: &dev-parameters
+<<: &dev-parameters
       parameters:
         REGION: dev 
 

--- a/internal/testdata/top_level_anchor_legacy.yml
+++ b/internal/testdata/top_level_anchor_legacy.yml
@@ -1,10 +1,9 @@
-aliases:
-  images:
-    alpine: &alpine-image
+version: "legacy"
+
+<<: &alpine-image
       image: alpine:latest
 
-  env:
-    dev-env: &dev-parameters
+<<: &dev-parameters
       parameters:
         REGION: dev 
 

--- a/internal/yaml.go
+++ b/internal/yaml.go
@@ -105,8 +105,8 @@ func collapseMergeAnchors(node *yaml.Node, warnings []string) []string {
 			keyNode := node.Content[i]
 
 			// anchor found
-			if keyNode.Value == "<<" {
-				if (i+1) < len(node.Content) && node.Content[i+1].Kind == yaml.AliasNode {
+			if keyNode.Tag == "!!merge" && keyNode.Value == "<<" {
+				if (i + 1) < len(node.Content) {
 					anchors = append(anchors, node.Content[i+1])
 				}
 

--- a/internal/yaml_test.go
+++ b/internal/yaml_test.go
@@ -23,7 +23,7 @@ func TestInternal_ParseYAML(t *testing.T) {
 			&yaml.Step{
 				Name:  "example",
 				Image: "alpine:latest",
-				Environment: map[string]string{
+				Parameters: map[string]interface{}{
 					"REGION": "dev",
 				},
 				Pull: "not_present",
@@ -46,6 +46,18 @@ func TestInternal_ParseYAML(t *testing.T) {
 			name:      "go-yaml",
 			file:      "testdata/go-yaml.yml",
 			wantBuild: wantBuild,
+		},
+		{
+			name:         "top level anchors",
+			file:         "testdata/top_level_anchor.yml",
+			wantBuild:    wantBuild,
+			wantWarnings: []string{`6:duplicate << keys in single YAML map`},
+		},
+		{
+			name:         "top level anchors legacy",
+			file:         "testdata/top_level_anchor_legacy.yml",
+			wantBuild:    wantBuild,
+			wantWarnings: []string{`using legacy version - address any incompatibilities and use "1" instead`},
 		},
 		{
 			name:         "buildkite legacy",


### PR DESCRIPTION
```yaml
version: "1"

<<: &alpine-image
      image: alpine:latest

<<: &dev-parameters
      parameters:
        REGION: dev 

steps:
  - name: example
    <<:
      - *alpine-image
      - *dev-parameters
    commands:
      - echo $REGION
```

the above was not honoring our `collapseMergeAnchors` function because the value was not an `alias node`. Now it will. 