### PR TITLE
chore(deps): upgrade go-github to v69

### DIFF
--- a/compiler/native/compile_test.go
+++ b/compiler/native/compile_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"github.com/urfave/cli/v2"
 	yml "gopkg.in/yaml.v3"
 

--- a/compiler/native/native_test.go
+++ b/compiler/native/native_test.go
@@ -21,9 +21,8 @@ func TestNative_New(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.String("clone-image", defaultCloneImage, "doc")
 	c := cli.NewContext(nil, set, nil)
-	public, _ := github.New(context.Background(), "", "")
+
 	want := &client{
-		Github:        public,
 		Compiler:      settings.CompilerMockEmpty(),
 		TemplateCache: make(map[string][]byte),
 	}
@@ -35,6 +34,12 @@ func TestNative_New(t *testing.T) {
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
+
+	if got.Github == nil {
+		t.Errorf("New returned nil Github client")
+	}
+
+	got.Github = nil
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("New is %v, want %v", got, want)
@@ -51,11 +56,8 @@ func TestNative_New_PrivateGithub(t *testing.T) {
 	set.String("github-token", token, "doc")
 	set.String("clone-image", defaultCloneImage, "doc")
 	c := cli.NewContext(nil, set, nil)
-	public, _ := github.New(context.Background(), "", "")
-	private, _ := github.New(context.Background(), url, token)
+
 	want := &client{
-		Github:           public,
-		PrivateGithub:    private,
 		UsePrivateGithub: true,
 		TemplateCache:    make(map[string][]byte),
 		Compiler:         settings.CompilerMockEmpty(),
@@ -68,6 +70,17 @@ func TestNative_New_PrivateGithub(t *testing.T) {
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
+
+	if got.Github == nil {
+		t.Errorf("New returned nil Github client")
+	}
+
+	if got.PrivateGithub == nil {
+		t.Errorf("New returned nil Private Github client")
+	}
+
+	got.Github = nil
+	got.PrivateGithub = nil
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("New is %v, want %v", got, want)
@@ -84,11 +97,8 @@ func TestNative_DuplicateRetainSettings(t *testing.T) {
 	set.String("github-token", token, "doc")
 	set.String("clone-image", defaultCloneImage, "doc")
 	c := cli.NewContext(nil, set, nil)
-	public, _ := github.New(context.Background(), "", "")
-	private, _ := github.New(context.Background(), url, token)
+
 	want := &client{
-		Github:           public,
-		PrivateGithub:    private,
 		UsePrivateGithub: true,
 		TemplateCache:    make(map[string][]byte),
 		Compiler:         settings.CompilerMockEmpty(),
@@ -101,6 +111,17 @@ func TestNative_DuplicateRetainSettings(t *testing.T) {
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
+
+	if got.Github == nil {
+		t.Errorf("New returned nil Github client")
+	}
+
+	if got.PrivateGithub == nil {
+		t.Errorf("New returned nil Private Github client")
+	}
+
+	got.Github = nil
+	got.PrivateGithub = nil
 
 	if !reflect.DeepEqual(got.Duplicate(), want) {
 		t.Errorf("New is %v, want %v", got, want)
@@ -123,6 +144,8 @@ func TestNative_DuplicateStripBuild(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unable to create new compiler: %v", err)
 	}
+
+	got.Github = want.Github
 
 	// modify engine with WithBuild and then call Duplicate
 	// to get a copy of the Engine without build attached.
@@ -149,6 +172,8 @@ func TestNative_WithBuild(t *testing.T) {
 		t.Errorf("Unable to create new compiler: %v", err)
 	}
 
+	got.Github = want.Github
+
 	if !reflect.DeepEqual(got.WithBuild(b), want) {
 		t.Errorf("WithBuild is %v, want %v", got, want)
 	}
@@ -171,6 +196,8 @@ func TestNative_WithFiles(t *testing.T) {
 		t.Errorf("Unable to create new compiler: %v", err)
 	}
 
+	got.Github = want.Github
+
 	if !reflect.DeepEqual(got.WithFiles(f), want) {
 		t.Errorf("WithFiles is %v, want %v", got, want)
 	}
@@ -191,6 +218,8 @@ func TestNative_WithComment(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unable to create new compiler: %v", err)
 	}
+
+	got.Github = want.Github
 
 	if !reflect.DeepEqual(got.WithComment(comment), want) {
 		t.Errorf("WithComment is %v, want %v", got, want)
@@ -213,6 +242,8 @@ func TestNative_WithLocal(t *testing.T) {
 		t.Errorf("Unable to create new compiler: %v", err)
 	}
 
+	got.Github = want.Github
+
 	if !reflect.DeepEqual(got.WithLocal(local), want) {
 		t.Errorf("WithLocal is %v, want %v", got, want)
 	}
@@ -233,6 +264,8 @@ func TestNative_WithLocalTemplates(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unable to create new compiler: %v", err)
 	}
+
+	got.Github = want.Github
 
 	if !reflect.DeepEqual(got.WithLocalTemplates(localTemplates), want) {
 		t.Errorf("WithLocalTemplates is %v, want %v", got, want)
@@ -274,6 +307,8 @@ func TestNative_WithMetadata(t *testing.T) {
 		t.Errorf("Unable to create new compiler: %v", err)
 	}
 
+	got.Github = want.Github
+
 	if !reflect.DeepEqual(got.WithMetadata(m), want) {
 		t.Errorf("WithMetadata is %v, want %v", got, want)
 	}
@@ -301,8 +336,13 @@ func TestNative_WithPrivateGitHub(t *testing.T) {
 		t.Errorf("Unable to create new compiler: %v", err)
 	}
 
-	if !reflect.DeepEqual(got.WithPrivateGitHub(context.Background(), url, token), want) {
-		t.Errorf("WithRepo is %v, want %v", got, want)
+	got.WithPrivateGitHub(context.Background(), url, token)
+
+	got.Github = want.Github
+	got.PrivateGithub = want.PrivateGithub
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("WithPrivateGitHub is %v, want %v", got, want)
 	}
 }
 
@@ -323,6 +363,8 @@ func TestNative_WithRepo(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unable to create new compiler: %v", err)
 	}
+
+	got.Github = want.Github
 
 	if !reflect.DeepEqual(got.WithRepo(r), want) {
 		t.Errorf("WithRepo is %v, want %v", got, want)
@@ -347,6 +389,8 @@ func TestNative_WithUser(t *testing.T) {
 		t.Errorf("Unable to create new compiler: %v", err)
 	}
 
+	got.Github = want.Github
+
 	if !reflect.DeepEqual(got.WithUser(u), want) {
 		t.Errorf("WithUser is %v, want %v", got, want)
 	}
@@ -367,6 +411,8 @@ func TestNative_WithLabels(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unable to create new compiler: %v", err)
 	}
+
+	got.Github = want.Github
 
 	if !reflect.DeepEqual(got.WithLabels(labels), want) {
 		t.Errorf("WithLocalTemplates is %v, want %v", got, want)

--- a/compiler/registry/github/github.go
+++ b/compiler/registry/github/github.go
@@ -5,9 +5,10 @@ package github
 import (
 	"context"
 	"net/url"
+	"reflect"
 	"strings"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"golang.org/x/oauth2"
 )
 
@@ -20,6 +21,10 @@ type client struct {
 	Github *github.Client
 	URL    string
 	API    string
+}
+
+func (c *client) Equal(other *client) bool {
+	return (reflect.DeepEqual(c.Github.Client(), other.Github.Client())) && c.URL == other.URL && c.API == other.API
 }
 
 // New returns a Registry implementation that integrates

--- a/compiler/registry/github/github_test.go
+++ b/compiler/registry/github/github_test.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"testing"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-github/v69/github"
 	"golang.org/x/oauth2"
 )
 
@@ -20,6 +20,7 @@ func TestGithub_New(t *testing.T) {
 	defer s.Close()
 
 	gitClient := github.NewClient(nil)
+
 	gitClient.BaseURL, _ = url.Parse(s.URL + "/api/v3/")
 
 	want := &client{
@@ -35,7 +36,7 @@ func TestGithub_New(t *testing.T) {
 		t.Errorf("New returned err: %v", err)
 	}
 
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Errorf("New is %v, want %v", got, want)
 	}
 }
@@ -66,8 +67,8 @@ func TestGithub_NewToken(t *testing.T) {
 		t.Errorf("New returned err: %v", err)
 	}
 
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("New is %+v, want %+v", got.Github, want.Github)
+	if !cmp.Equal(got, want) {
+		t.Errorf("New is %v, want %v", got, want)
 	}
 }
 

--- a/compiler/registry/github/template.go
+++ b/compiler/registry/github/template.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 
 	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/compiler/registry"

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/go-playground/assert/v2 v2.2.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/go-cmp v0.6.0
-	github.com/google/go-github/v68 v68.0.0
+	github.com/google/go-github/v69 v69.2.0
 	github.com/google/uuid v1.6.0
 	github.com/goware/urlx v0.3.2
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v68 v68.0.0 h1:ZW57zeNZiXTdQ16qrDiZ0k6XucrxZ2CGmoTvcCyQG6s=
-github.com/google/go-github/v68 v68.0.0/go.mod h1:K9HAUBovM2sLwM408A18h+wd9vqdLOEqTUCbnRIcx68=
+github.com/google/go-github/v69 v69.2.0 h1:wR+Wi/fN2zdUx9YxSmYE0ktiX9IAR/BeePzeaUUbEHE=
+github.com/google/go-github/v69 v69.2.0/go.mod h1:xne4jymxLR6Uj9b7J7PyTpkMYstEMMwGZa0Aehh1azM=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/router/middleware/compiler_test.go
+++ b/router/middleware/compiler_test.go
@@ -69,7 +69,7 @@ func TestMiddleware_CompilerNative(t *testing.T) {
 		t.Errorf("Compiler returned %v, want %v", resp.Code, http.StatusOK)
 	}
 
-	if !reflect.DeepEqual(got, want) {
+	if !reflect.DeepEqual(got.GetSettings(), want.GetSettings()) {
 		t.Errorf("Compiler is %v, want %v", got, want)
 	}
 }

--- a/scm/github/access.go
+++ b/scm/github/access.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"

--- a/scm/github/app_permissions.go
+++ b/scm/github/app_permissions.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 // see: https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28

--- a/scm/github/app_permissions_test.go
+++ b/scm/github/app_permissions_test.go
@@ -5,7 +5,7 @@ package github
 import (
 	"testing"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 )
 
 func TestGetInstallationPermission(t *testing.T) {

--- a/scm/github/app_transport.go
+++ b/scm/github/app_transport.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )

--- a/scm/github/authentication.go
+++ b/scm/github/authentication.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 
 	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/random"

--- a/scm/github/changeset.go
+++ b/scm/github/changeset.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"

--- a/scm/github/deployment.go
+++ b/scm/github/deployment.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"

--- a/scm/github/github.go
+++ b/scm/github/github.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 

--- a/scm/github/github_client.go
+++ b/scm/github/github_client.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/oauth2"

--- a/scm/github/github_client_test.go
+++ b/scm/github/github_client_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 
 	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/constants"

--- a/scm/github/github_test.go
+++ b/scm/github/github_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"golang.org/x/oauth2"
 )
 

--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"

--- a/scm/github/repo_test.go
+++ b/scm/github/repo_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 
 	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/compiler/types/yaml/yaml"

--- a/scm/github/webhook.go
+++ b/scm/github/webhook.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v68/github"
+	"github.com/google/go-github/v69/github"
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"


### PR DESCRIPTION
Because `go-github` changed the way `New` operates under the hood, we can no longer compare something like 

```go
a := github.New(...)
b := github.New(...)

reflect.DeepEqual(a,b)
```

So I had to tweak some tests to be less strict on this checking. I would have liked to use `cmp` throughout, but there are a lot of unexported fields in our compiler, and it would've been pretty cumbersome to write that test.