### PR TITLE
fix: support list of cors origins

### DIFF
--- a/cmd/vela-server/main.go
+++ b/cmd/vela-server/main.go
@@ -76,6 +76,11 @@ func main() {
 			Value:   "/account/authenticate",
 		},
 		&cli.StringFlag{
+			EnvVars: []string{"VELA_CORS_ALLOW_ORIGINS", "VELA_CORS_ALLOWED_ORIGINS"},
+			Name:    "cors-allow-origins",
+			Usage:   "list of origins a cross-domain request can be executed from",
+		},
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_SECRET"},
 			Name:    "vela-secret",
 			Usage:   "secret used for server <-> agent communication",

--- a/cmd/vela-server/main.go
+++ b/cmd/vela-server/main.go
@@ -75,7 +75,7 @@ func main() {
 			Usage:   "web ui oauth callback path",
 			Value:   "/account/authenticate",
 		},
-		&cli.StringFlag{
+		&cli.StringSliceFlag{
 			EnvVars: []string{"VELA_CORS_ALLOW_ORIGINS", "VELA_CORS_ALLOWED_ORIGINS"},
 			Name:    "cors-allow-origins",
 			Usage:   "list of origins a cross-domain request can be executed from",

--- a/cmd/vela-server/metadata.go
+++ b/cmd/vela-server/metadata.go
@@ -109,6 +109,10 @@ func metadataVela(c *cli.Context) (*internal.Vela, error) {
 		vela.WebAddress = c.String("webui-addr")
 	}
 
+	if len(c.StringSlice("cors-allow-origins")) > 0 {
+		vela.CORSAllowOrigins = c.StringSlice("cors-allow-origins")
+	}
+
 	if len(c.String("webui-oauth-callback")) > 0 {
 		vela.WebOauthCallbackPath = c.String("webui-oauth-callback")
 	}

--- a/cmd/vela-server/metadata.go
+++ b/cmd/vela-server/metadata.go
@@ -110,7 +110,7 @@ func metadataVela(c *cli.Context) (*internal.Vela, error) {
 	}
 
 	if len(c.StringSlice("cors-allow-origins")) > 0 {
-		vela.CORSAllowOrigins = c.StringSlice("cors-allow-origins")
+		vela.CorsAllowOrigins = c.StringSlice("cors-allow-origins")
 	}
 
 	if len(c.String("webui-oauth-callback")) > 0 {

--- a/compiler/types/pipeline/container_test.go
+++ b/compiler/types/pipeline/container_test.go
@@ -11,54 +11,35 @@ import (
 
 func TestPipeline_ContainerSlice_Purge(t *testing.T) {
 	// setup types
-	containers1 := testContainers()
-	*containers1 = (*containers1)[:len(*containers1)-1]
-
-	containers2 := testContainersOR()
-	*containers2 = (*containers2)[:len(*containers2)-1]
-
-	ruledata1 := &RuleData{
-		Branch: "main",
-		Event:  "pull_request",
-		Path:   []string{},
-		Repo:   "foo/bar",
-		Tag:    "refs/heads/main",
-	}
-
-	ruledata2 := &RuleData{
-		Branch: "dev",
-		Event:  "pull_request",
-		Path:   []string{},
-		Repo:   "foo/bar",
-		Tag:    "refs/heads/main",
-	}
+	containers := testContainers()
+	*containers = (*containers)[:len(*containers)-1]
 
 	// setup tests
 	tests := []struct {
 		containers *ContainerSlice
-		ruledata   *RuleData
 		want       *ContainerSlice
 	}{
 		{
 			containers: testContainers(),
-			ruledata:   ruledata1,
-			want:       containers1,
-		},
-		{
-			containers: testContainersOR(),
-			ruledata:   ruledata2,
-			want:       containers2,
+			want:       containers,
 		},
 		{
 			containers: new(ContainerSlice),
-			ruledata:   ruledata1,
 			want:       new(ContainerSlice),
 		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		got, _ := test.containers.Purge(test.ruledata)
+		r := &RuleData{
+			Branch: "main",
+			Event:  "pull_request",
+			Path:   []string{},
+			Repo:   "foo/bar",
+			Tag:    "refs/heads/main",
+		}
+
+		got, _ := test.containers.Purge(r)
 
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("Purge is %v, want %v", got, test.want)
@@ -1052,48 +1033,6 @@ func testContainers() *ContainerSlice {
 			Ruleset: Ruleset{
 				If:       Rules{Event: []string{"push"}},
 				Operator: "and",
-			},
-		},
-	}
-}
-
-func testContainersOR() *ContainerSlice {
-	return &ContainerSlice{
-		{
-			ID:          "step_github octocat._1_init",
-			Directory:   "/home/github/octocat",
-			Environment: map[string]string{"FOO": "bar"},
-			Image:       "#init",
-			Name:        "init",
-			Number:      1,
-			Pull:        "always",
-		},
-		{
-			ID:          "step_github octocat._1_clone",
-			Directory:   "/home/github/octocat",
-			Environment: map[string]string{"FOO": "bar"},
-			Image:       "target/vela-git:v0.3.0",
-			Name:        "clone",
-			Number:      2,
-			Pull:        "always",
-			IDRequest:   "yes",
-		},
-		{
-			ID:          "step_github/octocat._1_echo",
-			Commands:    []string{"echo hello"},
-			Directory:   "/home/github/octocat",
-			Environment: map[string]string{"FOO": "bar"},
-			Image:       "alpine:latest",
-			Name:        "echo",
-			Number:      3,
-			Pull:        "always",
-			ReportAs:    "echo-step",
-			Ruleset: Ruleset{
-				If: Rules{
-					Event:  []string{"push"},
-					Branch: []string{"main"},
-				},
-				Operator: "or",
 			},
 		},
 	}

--- a/internal/metadata.go
+++ b/internal/metadata.go
@@ -32,7 +32,7 @@ type (
 		AccessTokenDuration  time.Duration `json:"access_token_duration"`
 		RefreshTokenDuration time.Duration `json:"refresh_token_duration"`
 		OpenIDIssuer         string        `json:"oidc_issuer"`
-		CORSAllowOrigins     []string      `json:"cors_allow_origins"`
+		CorsAllowOrigins     []string      `json:"cors_allow_origins"`
 	}
 
 	// Metadata is the extra set of data passed to the compiler for

--- a/internal/metadata.go
+++ b/internal/metadata.go
@@ -32,6 +32,7 @@ type (
 		AccessTokenDuration  time.Duration `json:"access_token_duration"`
 		RefreshTokenDuration time.Duration `json:"refresh_token_duration"`
 		OpenIDIssuer         string        `json:"oidc_issuer"`
+		CORSAllowOrigins     []string      `json:"cors_allow_origins"`
 	}
 
 	// Metadata is the extra set of data passed to the compiler for

--- a/router/middleware/header.go
+++ b/router/middleware/header.go
@@ -32,8 +32,9 @@ func Options(c *gin.Context) {
 	} else {
 		c.Header("Access-Control-Allow-Origin", "*")
 
-		if len(m.Vela.WebAddress) > 0 {
-			c.Header("Access-Control-Allow-Origin", m.Vela.WebAddress)
+		origins := AllowedOrigins(m)
+		if len(origins) > 0 {
+			c.Header("Access-Control-Allow-Origin", origins)
 			c.Header("Access-Control-Allow-Credentials", "true")
 		}
 
@@ -65,12 +66,37 @@ func Cors(c *gin.Context) {
 
 	c.Header("Access-Control-Allow-Origin", "*")
 
-	if len(m.Vela.WebAddress) > 0 {
-		c.Header("Access-Control-Allow-Origin", m.Vela.WebAddress)
+	origins := AllowedOrigins(m)
+	if len(origins) > 0 {
+		c.Header("Access-Control-Allow-Origin", origins)
 		c.Header("Access-Control-Allow-Credentials", "true")
 	}
 
 	c.Header("Access-Control-Expose-Headers", "link, x-total-count")
+}
+
+// AllowedOrigins is a helper function that returns the
+// allowed origins for CORS requests.
+func AllowedOrigins(m *internal.Metadata) string {
+	corsOrigins := []string{
+		m.Vela.WebAddress,
+	}
+
+	corsOrigins = append(corsOrigins, m.Vela.CORSAllowOrigins...)
+
+	origins := ""
+
+	for _, origin := range corsOrigins {
+		if len(origin) > 0 {
+			if len(origins) > 0 {
+				origins += ","
+			}
+
+			origins += origin
+		}
+	}
+
+	return origins
 }
 
 // RequestVersion is a middleware function that injects the Vela API version

--- a/router/middleware/header.go
+++ b/router/middleware/header.go
@@ -32,7 +32,7 @@ func Options(c *gin.Context) {
 	} else {
 		c.Header("Access-Control-Allow-Origin", "*")
 
-		origin := CORSAllowOrigin(c, m)
+		origin := CorsAllowOrigin(c, m)
 		if len(origin) > 0 {
 			c.Header("Access-Control-Allow-Origin", origin)
 			c.Header("Access-Control-Allow-Credentials", "true")
@@ -66,7 +66,7 @@ func Cors(c *gin.Context) {
 
 	c.Header("Access-Control-Allow-Origin", "*")
 
-	origin := CORSAllowOrigin(c, m)
+	origin := CorsAllowOrigin(c, m)
 	if len(origin) > 0 {
 		c.Header("Access-Control-Allow-Origin", origin)
 		c.Header("Access-Control-Allow-Credentials", "true")
@@ -75,13 +75,13 @@ func Cors(c *gin.Context) {
 	c.Header("Access-Control-Expose-Headers", "link, x-total-count")
 }
 
-// CORSAllowOrigin is a helper function that returns the
+// CorsAllowOrigin is a helper function that returns the
 // allowed origin for CORS requests by checking the
 // request origin against the allowed origins in the
 // Vela metadata.
-func CORSAllowOrigin(c *gin.Context, m *internal.Metadata) string {
+func CorsAllowOrigin(c *gin.Context, m *internal.Metadata) string {
 	origin := c.Request.Header.Get("Origin")
-	for _, domain := range m.Vela.CORSAllowOrigins {
+	for _, domain := range m.Vela.CorsAllowOrigins {
 		if domain == origin {
 			return domain
 		}

--- a/router/middleware/header.go
+++ b/router/middleware/header.go
@@ -32,7 +32,7 @@ func Options(c *gin.Context) {
 	} else {
 		c.Header("Access-Control-Allow-Origin", "*")
 
-		origin := AllowedOrigin(c, m)
+		origin := CORSAllowOrigin(c, m)
 		if len(origin) > 0 {
 			c.Header("Access-Control-Allow-Origin", origin)
 			c.Header("Access-Control-Allow-Credentials", "true")
@@ -66,7 +66,7 @@ func Cors(c *gin.Context) {
 
 	c.Header("Access-Control-Allow-Origin", "*")
 
-	origin := AllowedOrigin(c, m)
+	origin := CORSAllowOrigin(c, m)
 	if len(origin) > 0 {
 		c.Header("Access-Control-Allow-Origin", origin)
 		c.Header("Access-Control-Allow-Credentials", "true")
@@ -75,23 +75,19 @@ func Cors(c *gin.Context) {
 	c.Header("Access-Control-Expose-Headers", "link, x-total-count")
 }
 
-// AllowedOrigin is a helper function that returns the
+// CORSAllowOrigin is a helper function that returns the
 // allowed origin for CORS requests by checking the
 // request origin against the allowed origins in the
 // Vela metadata.
-func AllowedOrigin(c *gin.Context, m *internal.Metadata) string {
-	origins := []string{
-		m.Vela.WebAddress,
-	}
-	origins = append(origins, m.Vela.CORSAllowOrigins...)
-
+func CORSAllowOrigin(c *gin.Context, m *internal.Metadata) string {
 	origin := c.Request.Header.Get("Origin")
-	for _, domain := range origins {
+	for _, domain := range m.Vela.CORSAllowOrigins {
 		if domain == origin {
 			return domain
 		}
 	}
 
+	// return the Vela web address as the default to preserve functionality
 	return m.Vela.WebAddress
 }
 

--- a/router/middleware/header.go
+++ b/router/middleware/header.go
@@ -32,9 +32,9 @@ func Options(c *gin.Context) {
 	} else {
 		c.Header("Access-Control-Allow-Origin", "*")
 
-		origins := AllowedOrigins(m)
-		if len(origins) > 0 {
-			c.Header("Access-Control-Allow-Origin", origins)
+		origin := AllowedOrigin(c, m)
+		if len(origin) > 0 {
+			c.Header("Access-Control-Allow-Origin", origin)
 			c.Header("Access-Control-Allow-Credentials", "true")
 		}
 
@@ -66,37 +66,33 @@ func Cors(c *gin.Context) {
 
 	c.Header("Access-Control-Allow-Origin", "*")
 
-	origins := AllowedOrigins(m)
-	if len(origins) > 0 {
-		c.Header("Access-Control-Allow-Origin", origins)
+	origin := AllowedOrigin(c, m)
+	if len(origin) > 0 {
+		c.Header("Access-Control-Allow-Origin", origin)
 		c.Header("Access-Control-Allow-Credentials", "true")
 	}
 
 	c.Header("Access-Control-Expose-Headers", "link, x-total-count")
 }
 
-// AllowedOrigins is a helper function that returns the
-// allowed origins for CORS requests.
-func AllowedOrigins(m *internal.Metadata) string {
-	corsOrigins := []string{
+// AllowedOrigin is a helper function that returns the
+// allowed origin for CORS requests by checking the
+// request origin against the allowed origins in the
+// Vela metadata.
+func AllowedOrigin(c *gin.Context, m *internal.Metadata) string {
+	origins := []string{
 		m.Vela.WebAddress,
 	}
+	origins = append(origins, m.Vela.CORSAllowOrigins...)
 
-	corsOrigins = append(corsOrigins, m.Vela.CORSAllowOrigins...)
-
-	origins := ""
-
-	for _, origin := range corsOrigins {
-		if len(origin) > 0 {
-			if len(origins) > 0 {
-				origins += ","
-			}
-
-			origins += origin
+	origin := c.Request.Header.Get("Origin")
+	for _, domain := range origins {
+		if domain == origin {
+			return domain
 		}
 	}
 
-	return origins
+	return m.Vela.WebAddress
 }
 
 // RequestVersion is a middleware function that injects the Vela API version

--- a/router/middleware/header_test.go
+++ b/router/middleware/header_test.go
@@ -189,7 +189,7 @@ func TestMiddleware_Cors(t *testing.T) {
 			m: &internal.Metadata{
 				Vela: &internal.Vela{
 					Address:          "http://localhost:8080",
-					CORSAllowOrigins: []string{},
+					CorsAllowOrigins: []string{},
 				},
 			},
 			origin:                "http://localhost:8888",
@@ -202,7 +202,7 @@ func TestMiddleware_Cors(t *testing.T) {
 			m: &internal.Metadata{
 				Vela: &internal.Vela{
 					WebAddress:       "http://localhost:8888",
-					CORSAllowOrigins: []string{},
+					CorsAllowOrigins: []string{},
 				},
 			},
 			origin:                "http://localhost:8888",
@@ -215,7 +215,7 @@ func TestMiddleware_Cors(t *testing.T) {
 			m: &internal.Metadata{
 				Vela: &internal.Vela{
 					WebAddress:       "http://localhost:8888",
-					CORSAllowOrigins: []string{"http://localhost:3000", "http://localhost:3001"},
+					CorsAllowOrigins: []string{"http://localhost:3000", "http://localhost:3001"},
 				},
 			},
 			origin:                "http://localhost:8888",
@@ -228,7 +228,7 @@ func TestMiddleware_Cors(t *testing.T) {
 			m: &internal.Metadata{
 				Vela: &internal.Vela{
 					WebAddress:       "",
-					CORSAllowOrigins: []string{"http://localhost:3000", "http://localhost:3001", "http://localhost:8888"},
+					CorsAllowOrigins: []string{"http://localhost:3000", "http://localhost:3001", "http://localhost:8888"},
 				},
 			},
 			origin:                "http://localhost:8888",

--- a/router/middleware/header_test.go
+++ b/router/middleware/header_test.go
@@ -176,45 +176,82 @@ func TestMiddleware_Options_InvalidMethod(t *testing.T) {
 }
 
 func TestMiddleware_Cors(t *testing.T) {
-	// setup types
-	wantOrigin := "*"
-	wantExposeHeaders := "link, x-total-count"
-	m := &internal.Metadata{
-		Vela: &internal.Vela{
-			Address: "http://localhost:8080",
+	tests := []struct {
+		name                  string
+		m                     *internal.Metadata
+		expectedOrigin        string
+		expectedCredentials   string
+		expectedExposeHeaders string
+	}{
+		{
+			name: "*",
+			m: &internal.Metadata{
+				Vela: &internal.Vela{
+					Address:          "http://example.com",
+					CORSAllowOrigins: []string{},
+				},
+			},
+			expectedOrigin:        "*",
+			expectedCredentials:   "",
+			expectedExposeHeaders: "link, x-total-count",
+		},
+		{
+			name: "WebAddress",
+			m: &internal.Metadata{
+				Vela: &internal.Vela{
+					WebAddress:       "http://example.com",
+					CORSAllowOrigins: []string{},
+				},
+			},
+			expectedOrigin:        "http://example.com",
+			expectedCredentials:   "true",
+			expectedExposeHeaders: "link, x-total-count",
+		},
+		{
+			name: "CORSAllowOrigins",
+			m: &internal.Metadata{
+				Vela: &internal.Vela{
+					WebAddress:       "",
+					CORSAllowOrigins: []string{"http://c1.com", "http://c2.com"},
+				},
+			},
+			expectedOrigin:        "http://c1.com,http://c2.com",
+			expectedCredentials:   "true",
+			expectedExposeHeaders: "link, x-total-count",
 		},
 	}
 
-	// setup context
-	gin.SetMode(gin.TestMode)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			resp := httptest.NewRecorder()
+			context, engine := gin.CreateTestContext(resp)
+			context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
 
-	resp := httptest.NewRecorder()
-	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+			// inject metadata
+			engine.Use(func(c *gin.Context) {
+				c.Set("metadata", tt.m)
+				c.Next()
+			})
+			engine.Use(Cors)
+			engine.GET("/health", func(c *gin.Context) {
+				c.Status(http.StatusOK)
+			})
+			engine.ServeHTTP(context.Writer, context.Request)
 
-	// setup mock server
-	engine.Use(Metadata(m))
-	engine.Use(Cors)
-	engine.GET("/health", func(c *gin.Context) {
-		c.Status(http.StatusOK)
-	})
-
-	// run test
-	engine.ServeHTTP(context.Writer, context.Request)
-
-	gotOrigin := context.Writer.Header().Get("Access-Control-Allow-Origin")
-	gotExposeHeaders := context.Writer.Header().Get("Access-Control-Expose-Headers")
-
-	if resp.Code != http.StatusOK {
-		t.Errorf("CORS returned %v, want %v", resp.Code, http.StatusOK)
-	}
-
-	if !reflect.DeepEqual(gotOrigin, wantOrigin) {
-		t.Errorf("CORS Access-Control-Allow-Origin is %v, want %v", gotOrigin, wantOrigin)
-	}
-
-	if !reflect.DeepEqual(gotExposeHeaders, wantExposeHeaders) {
-		t.Errorf("CORS Access-Control-Expose-Headers is %v, want %v", gotExposeHeaders, wantExposeHeaders)
+			gotOrigin := context.Writer.Header().Get("Access-Control-Allow-Origin")
+			if gotOrigin != tt.expectedOrigin {
+				t.Errorf("Access-Control-Allow-Origin is %v; want %v", gotOrigin, tt.expectedOrigin)
+			}
+			gotCredentials := context.Writer.Header().Get("Access-Control-Allow-Credentials")
+			if gotCredentials != tt.expectedCredentials {
+				t.Errorf("Access-Control-Allow-Credentials is %v; want %v", gotCredentials, tt.expectedCredentials)
+			}
+			gotExposeHeaders := context.Writer.Header().Get("Access-Control-Expose-Headers")
+			if gotExposeHeaders != tt.expectedExposeHeaders {
+				t.Errorf("Access-Control-Expose-Headers is %v; want %v", gotExposeHeaders, tt.expectedExposeHeaders)
+			}
+		})
 	}
 }
 

--- a/router/middleware/header_test.go
+++ b/router/middleware/header_test.go
@@ -187,7 +187,7 @@ func TestMiddleware_Cors(t *testing.T) {
 			name: "*",
 			m: &internal.Metadata{
 				Vela: &internal.Vela{
-					Address:          "http://example.com",
+					Address:          "http://localhost:8080",
 					CORSAllowOrigins: []string{},
 				},
 			},
@@ -199,11 +199,11 @@ func TestMiddleware_Cors(t *testing.T) {
 			name: "WebAddress",
 			m: &internal.Metadata{
 				Vela: &internal.Vela{
-					WebAddress:       "http://example.com",
+					WebAddress:       "http://localhost:8888",
 					CORSAllowOrigins: []string{},
 				},
 			},
-			expectedOrigin:        "http://example.com",
+			expectedOrigin:        "http://localhost:8888",
 			expectedCredentials:   "true",
 			expectedExposeHeaders: "link, x-total-count",
 		},
@@ -212,10 +212,10 @@ func TestMiddleware_Cors(t *testing.T) {
 			m: &internal.Metadata{
 				Vela: &internal.Vela{
 					WebAddress:       "",
-					CORSAllowOrigins: []string{"http://c1.com", "http://c2.com"},
+					CORSAllowOrigins: []string{"http://localhost:3000", "http://localhost:3001"},
 				},
 			},
-			expectedOrigin:        "http://c1.com,http://c2.com",
+			expectedOrigin:        "http://localhost:3000,http://localhost:3001",
 			expectedCredentials:   "true",
 			expectedExposeHeaders: "link, x-total-count",
 		},
@@ -243,10 +243,12 @@ func TestMiddleware_Cors(t *testing.T) {
 			if gotOrigin != tt.expectedOrigin {
 				t.Errorf("Access-Control-Allow-Origin is %v; want %v", gotOrigin, tt.expectedOrigin)
 			}
+
 			gotCredentials := context.Writer.Header().Get("Access-Control-Allow-Credentials")
 			if gotCredentials != tt.expectedCredentials {
 				t.Errorf("Access-Control-Allow-Credentials is %v; want %v", gotCredentials, tt.expectedCredentials)
 			}
+
 			gotExposeHeaders := context.Writer.Header().Get("Access-Control-Expose-Headers")
 			if gotExposeHeaders != tt.expectedExposeHeaders {
 				t.Errorf("Access-Control-Expose-Headers is %v; want %v", gotExposeHeaders, tt.expectedExposeHeaders)


### PR DESCRIPTION
this "fix" adds support for alternative browser client implementations

## Environment Variable

use `VELA_CORS_ALLOW_ORIGINS="https://vela-frontend-module.com,https://other-platform-frontend-module.com"` to set an optional list of CORS allowed origins 

the code still defaults to `m.Vela.WebAddress` so current configurations of `VELA_WEB_ADDRESS` are not impacted 