### PR TITLE
fix(compiler): split validate into YAML and Pipeline

### DIFF
--- a/compiler/engine.go
+++ b/compiler/engine.go
@@ -42,9 +42,13 @@ type Engine interface {
 	// an object to a string.
 	ParseRaw(interface{}) (string, error)
 
-	// Validate defines a function that verifies
+	// ValidateYAML defines a function that verifies
 	// the yaml configuration is accurate.
-	Validate(*yaml.Build) error
+	ValidateYAML(*yaml.Build) error
+
+	// ValidatePipeline defines a function that verifies
+	// the final pipeline build is accurate.
+	ValidatePipeline(*pipeline.Build) error
 
 	// Clone Compiler Interface Functions
 

--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -99,7 +99,7 @@ func (c *client) Compile(ctx context.Context, v interface{}) (*pipeline.Build, *
 			return nil, _pipeline, err
 		}
 		// validate the yaml configuration
-		err = c.Validate(newPipeline)
+		err = c.ValidateYAML(newPipeline)
 		if err != nil {
 			return nil, _pipeline, err
 		}
@@ -135,7 +135,7 @@ func (c *client) CompileLite(ctx context.Context, v interface{}, ruleData *pipel
 			return nil, _pipeline, err
 		}
 		// validate the yaml configuration
-		err = c.Validate(newPipeline)
+		err = c.ValidateYAML(newPipeline)
 		if err != nil {
 			return nil, _pipeline, err
 		}
@@ -225,7 +225,7 @@ func (c *client) CompileLite(ctx context.Context, v interface{}, ruleData *pipel
 	}
 
 	// validate the yaml configuration
-	err = c.Validate(p)
+	err = c.ValidateYAML(p)
 	if err != nil {
 		return nil, _pipeline, err
 	}
@@ -383,7 +383,7 @@ func (c *client) compileSteps(ctx context.Context, p *yaml.Build, _pipeline *api
 	}
 
 	// validate the yaml configuration
-	err = c.Validate(p)
+	err = c.ValidateYAML(p)
 	if err != nil {
 		return nil, _pipeline, err
 	}
@@ -441,6 +441,12 @@ func (c *client) compileSteps(ctx context.Context, p *yaml.Build, _pipeline *api
 		return nil, _pipeline, err
 	}
 
+	// validate the yaml configuration
+	err = c.ValidatePipeline(build)
+	if err != nil {
+		return nil, _pipeline, err
+	}
+
 	return build, _pipeline, nil
 }
 
@@ -485,7 +491,7 @@ func (c *client) compileStages(ctx context.Context, p *yaml.Build, _pipeline *ap
 	}
 
 	// validate the yaml configuration
-	err = c.Validate(p)
+	err = c.ValidateYAML(p)
 	if err != nil {
 		return nil, _pipeline, err
 	}
@@ -539,6 +545,12 @@ func (c *client) compileStages(ctx context.Context, p *yaml.Build, _pipeline *ap
 
 	// create executable representation
 	build, err := c.TransformStages(r, p)
+	if err != nil {
+		return nil, _pipeline, err
+	}
+
+	// validate the final pipeline configuration
+	err = c.ValidatePipeline(build)
 	if err != nil {
 		return nil, _pipeline, err
 	}

--- a/compiler/native/compile_test.go
+++ b/compiler/native/compile_test.go
@@ -1927,6 +1927,375 @@ func TestNative_Compile_NoStepsorStages(t *testing.T) {
 	}
 }
 
