### PR TITLE
enhance(oidc)!: stringify int and bool claims

### DIFF
--- a/api/types/oidc.go
+++ b/api/types/oidc.go
@@ -24,15 +24,15 @@ type OpenIDClaims struct {
 	Actor       string         `json:"actor,omitempty"`
 	ActorSCMID  string         `json:"actor_scm_id,omitempty"`
 	Branch      string         `json:"branch,omitempty"`
-	BuildID     int64          `json:"build_id,omitempty"`
-	BuildNumber int64          `json:"build_number,omitempty"`
-	Commands    bool           `json:"commands,omitempty"`
+	BuildID     string         `json:"build_id,omitempty"`
+	BuildNumber string         `json:"build_number,omitempty"`
+	Commands    string         `json:"commands,omitempty"`
 	CustomProps map[string]any `json:"custom_properties,omitempty"`
 	Event       string         `json:"event,omitempty"`
 	Image       string         `json:"image,omitempty"`
 	ImageName   string         `json:"image_name,omitempty"`
 	ImageTag    string         `json:"image_tag,omitempty"`
-	PullFork    bool           `json:"pull_fork,omitempty"`
+	PullFork    string         `json:"pull_fork,omitempty"`
 	Ref         string         `json:"ref,omitempty"`
 	Repo        string         `json:"repo,omitempty"`
 	Request     string         `json:"request,omitempty"`

--- a/internal/token/mint.go
+++ b/internal/token/mint.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -160,11 +161,11 @@ func (tm *Manager) MintIDToken(ctx context.Context, mto *MintTokenOpts, db datab
 	claims.Actor = mto.Build.GetSender()
 	claims.ActorSCMID = mto.Build.GetSenderSCMID()
 	claims.Branch = mto.Build.GetBranch()
-	claims.BuildNumber = mto.Build.GetNumber()
-	claims.BuildID = mto.Build.GetID()
+	claims.BuildNumber = strconv.FormatInt(mto.Build.GetNumber(), 10)
+	claims.BuildID = strconv.FormatInt(mto.Build.GetID(), 10)
 	claims.Repo = mto.Repo
 	claims.Event = fmt.Sprintf("%s:%s", mto.Build.GetEvent(), mto.Build.GetEventAction())
-	claims.PullFork = mto.Build.GetFork()
+	claims.PullFork = strconv.FormatBool(mto.Build.GetFork())
 	claims.SHA = mto.Build.GetCommit()
 	claims.Ref = mto.Build.GetRef()
 	claims.Subject = fmt.Sprintf("repo:%s:ref:%s:event:%s", mto.Repo, mto.Build.GetRef(), mto.Build.GetEvent())
@@ -179,7 +180,7 @@ func (tm *Manager) MintIDToken(ctx context.Context, mto *MintTokenOpts, db datab
 	}
 
 	claims.Request = mto.Request
-	claims.Commands = mto.Commands
+	claims.Commands = strconv.FormatBool(mto.Commands)
 
 	// set standard claims
 	claims.IssuedAt = jwt.NewNumericDate(time.Now())


### PR DESCRIPTION
Some integrations (namely Artifactory) expect all OIDC claims to be strings. Updating these will allow for better mapping options.