### PR TITLE
enhance(scm): verify owner access to repos prior to generating install token

### DIFF
--- a/compiler/types/yaml/yaml/git.go
+++ b/compiler/types/yaml/yaml/git.go
@@ -2,7 +2,11 @@
 
 package yaml
 
-import "github.com/go-vela/server/compiler/types/pipeline"
+import (
+	"strings"
+
+	"github.com/go-vela/server/compiler/types/pipeline"
+)
 
 // Git is the yaml representation of git configurations for a pipeline.
 type Git struct {
@@ -19,6 +23,13 @@ type Token struct {
 // ToPipeline converts the Git type
 // to a pipeline Git type.
 func (g *Git) ToPipeline() *pipeline.Git {
+	for i, repo := range g.Repositories {
+		split := strings.Split(repo, "/")
+		if len(split) == 2 {
+			g.Repositories[i] = split[1]
+		}
+	}
+
 	return &pipeline.Git{
 		Token: &pipeline.Token{
 			Repositories: g.Repositories,

--- a/compiler/types/yaml/yaml/git_test.go
+++ b/compiler/types/yaml/yaml/git_test.go
@@ -3,10 +3,10 @@
 package yaml
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/go-vela/server/compiler/types/pipeline"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestYaml_Git_ToPipeline(t *testing.T) {
@@ -41,6 +41,18 @@ func TestYaml_Git_ToPipeline(t *testing.T) {
 		},
 		{
 			git: &Git{
+				Token: Token{
+					Repositories: []string{"foo/bar"},
+				},
+			},
+			want: &pipeline.Git{
+				Token: &pipeline.Token{
+					Repositories: []string{"bar"},
+				},
+			},
+		},
+		{
+			git: &Git{
 				Token: Token{},
 			},
 			want: &pipeline.Git{
@@ -53,8 +65,8 @@ func TestYaml_Git_ToPipeline(t *testing.T) {
 	for _, test := range tests {
 		got := test.git.ToPipeline()
 
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("ToPipeline is %v, want %v", got, test.want)
+		if diff := cmp.Diff(test.want, got); diff != "" {
+			t.Errorf("ToPipeline is %s", diff)
 		}
 	}
 }

--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -707,16 +707,8 @@ func (c *Client) GetNetrcPassword(ctx context.Context, db database.Interface, r 
 	repos := g.Repositories
 
 	// use triggering repo as a restrictive default
-	if repos == nil {
+	if len(repos) == 0 {
 		repos = []string{r.GetName()}
-	}
-
-	// convert repo fullname org/name to just name for usability
-	for i, repo := range repos {
-		split := strings.Split(repo, "/")
-		if len(split) == 2 {
-			repos[i] = split[1]
-		}
 	}
 
 	// permissions that are applied to the token for every repo provided
@@ -741,6 +733,16 @@ func (c *Client) GetNetrcPassword(ctx context.Context, db database.Interface, r 
 		ghPermissions, err = ApplyInstallationPermissions(resource, perm, ghPermissions)
 		if err != nil {
 			return u.GetToken(), err
+		}
+	}
+
+	// verify repo owner has `write` access to listed repositories before provisioning install token
+	//
+	// this prevents an app installed across the org from bypassing restrictions
+	for _, repo := range g.Repositories {
+		access, err := c.RepoAccess(ctx, u.GetName(), u.GetToken(), r.GetOrg(), repo)
+		if err != nil || (access != constants.PermissionAdmin && access != constants.PermissionWrite) {
+			return u.GetToken(), fmt.Errorf("repository owner does not have adequate permissions to request install token for repository %s/%s", r.GetOrg(), repo)
 		}
 	}
 

--- a/scm/github/repo_test.go
+++ b/scm/github/repo_test.go
@@ -1643,6 +1643,15 @@ func TestGithub_GetNetrcPassword(t *testing.T) {
 		c.Status(http.StatusOK)
 		c.File("testdata/installations_access_tokens.json")
 	})
+	engine.GET("/api/v3/repos/:org/:repo/collaborators/foo/permission", func(c *gin.Context) {
+		c.Header("Content-Type", "application/json")
+		c.Status(http.StatusOK)
+		c.File("testdata/repo_admin.json")
+	})
+	engine.GET("/api/v3/repos/:org/:repo/collaborators/charlatan/permission", func(c *gin.Context) {
+		c.Header("Content-Type", "application/json")
+		c.Status(http.StatusForbidden)
+	})
 
 	s := httptest.NewServer(engine)
 	defer s.Close()
@@ -1660,6 +1669,10 @@ func TestGithub_GetNetrcPassword(t *testing.T) {
 	u := new(api.User)
 	u.SetName("foo")
 	u.SetToken("bar")
+
+	badUser := new(api.User)
+	badUser.SetName("charlatan")
+	badUser.SetToken("bar")
 
 	tests := []struct {
 		name          string
@@ -1734,6 +1747,19 @@ func TestGithub_GetNetrcPassword(t *testing.T) {
 				Token: yaml.Token{
 					Repositories: []string{"Hello-World"},
 					Permissions:  map[string]string{"contents": "invalid"},
+				},
+			},
+			appsTransport: true,
+			wantToken:     "bar",
+			wantErr:       true,
+		},
+		{
+			name: "owner with inadequate permission to other repo",
+			repo: installedRepo,
+			user: badUser,
+			git: yaml.Git{
+				Token: yaml.Token{
+					Repositories: []string{"Hello-World"},
 				},
 			},
 			appsTransport: true,


### PR DESCRIPTION
The org wide installation works great if the instance's permissions hierarchy is based on many orgs. However, if there is an installation of Vela on a single org, and the repositories within that org are _not_ fair game for every member of that org, then an org-wide installation of the Vela app seems like a potential security concern.

I decided to lean on the owner token to determine whether or not the build requesting the install token does indeed have adequate access to the repos it is requesting. Open to other ideas for that. 