### PR TITLE
fix(deployment): validate inputs in a case-insensitive manner

### DIFF
--- a/compiler/types/pipeline/deployment.go
+++ b/compiler/types/pipeline/deployment.go
@@ -63,9 +63,9 @@ func (d *Deployment) Validate(target string, inputParams map[string]string) erro
 	}
 
 	// make lowercase key map for validation (it is all uppercase in the end but users can write YAML how they want)
-	standardizedInput := make(map[string]string)
-	for k := range inputParams {
-		standardizedInput[strings.ToLower(k)] = inputParams[k]
+	standardizedInput := make(map[string]string, len(inputParams))
+	for k, v := range inputParams {
+		standardizedInput[strings.ToLower(k)] = v
 	}
 
 	// validate params

--- a/compiler/types/pipeline/deployment.go
+++ b/compiler/types/pipeline/deployment.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"strings"
 )
 
 type (
@@ -61,21 +62,31 @@ func (d *Deployment) Validate(target string, inputParams map[string]string) erro
 		return fmt.Errorf("deployment target `%s` not found in deployment config targets", target)
 	}
 
+	// make lowercase key map for validation (it is all uppercase in the end but users can write YAML how they want)
+	standardizedInput := make(map[string]string)
+	for k := range inputParams {
+		standardizedInput[strings.ToLower(k)] = inputParams[k]
+	}
+
 	// validate params
 	for kConfig, vConfig := range d.Parameters {
 		var (
 			inputStr string
 			ok       bool
 		)
+
+		// lowercase config key to match input map
+		standardizedK := strings.ToLower(kConfig)
+
 		// check if the parameter is required
 		if vConfig.Required {
 			// check if the parameter is provided
-			if inputStr, ok = inputParams[kConfig]; !ok {
+			if inputStr, ok = standardizedInput[standardizedK]; !ok {
 				return fmt.Errorf("deployment parameter %s is required", kConfig)
 			}
 		} else {
 			// check if the parameter is provided
-			if inputStr, ok = inputParams[kConfig]; !ok {
+			if inputStr, ok = standardizedInput[standardizedK]; !ok {
 				continue
 			}
 		}

--- a/compiler/types/pipeline/deployment_test.go
+++ b/compiler/types/pipeline/deployment_test.go
@@ -171,6 +171,18 @@ func TestPipeline_Deployment_Validate(t *testing.T) {
 			deployConfig: fullDeployConfig,
 			wantErr:      false,
 		},
+		{ // correct target and params - strange casing
+			inputTarget: "north",
+			inputParams: map[string]string{
+				"ALPHA":   "bar",
+				"beta":    "bar",
+				"gAmMa":   "1",
+				"deltA":   "true",
+				"Epsilon": "42",
+			},
+			deployConfig: fullDeployConfig,
+			wantErr:      false,
+		},
 	}
 
 	// run tests


### PR DESCRIPTION
Given the following deployment config:
```yaml
deployment:
  parameters:
    region:
      description: cluster region to deploy
      required: true
      type: string
      options:
        - us-west-1
        - us-south-2
    
    cluster_count:
      description: number of clusters to deploy to
      required: false
      type: integer
      max: 10
```

A deployment triggered via CLI like this:
```sh
vela add deployment  --target here --parameter "region=us-west-1" --parameter "CLUSTER_COUNT=50"
```

Would pass validation, even though the parameter is injected as `DEPLOYMENT_PARAMETER_CLUSTER_COUNT` regardless of the casing when it's passed in.