### PR TITLE
fix(scm): set all repo info in custom props handler

### DIFF
--- a/scm/github/webhook.go
+++ b/scm/github/webhook.go
@@ -576,6 +576,12 @@ func (c *Client) processCustomPropertiesEvent(h *api.Hook, payload *github.Custo
 	r.SetOrg(repo.GetOwner().GetLogin())
 	r.SetName(repo.GetName())
 	r.SetFullName(repo.GetFullName())
+	r.SetLink(repo.GetHTMLURL())
+	r.SetClone(repo.GetCloneURL())
+	r.SetBranch(repo.GetDefaultBranch())
+	r.SetPrivate(repo.GetPrivate())
+	r.SetActive(!repo.GetArchived())
+	r.SetTopics(repo.Topics)
 	r.SetCustomProps(repo.CustomProperties)
 
 	h.SetEvent(constants.EventCustomProperties)

--- a/scm/github/webhook_test.go
+++ b/scm/github/webhook_test.go
@@ -1506,9 +1506,15 @@ func TestGitHub_ProcessWebhook_CustomPropertyValuesUpdated(t *testing.T) {
 	wantHook.SetLink("https://github.com/github/octocat/settings/hooks")
 
 	wantRepo := new(api.Repo)
+	wantRepo.SetActive(true)
 	wantRepo.SetOrg("github")
 	wantRepo.SetName("octocat")
 	wantRepo.SetFullName("github/octocat")
+	wantRepo.SetLink("https://github.com/github/octocat")
+	wantRepo.SetClone("https://github.com/github/octocat.git")
+	wantRepo.SetBranch("main")
+	wantRepo.SetPrivate(true)
+	wantRepo.SetTopics([]string{})
 	wantRepo.SetCustomProps(map[string]any{"FOO": "testing"})
 
 	want := &internal.Webhook{


### PR DESCRIPTION
Because of the fallthrough [here](https://github.com/go-vela/server/blob/ec2dca5e078ba3539ece90c7b07e47b90282ecb7/api/webhook/post.go#L686), the repo gets some fields updated [here](https://github.com/go-vela/server/blob/ec2dca5e078ba3539ece90c7b07e47b90282ecb7/api/webhook/post.go#L712-L726), so we should make sure all those fields are up to date.