### PR TITLE
enhance(log)!: add timestamp field

### DIFF
--- a/api/log/create_service.go
+++ b/api/log/create_service.go
@@ -5,6 +5,7 @@ package log
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -104,6 +105,7 @@ func CreateServiceLog(c *gin.Context) {
 	input.SetServiceID(s.GetID())
 	input.SetBuildID(b.GetID())
 	input.SetRepoID(r.GetID())
+	input.SetCreatedAt(time.Now().UTC().Unix())
 
 	// send API call to create the logs
 	err = database.FromContext(c).CreateLog(ctx, input)

--- a/api/log/create_step.go
+++ b/api/log/create_step.go
@@ -5,6 +5,7 @@ package log
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -104,6 +105,7 @@ func CreateStepLog(c *gin.Context) {
 	input.SetStepID(s.GetID())
 	input.SetBuildID(b.GetID())
 	input.SetRepoID(r.GetID())
+	input.SetCreatedAt(time.Now().UTC().Unix())
 
 	// send API call to create the logs
 	err = database.FromContext(c).CreateLog(ctx, input)

--- a/api/service/plan.go
+++ b/api/service/plan.go
@@ -59,6 +59,7 @@ func PlanServices(ctx context.Context, database database.Interface, p *pipeline.
 		l.SetBuildID(b.GetID())
 		l.SetRepoID(b.GetRepo().GetID())
 		l.SetData([]byte{})
+		l.SetCreatedAt(time.Now().UTC().Unix())
 
 		// send API call to create the service logs
 		err = database.CreateLog(ctx, l)

--- a/api/step/plan.go
+++ b/api/step/plan.go
@@ -89,6 +89,7 @@ func planStep(ctx context.Context, database database.Interface, scm scm.Service,
 	l.SetBuildID(b.GetID())
 	l.SetRepoID(b.GetRepo().GetID())
 	l.SetData([]byte{})
+	l.SetCreatedAt(time.Now().UTC().Unix())
 
 	// send API call to create the step logs
 	err = database.CreateLog(ctx, l)

--- a/api/types/log.go
+++ b/api/types/log.go
@@ -19,7 +19,8 @@ type Log struct {
 	ServiceID *int64 `json:"service_id,omitempty"`
 	StepID    *int64 `json:"step_id,omitempty"`
 	// swagger:strfmt base64
-	Data *[]byte `json:"data,omitempty"`
+	Data      *[]byte `json:"data,omitempty"`
+	CreatedAt *int64  `json:"created_at,omitempty"`
 }
 
 // AppendData adds the provided data to the end of
@@ -137,6 +138,19 @@ func (l *Log) GetData() []byte {
 	return *l.Data
 }
 
+// GetCreatedAt returns the CreatedAt field.
+//
+// When the provided log type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (l *Log) GetCreatedAt() int64 {
+	// return zero value if log type or CreatedAt field is nil
+	if l == nil || l.CreatedAt == nil {
+		return 0
+	}
+
+	return *l.CreatedAt
+}
+
 // SetID sets the ID field.
 //
 // When the provided Log type is nil, it
@@ -215,6 +229,19 @@ func (l *Log) SetData(v []byte) {
 	l.Data = &v
 }
 
+// SetCreatedAt sets the CreatedAt field.
+//
+// When the provided log type is nil, it
+// will set nothing and immediately return.
+func (l *Log) SetCreatedAt(v int64) {
+	// return if Secret type is nil
+	if l == nil {
+		return
+	}
+
+	l.CreatedAt = &v
+}
+
 // String implements the Stringer interface for the Log type.
 func (l *Log) String() string {
 	return fmt.Sprintf(`{
@@ -224,6 +251,7 @@ func (l *Log) String() string {
   RepoID: %d,
   ServiceID: %d,
   StepID: %d,
+  CreatedAt: %d,
 }`,
 		l.GetBuildID(),
 		l.GetData(),
@@ -231,5 +259,6 @@ func (l *Log) String() string {
 		l.GetRepoID(),
 		l.GetServiceID(),
 		l.GetStepID(),
+		l.GetCreatedAt(),
 	)
 }

--- a/api/types/log.go
+++ b/api/types/log.go
@@ -234,7 +234,7 @@ func (l *Log) SetData(v []byte) {
 // When the provided log type is nil, it
 // will set nothing and immediately return.
 func (l *Log) SetCreatedAt(v int64) {
-	// return if Secret type is nil
+	// return if log type is nil
 	if l == nil {
 		return
 	}

--- a/api/types/log_test.go
+++ b/api/types/log_test.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestTypes_Log_AppendData(t *testing.T) {
@@ -176,6 +179,10 @@ func TestTypes_Log_Getters(t *testing.T) {
 		if !reflect.DeepEqual(test.log.GetData(), test.want.GetData()) {
 			t.Errorf("GetData is %v, want %v", test.log.GetData(), test.want.GetData())
 		}
+
+		if test.log.GetCreatedAt() != test.want.GetCreatedAt() {
+			t.Errorf("GetCreatedAt is %v, want %v", test.log.GetCreatedAt(), test.want.GetCreatedAt())
+		}
 	}
 }
 
@@ -206,6 +213,7 @@ func TestTypes_Log_Setters(t *testing.T) {
 		test.log.SetBuildID(test.want.GetBuildID())
 		test.log.SetRepoID(test.want.GetRepoID())
 		test.log.SetData(test.want.GetData())
+		test.log.SetCreatedAt(test.want.GetCreatedAt())
 
 		if test.log.GetID() != test.want.GetID() {
 			t.Errorf("SetID is %v, want %v", test.log.GetID(), test.want.GetID())
@@ -230,6 +238,10 @@ func TestTypes_Log_Setters(t *testing.T) {
 		if !reflect.DeepEqual(test.log.GetData(), test.want.GetData()) {
 			t.Errorf("SetData is %v, want %v", test.log.GetData(), test.want.GetData())
 		}
+
+		if test.log.GetCreatedAt() != test.want.GetCreatedAt() {
+			t.Errorf("SetCreatedAt is %v, want %v", test.log.GetCreatedAt(), test.want.GetCreatedAt())
+		}
 	}
 }
 
@@ -244,6 +256,7 @@ func TestTypes_Log_String(t *testing.T) {
   RepoID: %d,
   ServiceID: %d,
   StepID: %d,
+  CreatedAt: %d,
 }`,
 		l.GetBuildID(),
 		l.GetData(),
@@ -251,19 +264,22 @@ func TestTypes_Log_String(t *testing.T) {
 		l.GetRepoID(),
 		l.GetServiceID(),
 		l.GetStepID(),
+		l.GetCreatedAt(),
 	)
 
 	// run test
 	got := l.String()
 
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("String is %v, want %v", got, want)
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("String Mismatch: -want +got):\n%s", diff)
 	}
 }
 
 // testLog is a test helper function to create a Log
 // type with all fields set to a fake value.
 func testLog() *Log {
+	currentTime := time.Now()
+	tsCreate := currentTime.UTC().Unix()
 	l := new(Log)
 
 	l.SetID(1)
@@ -272,6 +288,7 @@ func testLog() *Log {
 	l.SetBuildID(1)
 	l.SetRepoID(1)
 	l.SetData([]byte("foo"))
+	l.SetCreatedAt(tsCreate)
 
 	return l
 }

--- a/database/integration_test.go
+++ b/database/integration_test.go
@@ -2730,6 +2730,7 @@ func newResources() *Resources {
 	logServiceOne.SetServiceID(1)
 	logServiceOne.SetStepID(0)
 	logServiceOne.SetData([]byte("foo"))
+	logServiceOne.SetCreatedAt(time.Now().UTC().Unix())
 
 	logServiceTwo := new(api.Log)
 	logServiceTwo.SetID(2)
@@ -2738,6 +2739,7 @@ func newResources() *Resources {
 	logServiceTwo.SetServiceID(2)
 	logServiceTwo.SetStepID(0)
 	logServiceTwo.SetData([]byte("foo"))
+	logServiceTwo.SetCreatedAt(time.Now().UTC().Unix())
 
 	logStepOne := new(api.Log)
 	logStepOne.SetID(3)
@@ -2746,6 +2748,7 @@ func newResources() *Resources {
 	logStepOne.SetServiceID(0)
 	logStepOne.SetStepID(1)
 	logStepOne.SetData([]byte("foo"))
+	logStepOne.SetCreatedAt(time.Now().UTC().Unix())
 
 	logStepTwo := new(api.Log)
 	logStepTwo.SetID(4)
@@ -2754,6 +2757,7 @@ func newResources() *Resources {
 	logStepTwo.SetServiceID(0)
 	logStepTwo.SetStepID(2)
 	logStepTwo.SetData([]byte("foo"))
+	logStepTwo.SetCreatedAt(time.Now().UTC().Unix())
 
 	pipelineOne := new(api.Pipeline)
 	pipelineOne.SetID(1)

--- a/database/log/count_build_test.go
+++ b/database/log/count_build_test.go
@@ -19,12 +19,14 @@ func TestLog_Engine_CountLogsForBuild(t *testing.T) {
 	_service.SetRepoID(1)
 	_service.SetBuildID(1)
 	_service.SetServiceID(1)
+	_service.SetCreatedAt(1)
 
 	_step := testutils.APILog()
 	_step.SetID(2)
 	_step.SetRepoID(1)
 	_step.SetBuildID(1)
 	_step.SetStepID(1)
+	_step.SetCreatedAt(1)
 
 	_repo := testutils.APIRepo()
 	_repo.SetID(1)

--- a/database/log/count_test.go
+++ b/database/log/count_test.go
@@ -19,12 +19,14 @@ func TestLog_Engine_CountLogs(t *testing.T) {
 	_service.SetRepoID(1)
 	_service.SetBuildID(1)
 	_service.SetServiceID(1)
+	_service.SetCreatedAt(1)
 
 	_step := testutils.APILog()
 	_step.SetID(2)
 	_step.SetRepoID(1)
 	_step.SetBuildID(1)
 	_step.SetStepID(1)
+	_step.SetCreatedAt(1)
 
 	_postgres, _mock := testPostgres(t)
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()

--- a/database/log/create_test.go
+++ b/database/log/create_test.go
@@ -19,12 +19,14 @@ func TestLog_Engine_CreateLog(t *testing.T) {
 	_service.SetRepoID(1)
 	_service.SetBuildID(1)
 	_service.SetServiceID(1)
+	_service.SetCreatedAt(1)
 
 	_step := testutils.APILog()
 	_step.SetID(2)
 	_step.SetRepoID(1)
 	_step.SetBuildID(1)
 	_step.SetStepID(1)
+	_step.SetCreatedAt(1)
 
 	_postgres, _mock := testPostgres(t)
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
@@ -34,16 +36,16 @@ func TestLog_Engine_CreateLog(t *testing.T) {
 
 	// ensure the mock expects the service query
 	_mock.ExpectQuery(`INSERT INTO "logs"
-("build_id","repo_id","service_id","step_id","data","id")
-VALUES ($1,$2,$3,$4,$5,$6) RETURNING "id"`).
-		WithArgs(1, 1, 1, nil, AnyArgument{}, 1).
+("build_id","repo_id","service_id","step_id","data","created_at","id")
+VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING "id"`).
+		WithArgs(1, 1, 1, nil, AnyArgument{}, 1, 1).
 		WillReturnRows(_rows)
 
 	// ensure the mock expects the step query
 	_mock.ExpectQuery(`INSERT INTO "logs"
-("build_id","repo_id","service_id","step_id","data","id")
-VALUES ($1,$2,$3,$4,$5,$6) RETURNING "id"`).
-		WithArgs(1, 1, nil, 1, AnyArgument{}, 2).
+("build_id","repo_id","service_id","step_id","data","created_at","id")
+VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING "id"`).
+		WithArgs(1, 1, nil, 1, AnyArgument{}, 1, 2).
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)

--- a/database/log/delete_test.go
+++ b/database/log/delete_test.go
@@ -18,6 +18,7 @@ func TestLog_Engine_DeleteLog(t *testing.T) {
 	_log.SetRepoID(1)
 	_log.SetBuildID(1)
 	_log.SetStepID(1)
+	_log.SetCreatedAt(1)
 
 	_postgres, _mock := testPostgres(t)
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()

--- a/database/log/get_service_test.go
+++ b/database/log/get_service_test.go
@@ -20,6 +20,7 @@ func TestLog_Engine_GetLogForService(t *testing.T) {
 	_log.SetBuildID(1)
 	_log.SetServiceID(1)
 	_log.SetData([]byte{})
+	_log.SetCreatedAt(1)
 
 	_service := testutils.APIService()
 	_service.SetID(1)

--- a/database/log/get_step_test.go
+++ b/database/log/get_step_test.go
@@ -20,6 +20,7 @@ func TestLog_Engine_GetLogForStep(t *testing.T) {
 	_log.SetBuildID(1)
 	_log.SetStepID(1)
 	_log.SetData([]byte{})
+	_log.SetCreatedAt(1)
 
 	_step := testutils.APIStep()
 	_step.SetID(1)

--- a/database/log/get_test.go
+++ b/database/log/get_test.go
@@ -20,6 +20,7 @@ func TestLog_Engine_GetLog(t *testing.T) {
 	_log.SetBuildID(1)
 	_log.SetStepID(1)
 	_log.SetData([]byte{})
+	_log.SetCreatedAt(1)
 
 	_postgres, _mock := testPostgres(t)
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()

--- a/database/log/list_build_test.go
+++ b/database/log/list_build_test.go
@@ -20,6 +20,7 @@ func TestLog_Engine_ListLogsForBuild(t *testing.T) {
 	_service.SetBuildID(1)
 	_service.SetServiceID(1)
 	_service.SetData([]byte{})
+	_service.SetCreatedAt(1)
 
 	_step := testutils.APILog()
 	_step.SetID(2)
@@ -27,6 +28,7 @@ func TestLog_Engine_ListLogsForBuild(t *testing.T) {
 	_step.SetBuildID(1)
 	_step.SetStepID(1)
 	_step.SetData([]byte{})
+	_step.SetCreatedAt(1)
 
 	_repo := testutils.APIRepo()
 	_repo.SetID(1)

--- a/database/log/list_test.go
+++ b/database/log/list_test.go
@@ -20,6 +20,7 @@ func TestLog_Engine_ListLogs(t *testing.T) {
 	_service.SetBuildID(1)
 	_service.SetServiceID(1)
 	_service.SetData([]byte{})
+	_service.SetCreatedAt(1)
 
 	_step := testutils.APILog()
 	_step.SetID(2)
@@ -27,6 +28,7 @@ func TestLog_Engine_ListLogs(t *testing.T) {
 	_step.SetBuildID(1)
 	_step.SetStepID(1)
 	_step.SetData([]byte{})
+	_step.SetCreatedAt(1)
 
 	_postgres, _mock := testPostgres(t)
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()

--- a/database/log/table.go
+++ b/database/log/table.go
@@ -20,6 +20,7 @@ logs (
 	service_id    BIGINT,
 	step_id       BIGINT,
 	data          BYTEA,
+	created_at    BIGINT,
 	UNIQUE(step_id),
 	UNIQUE(service_id)
 );
@@ -36,6 +37,7 @@ logs (
 	service_id    INTEGER,
 	step_id       INTEGER,
 	data          BLOB,
+	created_at    INTEGER,
 	UNIQUE(step_id),
 	UNIQUE(service_id)
 );

--- a/database/log/update_test.go
+++ b/database/log/update_test.go
@@ -20,6 +20,7 @@ func TestLog_Engine_UpdateLog(t *testing.T) {
 	_service.SetBuildID(1)
 	_service.SetServiceID(1)
 	_service.SetData([]byte{})
+	_service.SetCreatedAt(1)
 
 	_step := testutils.APILog()
 	_step.SetID(2)
@@ -27,22 +28,23 @@ func TestLog_Engine_UpdateLog(t *testing.T) {
 	_step.SetBuildID(1)
 	_step.SetStepID(1)
 	_step.SetData([]byte{})
+	_step.SetCreatedAt(1)
 
 	_postgres, _mock := testPostgres(t)
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the service query
 	_mock.ExpectExec(`UPDATE "logs"
-SET "build_id"=$1,"repo_id"=$2,"service_id"=$3,"step_id"=$4,"data"=$5
-WHERE "id" = $6`).
-		WithArgs(1, 1, 1, nil, AnyArgument{}, 1).
+SET "build_id"=$1,"repo_id"=$2,"service_id"=$3,"step_id"=$4,"data"=$5,"created_at"=$6
+WHERE "id" = $7`).
+		WithArgs(1, 1, 1, nil, AnyArgument{}, 1, 1).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	// ensure the mock expects the step query
 	_mock.ExpectExec(`UPDATE "logs"
-SET "build_id"=$1,"repo_id"=$2,"service_id"=$3,"step_id"=$4,"data"=$5
-WHERE "id" = $6`).
-		WithArgs(1, 1, nil, 1, AnyArgument{}, 2).
+SET "build_id"=$1,"repo_id"=$2,"service_id"=$3,"step_id"=$4,"data"=$5,"created_at"=$6
+WHERE "id" = $7`).
+		WithArgs(1, 1, nil, 1, AnyArgument{}, 1, 2).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)

--- a/database/types/log.go
+++ b/database/types/log.go
@@ -32,6 +32,7 @@ type Log struct {
 	ServiceID sql.NullInt64 `sql:"service_id"`
 	StepID    sql.NullInt64 `sql:"step_id"`
 	Data      []byte        `sql:"data"`
+	CreatedAt sql.NullInt64 `sql:"created_at"`
 }
 
 // Compress will manipulate the existing data for the
@@ -104,6 +105,11 @@ func (l *Log) Nullify() *Log {
 		l.StepID.Valid = false
 	}
 
+	// check if the CreatedAt field should be false
+	if l.CreatedAt.Int64 == 0 {
+		l.CreatedAt.Valid = false
+	}
+
 	return l
 }
 
@@ -118,6 +124,7 @@ func (l *Log) ToAPI() *api.Log {
 	log.SetServiceID(l.ServiceID.Int64)
 	log.SetStepID(l.StepID.Int64)
 	log.SetData(l.Data)
+	log.SetCreatedAt(l.CreatedAt.Int64)
 
 	return log
 }
@@ -153,6 +160,7 @@ func LogFromAPI(l *api.Log) *Log {
 		ServiceID: sql.NullInt64{Int64: l.GetServiceID(), Valid: true},
 		StepID:    sql.NullInt64{Int64: l.GetStepID(), Valid: true},
 		Data:      l.GetData(),
+		CreatedAt: sql.NullInt64{Int64: l.GetCreatedAt(), Valid: true},
 	}
 
 	return log.Nullify()

--- a/database/types/log_test.go
+++ b/database/types/log_test.go
@@ -233,6 +233,7 @@ func TestDatabase_Log_Nullify(t *testing.T) {
 		RepoID:    sql.NullInt64{Int64: 0, Valid: false},
 		ServiceID: sql.NullInt64{Int64: 0, Valid: false},
 		StepID:    sql.NullInt64{Int64: 0, Valid: false},
+		CreatedAt: sql.NullInt64{Int64: 0, Valid: false},
 	}
 
 	// setup tests
@@ -274,6 +275,7 @@ func TestDatabase_Log_ToAPI(t *testing.T) {
 	want.SetBuildID(1)
 	want.SetRepoID(1)
 	want.SetData([]byte("foo"))
+	want.SetCreatedAt(tsCreate)
 
 	// run test
 	got := testLog().ToAPI()
@@ -349,6 +351,7 @@ func TestDatabase_LogFromAPI(t *testing.T) {
 	l.SetBuildID(1)
 	l.SetRepoID(1)
 	l.SetData([]byte("foo"))
+	l.SetCreatedAt(tsCreate)
 
 	want := testLog()
 
@@ -370,5 +373,6 @@ func testLog() *Log {
 		ServiceID: sql.NullInt64{Int64: 1, Valid: true},
 		StepID:    sql.NullInt64{Int64: 1, Valid: true},
 		Data:      []byte("foo"),
+		CreatedAt: sql.NullInt64{Int64: tsCreate, Valid: true},
 	}
 }

--- a/mock/server/log.go
+++ b/mock/server/log.go
@@ -21,7 +21,8 @@ const (
   "repo_id": 1,
   "service_id": 1,
   "step_id": 1,
-  "data": "SGVsbG8sIFdvcmxkIQ=="
+  "data": "SGVsbG8sIFdvcmxkIQ==",
+  "created_at": 1
 }`
 )
 


### PR DESCRIPTION
adding timestamp field to log table.

to note, `BIGINT` used for consistency with other tables, but might not be the most straight-forward for partitioning by time spans. open to change that or add on to it.