### PR TITLE
fix(compiler): validate step naming conflicts

### DIFF
--- a/compiler/native/validate.go
+++ b/compiler/native/validate.go
@@ -85,6 +85,8 @@ func validateServices(s yaml.ServiceSlice) error {
 // validateStages is a helper function that verifies the
 // stages block in the yaml configuration is valid.
 func validateStages(s yaml.StageSlice) error {
+	nameMap := make(map[string]bool)
+
 	for _, stage := range s {
 		if len(stage.Name) == 0 {
 			return fmt.Errorf("no name provided for stage")
@@ -109,6 +111,12 @@ func validateStages(s yaml.StageSlice) error {
 			if step.Name == "clone" || step.Name == "init" {
 				continue
 			}
+
+			if _, ok := nameMap[stage.Name+"_"+step.Name]; ok {
+				return fmt.Errorf("step %s for stage %s is already defined", step.Name, stage.Name)
+			}
+
+			nameMap[stage.Name+"_"+step.Name] = true
 
 			if len(step.Commands) == 0 && len(step.Environment) == 0 &&
 				len(step.Parameters) == 0 && len(step.Secrets) == 0 &&

--- a/compiler/native/validate_test.go
+++ b/compiler/native/validate_test.go
@@ -389,6 +389,53 @@ func TestNative_Validate_Stages_NoCommands(t *testing.T) {
 	}
 }
 
+func TestNative_Validate_Stages_StepNameConflict(t *testing.T) {
+	// setup types
+	set := flag.NewFlagSet("test", 0)
+	set.String("clone-image", defaultCloneImage, "doc")
+	c := cli.NewContext(nil, set, nil)
+
+	str := "foo"
+	p := &yaml.Build{
+		Version: "v1",
+		Stages: yaml.StageSlice{
+			&yaml.Stage{
+				Name: str,
+				Steps: yaml.StepSlice{
+					&yaml.Step{
+						Commands: raw.StringSlice{"echo hello"},
+						Image:    "alpine",
+						Name:     str,
+						Pull:     "always",
+					},
+				},
+			},
+			&yaml.Stage{
+				Name: str,
+				Steps: yaml.StepSlice{
+					&yaml.Step{
+						Commands: raw.StringSlice{"echo hello"},
+						Image:    "alpine",
+						Name:     str,
+						Pull:     "always",
+					},
+				},
+			},
+		},
+	}
+
+	// run test
+	compiler, err := FromCLIContext(c)
+	if err != nil {
+		t.Errorf("Unable to create new compiler: %v", err)
+	}
+
+	err = compiler.Validate(p)
+	if err == nil {
+		t.Errorf("Validate should have returned err")
+	}
+}
+
 func TestNative_Validate_Stages_NeedsSelfReference(t *testing.T) {
 	// setup types
 	set := flag.NewFlagSet("test", 0)
@@ -469,6 +516,36 @@ func TestNative_Validate_Steps_NoName(t *testing.T) {
 			&yaml.Step{
 				Commands: raw.StringSlice{"echo hello"},
 				Name:     "",
+				Pull:     "always",
+			},
+		},
+	}
+
+	// run test
+	compiler, err := FromCLIContext(c)
+	if err != nil {
+		t.Errorf("Unable to create new compiler: %v", err)
+	}
+
+	err = compiler.Validate(p)
+	if err == nil {
+		t.Errorf("Validate should have returned err")
+	}
+}
+
+func TestNative_Validate_Steps_NameCollision(t *testing.T) {
+	// setup types
+	set := flag.NewFlagSet("test", 0)
+	set.String("clone-image", defaultCloneImage, "doc")
+	c := cli.NewContext(nil, set, nil)
+
+	str := "foo"
+	p := &yaml.Build{
+		Version: "v1",
+		Steps: yaml.StepSlice{
+			&yaml.Step{
+				Commands: raw.StringSlice{"echo hello"},
+				Name:     str,
 				Pull:     "always",
 			},
 		},

--- a/compiler/native/validate_test.go
+++ b/compiler/native/validate_test.go
@@ -701,3 +701,40 @@ func TestNative_Validate_MultiReportAs(t *testing.T) {
 		t.Errorf("Validate should have returned err")
 	}
 }
+
+func TestNative_Validate_Steps_StepNameConflict(t *testing.T) {
+	// setup types
+	set := flag.NewFlagSet("test", 0)
+	set.String("clone-image", defaultCloneImage, "doc")
+	c := cli.NewContext(nil, set, nil)
+
+	str := "foo"
+	p := &yaml.Build{
+		Version: "v1",
+		Steps: yaml.StepSlice{
+			&yaml.Step{
+				Commands: raw.StringSlice{"echo hello"},
+				Image:    "alpine",
+				Name:     str,
+				Pull:     "always",
+			},
+			&yaml.Step{
+				Commands: raw.StringSlice{"echo goodbye"},
+				Image:    "alpine",
+				Name:     str,
+				Pull:     "always",
+			},
+		},
+	}
+
+	// run test
+	compiler, err := FromCLIContext(c)
+	if err != nil {
+		t.Errorf("Unable to create new compiler: %v", err)
+	}
+
+	err = compiler.Validate(p)
+	if err == nil {
+		t.Errorf("Validate should have returned err")
+	}
+}


### PR DESCRIPTION
Things only go bad when steps have the same name. I think it's best we handle this at compile time rather than pick up the pieces of daemon errors in worker code.