### PR TITLE
fix(compiler): allow for private github.com templates

### DIFF
--- a/compiler/native/expand.go
+++ b/compiler/native/expand.go
@@ -319,19 +319,7 @@ func (c *Client) getTemplate(ctx context.Context, tmpl *yaml.Template, name stri
 		}
 
 		// pull from github without auth when the host isn't provided or is set to github.com
-		if !c.UsePrivateGithub && (len(src.Host) == 0 || !c.UsePrivateGithub && strings.Contains(src.Host, "github.com")) {
-			logrus.WithFields(logrus.Fields{
-				"org":  src.Org,
-				"repo": src.Repo,
-				"path": src.Name,
-				"host": src.Host,
-			}).Tracef("Using GitHub client to pull template")
-
-			bytes, err = c.Github.Template(ctx, nil, src)
-			if err != nil {
-				return bytes, err
-			}
-		} else {
+		if c.UsePrivateGithub {
 			logrus.WithFields(logrus.Fields{
 				"org":  src.Org,
 				"repo": src.Repo,
@@ -346,6 +334,18 @@ func (c *Client) getTemplate(ctx context.Context, tmpl *yaml.Template, name stri
 
 			// use private (authenticated) github instance to pull from
 			bytes, err = c.PrivateGithub.Template(ctx, c.user, src)
+			if err != nil {
+				return bytes, err
+			}
+		} else {
+			logrus.WithFields(logrus.Fields{
+				"org":  src.Org,
+				"repo": src.Repo,
+				"path": src.Name,
+				"host": src.Host,
+			}).Tracef("Using GitHub client to pull template")
+
+			bytes, err = c.Github.Template(ctx, nil, src)
 			if err != nil {
 				return bytes, err
 			}

--- a/compiler/native/expand.go
+++ b/compiler/native/expand.go
@@ -319,7 +319,7 @@ func (c *Client) getTemplate(ctx context.Context, tmpl *yaml.Template, name stri
 		}
 
 		// pull from github without auth when the host isn't provided or is set to github.com
-		if !c.UsePrivateGithub && (len(src.Host) == 0 || strings.Contains(src.Host, "github.com")) {
+		if !c.UsePrivateGithub && (len(src.Host) == 0 || !c.UsePrivateGithub && strings.Contains(src.Host, "github.com")) {
 			logrus.WithFields(logrus.Fields{
 				"org":  src.Org,
 				"repo": src.Repo,

--- a/compiler/native/native.go
+++ b/compiler/native/native.go
@@ -208,6 +208,7 @@ func (c *Client) WithPrivateGitHub(ctx context.Context, url, token string) compi
 		privGithub, _ := setupPrivateGithub(ctx, url, token)
 
 		c.PrivateGithub = privGithub
+		c.UsePrivateGithub = true
 	}
 
 	return c


### PR DESCRIPTION
Checking for the presence of `"github.com"` in the source config for fetching templates does not mean that the template is public.

By setting `UsePrivateGithub` to `true` when the `WithPrivateGitHub()` function is called, we can add some extra logic to make sure we aren't invoking `c.GitHub.Template` when we should be using `c.PrivateGitHub.Template`