### PR TITLE
enhance(settings)!: make dashboard repo limit adjustable by platform admins

### DIFF
--- a/api/admin/settings.go
+++ b/api/admin/settings.go
@@ -198,6 +198,12 @@ func UpdateSettings(c *gin.Context) {
 		l.Infof("platform admin: updating schedule allowlist to: %s", input.GetScheduleAllowlist())
 	}
 
+	if input.MaxDashboardRepos != nil {
+		_s.SetMaxDashboardRepos(input.GetMaxDashboardRepos())
+
+		l.Infof("platform admin: updating max dashboard repos to: %d", input.GetMaxDashboardRepos())
+	}
+
 	_s.SetUpdatedBy(u.GetName())
 
 	// send API call to update the settings

--- a/api/dashboard/create.go
+++ b/api/dashboard/create.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/database"
+	"github.com/go-vela/server/router/middleware/settings"
 	"github.com/go-vela/server/router/middleware/user"
 	"github.com/go-vela/server/util"
 )
@@ -172,6 +173,13 @@ func createAdminSet(c context.Context, caller *types.User, users []*types.User) 
 // validateRepoSet is a helper function that confirms all dashboard repos exist and are enabled
 // in the database while also confirming the IDs match when saving.
 func validateRepoSet(c context.Context, repos []*types.DashboardRepo) error {
+	s := settings.FromContext(c)
+
+	// check if the number of repos exceeds the max allowed
+	if len(repos) > int(s.GetMaxDashboardRepos()) {
+		return fmt.Errorf("unable to create dashboard: max dashboard repos exceeded %d", s.GetMaxDashboardRepos())
+	}
+
 	for _, repo := range repos {
 		// verify format (org/repo)
 		parts := strings.Split(repo.GetName(), "/")

--- a/api/types/settings/platform.go
+++ b/api/types/settings/platform.go
@@ -5,6 +5,7 @@ package settings
 import (
 	"fmt"
 
+	"github.com/go-vela/server/util"
 	"github.com/urfave/cli/v3"
 )
 
@@ -13,13 +14,14 @@ import (
 // swagger:model Platform
 type Platform struct {
 	ID                *int32 `json:"id"`
-	*Compiler         `json:"compiler,omitempty"           yaml:"compiler,omitempty"`
-	*Queue            `json:"queue,omitempty"              yaml:"queue,omitempty"`
-	RepoAllowlist     *[]string `json:"repo_allowlist,omitempty"     yaml:"repo_allowlist,omitempty"`
-	ScheduleAllowlist *[]string `json:"schedule_allowlist,omitempty" yaml:"schedule_allowlist,omitempty"`
-	CreatedAt         *int64    `json:"created_at,omitempty"         yaml:"created_at,omitempty"`
-	UpdatedAt         *int64    `json:"updated_at,omitempty"         yaml:"updated_at,omitempty"`
-	UpdatedBy         *string   `json:"updated_by,omitempty"         yaml:"updated_by,omitempty"`
+	*Compiler         `json:"compiler,omitempty"            yaml:"compiler,omitempty"`
+	*Queue            `json:"queue,omitempty"               yaml:"queue,omitempty"`
+	RepoAllowlist     *[]string `json:"repo_allowlist,omitempty"      yaml:"repo_allowlist,omitempty"`
+	ScheduleAllowlist *[]string `json:"schedule_allowlist,omitempty"  yaml:"schedule_allowlist,omitempty"`
+	MaxDashboardRepos *int32    `json:"max_dashboard_repos,omitempty" yaml:"max_dashboard_repos,omitempty"`
+	CreatedAt         *int64    `json:"created_at,omitempty"          yaml:"created_at,omitempty"`
+	UpdatedAt         *int64    `json:"updated_at,omitempty"          yaml:"updated_at,omitempty"`
+	UpdatedBy         *string   `json:"updated_by,omitempty"          yaml:"updated_by,omitempty"`
 }
 
 // FromCLICommand returns a new Platform record from a cli command.
@@ -31,6 +33,9 @@ func FromCLICommand(c *cli.Command) *Platform {
 
 	// set repos permitted to use schedules
 	ps.SetScheduleAllowlist(c.StringSlice("vela-schedule-allowlist"))
+
+	// set max repos per dashboard
+	ps.SetMaxDashboardRepos(util.Int32FromInt64(c.Int("max-dashboard-repos")))
 
 	return ps
 }
@@ -98,6 +103,19 @@ func (ps *Platform) GetScheduleAllowlist() []string {
 	}
 
 	return *ps.ScheduleAllowlist
+}
+
+// GetMaxDashboardRepos returns the MaxDashboardRepos field.
+//
+// When the provided Platform type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (ps *Platform) GetMaxDashboardRepos() int32 {
+	// return zero value if Platform type or MaxDashboardRepos field is nil
+	if ps == nil || ps.MaxDashboardRepos == nil {
+		return 0
+	}
+
+	return *ps.MaxDashboardRepos
 }
 
 // GetCreatedAt returns the CreatedAt field.
@@ -204,6 +222,19 @@ func (ps *Platform) SetScheduleAllowlist(v []string) {
 	ps.ScheduleAllowlist = &v
 }
 
+// SetMaxDashboardRepos sets the MaxDashboardRepos field.
+//
+// When the provided Platform type is nil, it
+// will set nothing and immediately return.
+func (ps *Platform) SetMaxDashboardRepos(v int32) {
+	// return if Platform type is nil
+	if ps == nil {
+		return
+	}
+
+	ps.MaxDashboardRepos = &v
+}
+
 // SetCreatedAt sets the CreatedAt field.
 //
 // When the provided Platform type is nil, it
@@ -258,6 +289,7 @@ func (ps *Platform) FromSettings(_ps *Platform) {
 	ps.SetQueue(_ps.GetQueue())
 	ps.SetRepoAllowlist(_ps.GetRepoAllowlist())
 	ps.SetScheduleAllowlist(_ps.GetScheduleAllowlist())
+	ps.SetMaxDashboardRepos(_ps.GetMaxDashboardRepos())
 
 	ps.SetCreatedAt(_ps.GetCreatedAt())
 	ps.SetUpdatedAt(_ps.GetUpdatedAt())
@@ -275,6 +307,7 @@ func (ps *Platform) String() string {
   Queue: %v,
   RepoAllowlist: %v,
   ScheduleAllowlist: %v,
+  MaxDashboardRepos: %d,
   CreatedAt: %d,
   UpdatedAt: %d,
   UpdatedBy: %s,
@@ -284,6 +317,7 @@ func (ps *Platform) String() string {
 		qs.String(),
 		ps.GetRepoAllowlist(),
 		ps.GetScheduleAllowlist(),
+		ps.GetMaxDashboardRepos(),
 		ps.GetCreatedAt(),
 		ps.GetUpdatedAt(),
 		ps.GetUpdatedBy(),
@@ -299,6 +333,7 @@ func PlatformMockEmpty() Platform {
 
 	ps.SetRepoAllowlist([]string{})
 	ps.SetScheduleAllowlist([]string{})
+	ps.SetMaxDashboardRepos(0)
 
 	return ps
 }

--- a/api/types/settings/platform.go
+++ b/api/types/settings/platform.go
@@ -5,8 +5,9 @@ package settings
 import (
 	"fmt"
 
-	"github.com/go-vela/server/util"
 	"github.com/urfave/cli/v3"
+
+	"github.com/go-vela/server/util"
 )
 
 // Platform is the API representation of platform settingps.

--- a/api/types/settings/platform_test.go
+++ b/api/types/settings/platform_test.go
@@ -43,6 +43,10 @@ func TestTypes_Platform_Getters(t *testing.T) {
 		if !reflect.DeepEqual(test.platform.GetScheduleAllowlist(), test.want.GetScheduleAllowlist()) {
 			t.Errorf("GetScheduleAllowlist is %v, want %v", test.platform.GetScheduleAllowlist(), test.want.GetScheduleAllowlist())
 		}
+
+		if test.platform.GetMaxDashboardRepos() != test.want.GetMaxDashboardRepos() {
+			t.Errorf("GetMaxDashboardRepos is %v, want %v", test.platform.GetMaxDashboardRepos(), test.want.GetMaxDashboardRepos())
+		}
 	}
 }
 
@@ -90,6 +94,12 @@ func TestTypes_Platform_Setters(t *testing.T) {
 		if !reflect.DeepEqual(test.platform.GetScheduleAllowlist(), test.want.GetScheduleAllowlist()) {
 			t.Errorf("SetScheduleAllowlist is %v, want %v", test.platform.GetScheduleAllowlist(), test.want.GetScheduleAllowlist())
 		}
+
+		test.platform.SetMaxDashboardRepos(test.want.GetMaxDashboardRepos())
+
+		if test.platform.GetMaxDashboardRepos() != test.want.GetMaxDashboardRepos() {
+			t.Errorf("SetMaxDashboardRepos is %v, want %v", test.platform.GetMaxDashboardRepos(), test.want.GetMaxDashboardRepos())
+		}
 	}
 }
 
@@ -103,6 +113,7 @@ func TestTypes_Platform_Update(t *testing.T) {
 	sUpdate.SetQueue(Queue{})
 	sUpdate.SetRepoAllowlist([]string{"foo"})
 	sUpdate.SetScheduleAllowlist([]string{"bar"})
+	sUpdate.SetMaxDashboardRepos(20)
 
 	// setup tests
 	tests := []struct {
@@ -141,6 +152,7 @@ func TestTypes_Platform_String(t *testing.T) {
   Queue: %v,
   RepoAllowlist: %v,
   ScheduleAllowlist: %v,
+  MaxDashboardRepos: %d,
   CreatedAt: %d,
   UpdatedAt: %d,
   UpdatedBy: %s,
@@ -150,6 +162,7 @@ func TestTypes_Platform_String(t *testing.T) {
 		qs.String(),
 		s.GetRepoAllowlist(),
 		s.GetScheduleAllowlist(),
+		s.GetMaxDashboardRepos(),
 		s.GetCreatedAt(),
 		s.GetUpdatedAt(),
 		s.GetUpdatedBy(),
@@ -174,6 +187,7 @@ func testPlatformSettings() *Platform {
 	s.SetUpdatedBy("vela-server")
 	s.SetRepoAllowlist([]string{"foo", "bar"})
 	s.SetScheduleAllowlist([]string{"*"})
+	s.SetMaxDashboardRepos(10)
 
 	// setup types
 	// setup compiler

--- a/cmd/vela-server/flags.go
+++ b/cmd/vela-server/flags.go
@@ -217,6 +217,12 @@ var Flags = []cli.Flag{
 			return nil
 		},
 	},
+	&cli.IntFlag{
+		Name:    "max-dashboard-repos",
+		Usage:   "set the maximum amount of repos that can belong to a dashboard",
+		Sources: cli.EnvVars("VELA_MAX_DASHBOARD_REPOS"),
+		Value:   10,
+	},
 	// Token Manager Flags
 	&cli.DurationFlag{
 		Name:    "user-access-token-duration",

--- a/constants/limit.go
+++ b/constants/limit.go
@@ -46,9 +46,6 @@ const (
 	// ReportStepStatusLimit defines the maximum number of steps in a pipeline that may report their status to the SCM.
 	ReportStepStatusLimit = 10
 
-	// DashboardRepoLimit defines the maximum number of repos that can be assigned to a dashboard.
-	DashboardRepoLimit = 10
-
 	// UserDashboardLimit defines the maximum number of dashboards that can be assigned to a user.
 	UserDashboardLimit = 10
 

--- a/database/settings/create_test.go
+++ b/database/settings/create_test.go
@@ -20,6 +20,7 @@ func TestSettings_Engine_CreateSettings(t *testing.T) {
 	_settings.SetRoutes([]string{"vela"})
 	_settings.SetRepoAllowlist([]string{"octocat/hello-world"})
 	_settings.SetScheduleAllowlist([]string{"*"})
+	_settings.SetMaxDashboardRepos(10)
 	_settings.SetCreatedAt(1)
 	_settings.SetUpdatedAt(1)
 	_settings.SetUpdatedBy("")
@@ -31,9 +32,9 @@ func TestSettings_Engine_CreateSettings(t *testing.T) {
 	_rows := sqlmock.NewRows([]string{"id"}).AddRow(1)
 
 	// ensure the mock expects the query
-	_mock.ExpectQuery(`INSERT INTO "settings" ("compiler","queue","repo_allowlist","schedule_allowlist","created_at","updated_at","updated_by","id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING "id"`).
+	_mock.ExpectQuery(`INSERT INTO "settings" ("compiler","queue","repo_allowlist","schedule_allowlist","max_dashboard_repos","created_at","updated_at","updated_by","id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9) RETURNING "id"`).
 		WithArgs(`{"clone_image":{"String":"target/vela-git-slim:latest","Valid":true},"template_depth":{"Int64":10,"Valid":true},"starlark_exec_limit":{"Int64":100,"Valid":true}}`,
-			`{"routes":["vela"]}`, `{"octocat/hello-world"}`, `{"*"}`, 1, 1, ``, 1).
+			`{"routes":["vela"]}`, `{"octocat/hello-world"}`, `{"*"}`, 10, 1, 1, ``, 1).
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)

--- a/database/settings/get_test.go
+++ b/database/settings/get_test.go
@@ -22,6 +22,7 @@ func TestSettings_Engine_GetSettings(t *testing.T) {
 	_settings.SetRoutes([]string{"vela"})
 	_settings.SetRepoAllowlist([]string{"octocat/hello-world"})
 	_settings.SetScheduleAllowlist([]string{"*"})
+	_settings.SetMaxDashboardRepos(10)
 	_settings.SetCreatedAt(1)
 	_settings.SetUpdatedAt(1)
 	_settings.SetUpdatedBy("octocat")

--- a/database/settings/table.go
+++ b/database/settings/table.go
@@ -19,6 +19,7 @@ settings (
 	queue               JSON DEFAULT NULL,
 	repo_allowlist      VARCHAR(1000),
 	schedule_allowlist  VARCHAR(1000),
+	max_dashboard_repos INTEGER,
 	created_at          BIGINT,
 	updated_at          BIGINT,
 	updated_by          VARCHAR(250)
@@ -35,6 +36,7 @@ settings (
 	queue         	   	   	TEXT,
 	repo_allowlist	   	   	VARCHAR(1000),
 	schedule_allowlist		VARCHAR(1000),
+	max_dashboard_repos     INTEGER,
 	created_at         		INTEGER,
 	updated_at         		INTEGER,
 	updated_by         		TEXT

--- a/database/settings/table.go
+++ b/database/settings/table.go
@@ -31,15 +31,15 @@ settings (
 CREATE TABLE
 IF NOT EXISTS
 settings (
-	id                 	   	INTEGER PRIMARY KEY AUTOINCREMENT,
-	compiler           	   	TEXT,
-	queue         	   	   	TEXT,
-	repo_allowlist	   	   	VARCHAR(1000),
-	schedule_allowlist		VARCHAR(1000),
+	id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+	compiler                TEXT,
+	queue                   TEXT,
+	repo_allowlist          VARCHAR(1000),
+	schedule_allowlist      VARCHAR(1000),
 	max_dashboard_repos     INTEGER,
-	created_at         		INTEGER,
-	updated_at         		INTEGER,
-	updated_by         		TEXT
+	created_at              INTEGER,
+	updated_at              INTEGER,
+	updated_by              TEXT
 );
 `
 )

--- a/database/settings/update_test.go
+++ b/database/settings/update_test.go
@@ -22,6 +22,7 @@ func TestSettings_Engine_UpdateSettings(t *testing.T) {
 	_settings.SetRoutes([]string{"vela", "large"})
 	_settings.SetRepoAllowlist([]string{"octocat/hello-world"})
 	_settings.SetScheduleAllowlist([]string{"*"})
+	_settings.SetMaxDashboardRepos(10)
 	_settings.SetCreatedAt(1)
 	_settings.SetUpdatedAt(1)
 	_settings.SetUpdatedBy("octocat")
@@ -30,9 +31,9 @@ func TestSettings_Engine_UpdateSettings(t *testing.T) {
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
-	_mock.ExpectExec(`UPDATE "settings" SET "compiler"=$1,"queue"=$2,"repo_allowlist"=$3,"schedule_allowlist"=$4,"created_at"=$5,"updated_at"=$6,"updated_by"=$7 WHERE "id" = $8`).
+	_mock.ExpectExec(`UPDATE "settings" SET "compiler"=$1,"queue"=$2,"repo_allowlist"=$3,"schedule_allowlist"=$4,"max_dashboard_repos"=$5,"created_at"=$6,"updated_at"=$7,"updated_by"=$8 WHERE "id" = $9`).
 		WithArgs(`{"clone_image":{"String":"target/vela-git-slim:latest","Valid":true},"template_depth":{"Int64":10,"Valid":true},"starlark_exec_limit":{"Int64":100,"Valid":true}}`,
-			`{"routes":["vela","large"]}`, `{"octocat/hello-world"}`, `{"*"}`, 1, testutils.AnyArgument{}, "octocat", 1).
+			`{"routes":["vela","large"]}`, `{"octocat/hello-world"}`, `{"*"}`, 10, 1, testutils.AnyArgument{}, "octocat", 1).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)

--- a/database/types/dashboard.go
+++ b/database/types/dashboard.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/uuid"
 
 	api "github.com/go-vela/server/api/types"
-	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/util"
 )
 
@@ -141,11 +140,6 @@ func (d *Dashboard) Validate() error {
 	// verify the Name field is populated
 	if len(d.Name.String) == 0 {
 		return ErrEmptyDashName
-	}
-
-	// verify the number of repos
-	if len(d.Repos) > constants.DashboardRepoLimit {
-		return fmt.Errorf("exceeded repos limit of %d", constants.DashboardRepoLimit)
 	}
 
 	// ensure that all Dashboard string fields

--- a/database/types/dashboard_test.go
+++ b/database/types/dashboard_test.go
@@ -90,17 +90,6 @@ func TestTypes_Dashboard_ToAPI(t *testing.T) {
 func TestTypes_Dashboard_Validate(t *testing.T) {
 	uuid, _ := uuid.Parse("c8da1302-07d6-11ea-882f-4893bca275b8")
 
-	dashRepo := new(api.DashboardRepo)
-	dashRepo.SetName("dashboard-repo")
-
-	dashRepos := []*api.DashboardRepo{}
-	for i := 0; i < 11; i++ {
-		dashRepos = append(dashRepos, dashRepo)
-	}
-
-	exceededReposDashboard := testDashboard()
-	exceededReposDashboard.Repos = DashReposJSON(dashRepos)
-
 	// setup tests
 	tests := []struct {
 		failure   bool
@@ -115,10 +104,6 @@ func TestTypes_Dashboard_Validate(t *testing.T) {
 			dashboard: &Dashboard{
 				ID: uuid,
 			},
-		},
-		{ // hit repo limit
-			failure:   true,
-			dashboard: exceededReposDashboard,
 		},
 	}
 

--- a/database/types/settings.go
+++ b/database/types/settings.go
@@ -28,8 +28,8 @@ type (
 		Compiler `json:"compiler" sql:"compiler"`
 		Queue    `json:"queue"    sql:"queue"`
 
-		RepoAllowlist     pq.StringArray `json:"repo_allowlist"      sql:"repo_allowlist"     gorm:"type:varchar(1000)"`
-		ScheduleAllowlist pq.StringArray `json:"schedule_allowlist"  sql:"schedule_allowlist" gorm:"type:varchar(1000)"`
+		RepoAllowlist     pq.StringArray `json:"repo_allowlist"      sql:"repo_allowlist"      gorm:"type:varchar(1000)"`
+		ScheduleAllowlist pq.StringArray `json:"schedule_allowlist"  sql:"schedule_allowlist"  gorm:"type:varchar(1000)"`
 		MaxDashboardRepos sql.NullInt32  `json:"max_dashboard_repos" sql:"max_dashboard_repos"`
 
 		CreatedAt sql.NullInt64  `sql:"created_at"`

--- a/database/types/settings_test.go
+++ b/database/types/settings_test.go
@@ -53,6 +53,7 @@ func TestTypes_Platform_ToAPI(t *testing.T) {
 	want.SetID(1)
 	want.SetRepoAllowlist([]string{"github/octocat"})
 	want.SetScheduleAllowlist([]string{"*"})
+	want.SetMaxDashboardRepos(10)
 	want.SetCreatedAt(0)
 	want.SetUpdatedAt(0)
 	want.SetUpdatedBy("")
@@ -86,7 +87,8 @@ func TestTypes_Platform_Validate(t *testing.T) {
 		{ // no CloneImage set for settings
 			failure: true,
 			settings: &Platform{
-				ID: sql.NullInt32{Int32: 1, Valid: true},
+				ID:                sql.NullInt32{Int32: 1, Valid: true},
+				MaxDashboardRepos: sql.NullInt32{Int32: 10, Valid: true},
 				Compiler: Compiler{
 					TemplateDepth:     sql.NullInt64{Int64: 10, Valid: true},
 					StarlarkExecLimit: sql.NullInt64{Int64: 100, Valid: true},
@@ -96,7 +98,8 @@ func TestTypes_Platform_Validate(t *testing.T) {
 		{ // no TemplateDepth set for settings
 			failure: true,
 			settings: &Platform{
-				ID: sql.NullInt32{Int32: 1, Valid: true},
+				ID:                sql.NullInt32{Int32: 1, Valid: true},
+				MaxDashboardRepos: sql.NullInt32{Int32: 10, Valid: true},
 				Compiler: Compiler{
 					CloneImage:        sql.NullString{String: "target/vela-git-slim:latest", Valid: true},
 					StarlarkExecLimit: sql.NullInt64{Int64: 100, Valid: true},
@@ -106,17 +109,30 @@ func TestTypes_Platform_Validate(t *testing.T) {
 		{ // no StarlarkExecLimit set for settings
 			failure: true,
 			settings: &Platform{
-				ID: sql.NullInt32{Int32: 1, Valid: true},
+				ID:                sql.NullInt32{Int32: 1, Valid: true},
+				MaxDashboardRepos: sql.NullInt32{Int32: 10, Valid: true},
 				Compiler: Compiler{
 					CloneImage:    sql.NullString{String: "target/vela-git-slim:latest", Valid: true},
 					TemplateDepth: sql.NullInt64{Int64: 10, Valid: true},
 				},
 			},
 		},
+		{ // no MaxDashboardRepos set for settings
+			failure: true,
+			settings: &Platform{
+				ID: sql.NullInt32{Int32: 1, Valid: true},
+				Compiler: Compiler{
+					CloneImage:        sql.NullString{String: "target/vela-git-slim:latest", Valid: true},
+					TemplateDepth:     sql.NullInt64{Int64: 10, Valid: true},
+					StarlarkExecLimit: sql.NullInt64{Int64: 100, Valid: true},
+				},
+			},
+		},
 		{ // no queue fields set for settings
 			failure: false,
 			settings: &Platform{
-				ID: sql.NullInt32{Int32: 1, Valid: true},
+				ID:                sql.NullInt32{Int32: 1, Valid: true},
+				MaxDashboardRepos: sql.NullInt32{Int32: 10, Valid: true},
 				Compiler: Compiler{
 					CloneImage:        sql.NullString{String: "target/vela-git-slim:latest", Valid: true},
 					TemplateDepth:     sql.NullInt64{Int64: 10, Valid: true},
@@ -151,6 +167,7 @@ func TestTypes_Platform_PlatformFromAPI(t *testing.T) {
 	s.SetID(1)
 	s.SetRepoAllowlist([]string{"github/octocat"})
 	s.SetScheduleAllowlist([]string{"*"})
+	s.SetMaxDashboardRepos(10)
 	s.SetCreatedAt(0)
 	s.SetUpdatedAt(0)
 	s.SetUpdatedBy("")
@@ -188,6 +205,7 @@ func testPlatform() *Platform {
 		},
 		RepoAllowlist:     []string{"github/octocat"},
 		ScheduleAllowlist: []string{"*"},
+		MaxDashboardRepos: sql.NullInt32{Int32: 10, Valid: true},
 		CreatedAt:         sql.NullInt64{Int64: 0, Valid: true},
 		UpdatedAt:         sql.NullInt64{Int64: 0, Valid: true},
 		UpdatedBy:         sql.NullString{String: "", Valid: true},

--- a/mock/server/settings.go
+++ b/mock/server/settings.go
@@ -32,6 +32,7 @@ const (
 			"schedule_allowlist": [
 				"octocat/hello-world"
 			],
+			"max_dashboard_repos": 10,
 			"created_at": 1,
 			"updated_at": 1,
 			"updated_by": "octocat"
@@ -57,6 +58,7 @@ const (
 				"octocat/hello-world",
 				"octocat/*"
 			],
+			"max_dashboard_repos": 10,
 			"created_at": 1,
 			"updated_at": 1,
 			"updated_by": "octocat"
@@ -82,6 +84,7 @@ const (
 			"octocat/hello-world",
 			"octocat/*"
 		],
+		"max_dashboard_repos": 10,
 		"created_at": 1,
 		"updated_at": 1,
 		"updated_by": "octocat"

--- a/scm/github/access.go
+++ b/scm/github/access.go
@@ -26,7 +26,6 @@ func (c *Client) OrgAccess(ctx context.Context, u *api.User, org string) (string
 			"user": u.GetName(),
 		}).Debugf("skipping access level check for user %s with org %s", u.GetName(), org)
 
-		//nolint:goconst // ignore making constant
 		return "admin", nil
 	}
 


### PR DESCRIPTION
Since the dashboard repos are just stored as JSON in the database, the limit on number of repos should probably be adjustable rather than firmly set at 10.

Breaking because it adds a column to the settings DB table.