### PR TITLE
fix(queue): validate addr in opts not flags

### DIFF
--- a/queue/flags.go
+++ b/queue/flags.go
@@ -38,7 +38,6 @@ var Flags = []cli.Flag{
 			cli.EnvVar("QUEUE_ADDR"),
 			cli.File("/vela/queue/addr"),
 		),
-		Required: true,
 		Action: func(_ context.Context, _ *cli.Command, v string) error {
 			// check if the queue address has a scheme
 			if !strings.Contains(v, "://") {

--- a/queue/flags_test.go
+++ b/queue/flags_test.go
@@ -63,13 +63,12 @@ func TestDatabase_Flags(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "empty addr",
+			name: "empty addr - validated in opts",
 			flags: map[string]string{
 				"queue.driver":     "redis",
 				"queue.routes":     "vela,worker",
 				"queue.public-key": "CuS+EQAzofbk3tVFS3bt5f2tIb4YiJJC4nVMFQYQElg=",
 			},
-			wantErr: true,
 		},
 		{
 			name: "invalid addr",
@@ -92,7 +91,7 @@ func TestDatabase_Flags(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "empty public key",
+			name: "empty public key - validated in opts",
 			flags: map[string]string{
 				"queue.driver": "redis",
 				"queue.addr":   "redis://redis.example.com",


### PR DESCRIPTION
Since worker can either source queue creds or fetch them from server, flag validation should allow for empty values while setup routines do the checking