### PR TITLE
fix(yaml): bubble up rules struct unmarshal errors

### DIFF
--- a/compiler/types/yaml/yaml/ruleset.go
+++ b/compiler/types/yaml/yaml/ruleset.go
@@ -67,11 +67,15 @@ func (r *Ruleset) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	})
 
 	// attempt to unmarshal simple ruleset
-	//nolint:errcheck // intentionally not handling error
-	unmarshal(simple)
+	err := unmarshal(simple)
+	if err != nil {
+		return err
+	}
 	// attempt to unmarshal advanced ruleset
-	//nolint:errcheck // intentionally not handling error
-	unmarshal(advanced)
+	err = unmarshal(advanced)
+	if err != nil {
+		return err
+	}
 
 	// set ruleset `unless` to advanced `unless` rules
 	r.Unless = advanced.Unless

--- a/compiler/types/yaml/yaml/ruleset_test.go
+++ b/compiler/types/yaml/yaml/ruleset_test.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/go-vela/server/compiler/types/pipeline"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestYaml_Ruleset_ToPipeline(t *testing.T) {
@@ -95,8 +96,9 @@ func TestYaml_Ruleset_ToPipeline(t *testing.T) {
 func TestYaml_Ruleset_UnmarshalYAML(t *testing.T) {
 	// setup tests
 	tests := []struct {
-		file string
-		want *Ruleset
+		file    string
+		want    *Ruleset
+		wantErr bool
 	}{
 		{
 			file: "testdata/ruleset_simple.yml",
@@ -148,6 +150,27 @@ func TestYaml_Ruleset_UnmarshalYAML(t *testing.T) {
 				Matcher:  "regex",
 			},
 		},
+		{
+			file: "testdata/ruleset_unknown_field.yml",
+			want: &Ruleset{
+				If: Rules{
+					Branch: []string{"main"},
+					Event:  []string{"push"},
+				},
+				Matcher:  "filepath",
+				Operator: "and",
+			},
+		},
+		{
+			file:    "testdata/ruleset_collide.yml",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			file:    "testdata/ruleset_collide_adv.yml",
+			want:    nil,
+			wantErr: true,
+		},
 	}
 
 	// run tests
@@ -161,12 +184,20 @@ func TestYaml_Ruleset_UnmarshalYAML(t *testing.T) {
 
 		err = yaml.Unmarshal(b, got)
 
+		if test.wantErr {
+			if err == nil {
+				t.Errorf("UnmarshalYAML should have returned err")
+			}
+
+			continue
+		}
+
 		if err != nil {
 			t.Errorf("UnmarshalYAML returned err: %v", err)
 		}
 
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("UnmarshalYAML is %v, want %v", got, test.want)
+		if diff := cmp.Diff(got, test.want); diff != "" {
+			t.Errorf("UnmarshalYAML mismatch (-got +want):\n%s", diff)
 		}
 	}
 }
@@ -246,6 +277,11 @@ func TestYaml_Rules_UnmarshalYAML(t *testing.T) {
 				Tag:      []string{"v0.1.0"},
 				Target:   []string{"production"},
 			},
+		},
+		{
+			failure: true,
+			file:    "testdata/ruleset_collide.yml",
+			want:    nil,
 		},
 		{
 			failure: true,

--- a/compiler/types/yaml/yaml/testdata/ruleset_collide.yml
+++ b/compiler/types/yaml/yaml/testdata/ruleset_collide.yml
@@ -1,0 +1,4 @@
+---
+branch: main
+branch:
+event: push

--- a/compiler/types/yaml/yaml/testdata/ruleset_collide_adv.yml
+++ b/compiler/types/yaml/yaml/testdata/ruleset_collide_adv.yml
@@ -1,0 +1,8 @@
+---
+if:
+  event: push
+  branch: main
+  event:
+unless:
+  tag: v3*
+  matcher: filepath

--- a/compiler/types/yaml/yaml/testdata/ruleset_unknown_field.yml
+++ b/compiler/types/yaml/yaml/testdata/ruleset_unknown_field.yml
@@ -1,0 +1,4 @@
+---
+event: push
+branch: main
+user: octocat


### PR DESCRIPTION
It looks like these two unchecked `unmarshal` calls were part of the [initial go-vela/types commit](https://github.com/go-vela/types/blame/main/yaml/ruleset.go), so I am not sure if there is some extra backstory here that I'm missing. However, it would be nice to bubble up errors here, since suppressing them just returns an empty rules block which gets converted to no rules.

```yaml
ruleset:
  branch:
  event: push
  branch: main
```
converts to -->

Before:
```yaml
ruleset:
  operator: and
  matcher: filepath
```

After:
```
error: "mapping key \"branch\" already defined"
```

FWIW, the unmarshaler is not strict on fields, so this won't break pipelines that are using unknown fields (threw in a test just to confirm).