### PR TITLE
fix(queue): remove validation of public key from flag set

### DIFF
--- a/queue/flags.go
+++ b/queue/flags.go
@@ -99,6 +99,5 @@ var Flags = []cli.Flag{
 			cli.EnvVar("QUEUE_PUBLIC_KEY"),
 			cli.File("/vela/signing.pub"),
 		),
-		Required: true,
 	},
 }

--- a/queue/flags_test.go
+++ b/queue/flags_test.go
@@ -98,7 +98,7 @@ func TestDatabase_Flags(t *testing.T) {
 				"queue.addr":   "redis://redis.example.com",
 				"queue.routes": "vela,worker",
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
We validate the presence of the public key in `setup.go` because the worker fetches the queue public key. It's not a flag for the worker.