+func TestNative_Compile_StageNameCollision(t *testing.T) {
+	// setup types
+	set := flag.NewFlagSet("test", 0)
+	set.String("clone-image", defaultCloneImage, "doc")
+	c := cli.NewContext(nil, set, nil)
+	name := "foo"
+	author := "author"
+	number := 1
+
+	m := &internal.Metadata{
+		Database: &internal.Database{
+			Driver: "foo",
+			Host:   "foo",
+		},
+		Queue: &internal.Queue{
+			Channel: "foo",
+			Driver:  "foo",
+			Host:    "foo",
+		},
+		Source: &internal.Source{
+			Driver: "foo",
+			Host:   "foo",
+		},
+		Vela: &internal.Vela{
+			Address:    "foo",
+			WebAddress: "foo",
+		},
+	}
+
+	// run test
+	yaml, err := os.ReadFile("testdata/stages_name_conflict.yml")
+	if err != nil {
+		t.Errorf("Reading yaml file return err: %v", err)
+	}
+
+	compiler, err := FromCLIContext(c)
+	if err != nil {
+		t.Errorf("Creating compiler returned err: %v", err)
+	}
+
+	// todo: this needs to be fixed in compiler validation
+	// this is a dirty hack to make this test pass
+	compiler.WithMetadata(m)
+
+	compiler.repo = &api.Repo{Name: &author}
+	compiler.build = &api.Build{Author: &name, Number: &number}
+
+	got, _, err := compiler.Compile(context.Background(), yaml)
+	if err == nil {
+		t.Errorf("Compile should have returned err")
+	}
+
+	if got != nil {
+		t.Errorf("Compile is %v, want %v", got, nil)
+	}
+}
+
+func TestNative_Compile_StageNameCollisionPurged(t *testing.T) {
+	// setup types
+	set := flag.NewFlagSet("test", 0)
+	set.String("clone-image", defaultCloneImage, "doc")
+	c := cli.NewContext(nil, set, nil)
+
+	m := &internal.Metadata{
+		Database: &internal.Database{
+			Driver: "foo",
+			Host:   "foo",
+		},
+		Queue: &internal.Queue{
+			Channel: "foo",
+			Driver:  "foo",
+			Host:    "foo",
+		},
+		Source: &internal.Source{
+			Driver: "foo",
+			Host:   "foo",
+		},
+		Vela: &internal.Vela{
+			Address:    "foo",
+			WebAddress: "foo",
+		},
+	}
+
+	compiler, err := FromCLIContext(c)
+	if err != nil {
+		t.Errorf("Creating compiler returned err: %v", err)
+	}
+
+	compiler.WithMetadata(m)
+
+	build := new(api.Build)
+	build.SetID(1)
+	build.SetEvent("push")
+
+	compiler.WithBuild(build)
+
+	initEnv := environment(build, m, nil, nil, nil)
+
+	stepEnv := environment(build, m, nil, nil, nil)
+	stepEnv["HOME"] = "/root"
+	stepEnv["SHELL"] = "/bin/sh"
+	stepEnv["VELA_BUILD_SCRIPT"] = generateScriptPosix([]string{`echo "Building..."`})
+
+	want := &pipeline.Build{
+		Version: "1",
+		ID:      "__0",
+		Metadata: pipeline.Metadata{
+			Clone:       true,
+			Template:    false,
+			Environment: []string{"steps", "services", "secrets"},
+			AutoCancel:  &pipeline.CancelOptions{},
+		},
+		Stages: pipeline.StageSlice{
+			&pipeline.Stage{
+				Name:        "init",
+				Environment: initEnv,
+				Steps: pipeline.ContainerSlice{
+					&pipeline.Container{
+						ID:          "__0_init_init",
+						Directory:   "/vela/src/foo//",
+						Environment: initEnv,
+						Image:       "#init",
+						Name:        "init",
+						Number:      1,
+						Pull:        "not_present",
+					},
+				},
+			},
+			&pipeline.Stage{
+				Name:        "clone",
+				Environment: initEnv,
+				Steps: pipeline.ContainerSlice{
+					&pipeline.Container{
+						ID:          "__0_clone_clone",
+						Directory:   "/vela/src/foo//",
+						Environment: initEnv,
+						Image:       defaultCloneImage,
+						Name:        "clone",
+						Number:      2,
+						Pull:        "not_present",
+					},
+				},
+			},
+			&pipeline.Stage{
+				Name:        "three",
+				Needs:       []string{"clone"},
+				Environment: initEnv,
+				Steps: pipeline.ContainerSlice{
+					&pipeline.Container{
+						ID:          "__0_three_word_key_build",
+						Commands:    []string{"echo $VELA_BUILD_SCRIPT | base64 -d | /bin/sh -e"},
+						Directory:   "/vela/src/foo//",
+						Entrypoint:  []string{"/bin/sh", "-c"},
+						Environment: stepEnv,
+						Image:       "alpine",
+						Name:        "word_key_build",
+						Number:      3,
+						Pull:        "not_present",
+					},
+				},
+			},
+		},
+	}
+
+	// run test
+	yaml, err := os.ReadFile("testdata/stages_name_conflict_purged.yml")
+	if err != nil {
+		t.Errorf("Reading yaml file return err: %v", err)
+	}
+
+	got, _, err := compiler.Compile(context.Background(), yaml)
+	if err != nil {
+		t.Errorf("Compile returned err: %v", err)
+	}
+
+	// WARNING: hack to compare stages
+	//
+	// Channel values can only be compared for equality.
+	// Two channel values are considered equal if they
+	// originated from the same make call meaning they
+	// refer to the same channel value in memory.
+	for i, stage := range got.Stages {
+		tmp := want.Stages
+
+		tmp[i].Done = stage.Done
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Compile() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestNative_Compile_StepNameCollision(t *testing.T) {
+	// setup types
+	set := flag.NewFlagSet("test", 0)
+	set.String("clone-image", defaultCloneImage, "doc")
+	c := cli.NewContext(nil, set, nil)
+	name := "foo"
+	author := "author"
+	number := 1
+
+	m := &internal.Metadata{
+		Database: &internal.Database{
+			Driver: "foo",
+			Host:   "foo",
+		},
+		Queue: &internal.Queue{
+			Channel: "foo",
+			Driver:  "foo",
+			Host:    "foo",
+		},
+		Source: &internal.Source{
+			Driver: "foo",
+			Host:   "foo",
+		},
+		Vela: &internal.Vela{
+			Address:    "foo",
+			WebAddress: "foo",
+		},
+	}
+
+	// run test
+	yaml, err := os.ReadFile("testdata/steps_name_conflict.yml")
+	if err != nil {
+		t.Errorf("Reading yaml file return err: %v", err)
+	}
+
+	compiler, err := FromCLIContext(c)
+	if err != nil {
+		t.Errorf("Creating compiler returned err: %v", err)
+	}
+
+	// todo: this needs to be fixed in compiler validation
+	// this is a dirty hack to make this test pass
+	compiler.WithMetadata(m)
+
+	compiler.repo = &api.Repo{Name: &author}
+	compiler.build = &api.Build{Author: &name, Number: &number}
+
+	got, _, err := compiler.Compile(context.Background(), yaml)
+	if err == nil {
+		t.Errorf("Compile should have returned err")
+	}
+
+	if got != nil {
+		t.Errorf("Compile is %v, want %v", got, nil)
+	}
+}
+
+func TestNative_Compile_StepNameCollisionPurged(t *testing.T) {
+	// setup types
+	set := flag.NewFlagSet("test", 0)
+	set.String("clone-image", defaultCloneImage, "doc")
+	c := cli.NewContext(nil, set, nil)
+
+	m := &internal.Metadata{
+		Database: &internal.Database{
+			Driver: "foo",
+			Host:   "foo",
+		},
+		Queue: &internal.Queue{
+			Channel: "foo",
+			Driver:  "foo",
+			Host:    "foo",
+		},
+		Source: &internal.Source{
+			Driver: "foo",
+			Host:   "foo",
+		},
+		Vela: &internal.Vela{
+			Address:    "foo",
+			WebAddress: "foo",
+		},
+	}
+
+	compiler, err := FromCLIContext(c)
+	if err != nil {
+		t.Errorf("Creating compiler returned err: %v", err)
+	}
+
+	compiler.WithMetadata(m)
+
+	build := new(api.Build)
+	build.SetID(1)
+	build.SetEvent("push")
+
+	compiler.WithBuild(build)
+
+	initEnv := environment(build, m, nil, nil, nil)
+
+	buildEnv := environment(build, m, nil, nil, nil)
+	buildEnv["HOME"] = "/root"
+	buildEnv["SHELL"] = "/bin/sh"
+	buildEnv["VELA_BUILD_SCRIPT"] = generateScriptPosix([]string{`echo "Building..."`})
+
+	testEnv := environment(build, m, nil, nil, nil)
+	testEnv["HOME"] = "/root"
+	testEnv["SHELL"] = "/bin/sh"
+	testEnv["VELA_BUILD_SCRIPT"] = generateScriptPosix([]string{`echo "Testing..."`})
+
+	want := &pipeline.Build{
+		Version: "1",
+		ID:      "__0",
+		Metadata: pipeline.Metadata{
+			Clone:       true,
+			Template:    false,
+			Environment: []string{"steps", "services", "secrets"},
+			AutoCancel:  &pipeline.CancelOptions{},
+		},
+		Steps: pipeline.ContainerSlice{
+			&pipeline.Container{
+				ID:          "step___0_init",
+				Directory:   "/vela/src/foo//",
+				Environment: initEnv,
+				Image:       "#init",
+				Name:        "init",
+				Number:      1,
+				Pull:        "not_present",
+			},
+			&pipeline.Container{
+				ID:          "step___0_clone",
+				Directory:   "/vela/src/foo//",
+				Environment: initEnv,
+				Image:       defaultCloneImage,
+				Name:        "clone",
+				Number:      2,
+				Pull:        "not_present",
+			},
+			&pipeline.Container{
+				ID:          "step___0_build",
+				Commands:    []string{"echo $VELA_BUILD_SCRIPT | base64 -d | /bin/sh -e"},
+				Directory:   "/vela/src/foo//",
+				Entrypoint:  []string{"/bin/sh", "-c"},
+				Environment: buildEnv,
+				Image:       "alpine",
+				Name:        "build",
+				Number:      3,
+				Pull:        "not_present",
+			},
+			&pipeline.Container{
+				ID:          "step___0_test",
+				Commands:    []string{"echo $VELA_BUILD_SCRIPT | base64 -d | /bin/sh -e"},
+				Directory:   "/vela/src/foo//",
+				Entrypoint:  []string{"/bin/sh", "-c"},
+				Environment: testEnv,
+				Image:       "alpine",
+				Name:        "test",
+				Number:      4,
+				Pull:        "not_present",
+			},
+		},
+	}
+
+	// run test
+	yaml, err := os.ReadFile("testdata/steps_name_conflict_purged.yml")
+	if err != nil {
+		t.Errorf("Reading yaml file return err: %v", err)
+	}
+
+	got, _, err := compiler.Compile(context.Background(), yaml)
+	if err != nil {
+		t.Errorf("Compile returned err: %v", err)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Compile() mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestNative_Compile_StepsandStages(t *testing.T) {
 	// setup types
 	set := flag.NewFlagSet("test", 0)

--- a/compiler/native/testdata/stages_name_conflict.yml
+++ b/compiler/native/testdata/stages_name_conflict.yml
@@ -1,0 +1,15 @@
+version: "1"
+
+stages:
+  three_word_key:
+    steps:
+      - name: build
+        image: alpine
+        commands:
+          - echo "Building..."
+  three:
+    steps:
+      - name: word_key_build
+        image: alpine
+        commands:
+          - echo "Building..."

--- a/compiler/native/testdata/stages_name_conflict_purged.yml
+++ b/compiler/native/testdata/stages_name_conflict_purged.yml
@@ -1,0 +1,17 @@
+version: "1"
+
+stages:
+  three_word_key:
+    steps:
+      - name: build
+        image: alpine
+        ruleset:
+          event: pull_request
+        commands:
+          - echo "Building..."
+  three:
+    steps:
+      - name: word_key_build
+        image: alpine
+        commands:
+          - echo "Building..."

--- a/compiler/native/testdata/steps_name_conflict.yml
+++ b/compiler/native/testdata/steps_name_conflict.yml
@@ -1,0 +1,15 @@
+version: "1"
+
+steps:
+  - name: build
+    image: alpine
+    commands:
+      - echo "Building..."
+  - name: test
+    image: alpine
+    commands:
+      - echo "Testing..."
+  - name: build
+    image: alpine
+    commands:
+      - echo "Building...again?"

--- a/compiler/native/testdata/steps_name_conflict_purged.yml
+++ b/compiler/native/testdata/steps_name_conflict_purged.yml
@@ -1,0 +1,17 @@
+version: "1"
+
+steps:
+  - name: build
+    image: alpine
+    commands:
+      - echo "Building..."
+  - name: test
+    image: alpine
+    commands:
+      - echo "Testing..."
+  - name: build
+    image: alpine
+    ruleset:
+      event: pull_request
+    commands:
+      - echo "Building...again?"


### PR DESCRIPTION
There are a couple things that are checked during `Validate` that may not accurately reflect the build that ends up being run. For instance, you could name steps the same if it's guaranteed they will never run at the same time due to rulesets. By splitting validate into a YAML validation and a pipeline validation, we have a more accurate validator.