### PR TITLE
enhance(scm)!: support truly custom webhook address

### DIFF
--- a/scm/github/opts.go
+++ b/scm/github/opts.go
@@ -95,7 +95,14 @@ func WithServerWebhookAddress(address string) ClientOpt {
 
 		// fallback to Vela server address if the provided Vela server webhook address is empty
 		if len(address) == 0 {
-			c.config.ServerWebhookAddress = c.config.ServerAddress
+			c.config.ServerWebhookAddress = fmt.Sprintf("%s/webhook", c.config.ServerAddress)
+			return nil
+		}
+
+		if strings.EqualFold(address, c.config.ServerAddress) {
+			c.Logger.Warnf("vela server webhook address is the same as the server address. setting to %s/webhook", c.config.ServerAddress)
+			c.config.ServerWebhookAddress = fmt.Sprintf("%s/webhook", c.config.ServerAddress)
+
 			return nil
 		}
 

--- a/scm/github/opts_test.go
+++ b/scm/github/opts_test.go
@@ -195,13 +195,13 @@ func TestGithub_ClientOpt_WithServerWebhookAddress(t *testing.T) {
 			failure:        false,
 			address:        "https://vela.example.com",
 			webhookAddress: "",
-			want:           "https://vela.example.com",
+			want:           "https://vela.example.com/webhook",
 		},
 		{
 			failure:        false,
 			address:        "https://vela.example.com",
 			webhookAddress: "https://vela.example.com",
-			want:           "https://vela.example.com",
+			want:           "https://vela.example.com/webhook",
 		},
 		{
 			failure:        false,

--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -130,7 +130,7 @@ func (c *client) DestroyWebhook(ctx context.Context, u *api.User, org, name stri
 		}
 
 		// capture hook ID if the hook url matches
-		if strings.EqualFold(hook.GetConfig().GetURL(), fmt.Sprintf("%s/webhook", c.config.ServerWebhookAddress)) {
+		if strings.EqualFold(hook.GetConfig().GetURL(), c.config.ServerWebhookAddress) {
 			ids = append(ids, hook.GetID())
 		}
 	}
@@ -141,7 +141,7 @@ func (c *client) DestroyWebhook(ctx context.Context, u *api.User, org, name stri
 			"org":  org,
 			"repo": name,
 			"user": u.GetName(),
-		}).Warnf("no repository webhooks matching %s/webhook found for %s/%s", c.config.ServerWebhookAddress, org, name)
+		}).Warnf("no repository webhooks matching %s found for %s/%s", c.config.ServerWebhookAddress, org, name)
 
 		return nil
 	}
@@ -202,7 +202,7 @@ func (c *client) CreateWebhook(ctx context.Context, u *api.User, r *api.Repo, h 
 	hook := &github.Hook{
 		Events: events,
 		Config: &github.HookConfig{
-			URL:         github.String(fmt.Sprintf("%s/webhook", c.config.ServerWebhookAddress)),
+			URL:         github.String(c.config.ServerWebhookAddress),
 			ContentType: github.String("form"),
 			Secret:      github.String(r.GetHash()),
 		},


### PR DESCRIPTION
If an installation wants to support a different webhook address for a pass through to the Vela server, the suffix of `/webhook` should not be forced onto those custom addresses

Marking as breaking because users could have already accounted for this by supplying a custom address knowing it ends in `/webhook`