### PR TITLE
fix(api): pass correct build into Gatekeep helper func

### DIFF
--- a/api/build/restart.go
+++ b/api/build/restart.go
@@ -173,7 +173,7 @@ func RestartBuild(c *gin.Context) {
 			item.Build.GetHost(),
 		)
 	} else {
-		err := GatekeepBuild(c, b, r)
+		err := GatekeepBuild(c, item.Build, item.Build.GetRepo())
 		if err != nil {
 			util.HandleError(c, http.StatusInternalServerError, err)
 

--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -623,7 +623,7 @@ func PostWebhook(c *gin.Context) {
 			b.GetHost(),
 		)
 	} else {
-		err := build.GatekeepBuild(c, b, repo)
+		err := build.GatekeepBuild(c, item.Build, item.Build.GetRepo())
 		if err != nil {
 			retErr := fmt.Errorf("unable to gate build: %w", err)
 			util.HandleError(c, http.StatusInternalServerError, err)


### PR DESCRIPTION
Technically this change is only needed for restart since `build` is up to date with its number and such in `PostWebhook` but I think using `item.Build` for all post- compiling/planning is good practice.