### PR TITLE
fix(ci): file -> files in codecov action field

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,4 +43,4 @@ jobs:
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           use_oidc: true
-          file: coverage.out
+          files: coverage.out


### PR DESCRIPTION
didn't realize this field was updated and missed the annotation on the `test` run (see https://github.com/codecov/codecov-action?tab=readme-ov-file#arguments for field info on `files`)

![image](https://github.com/user-attachments/assets/4f52c37a-1568-4cf6-ae5f-e5f1ee26d5c7)
