### PR TITLE
fix(ci): disable CGO for static CI builds in workflows

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -38,7 +38,7 @@ jobs:
       - name: build
         env:
           GOOS: linux
-          CGO_ENABLED: "1"
+          CGO_ENABLED: "0"
         run: |
           make build-static-ci
 
@@ -93,7 +93,7 @@ jobs:
       - name: build
         env:
           GOOS: linux
-          CGO_ENABLED: "1"
+          CGO_ENABLED: "0"
         run: |
           make build-static-ci
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       - name: build
         env:
           GOOS: linux
-          CGO_ENABLED: "1"
+          CGO_ENABLED: "0"
         run: |
           make build-static-ci
 
@@ -82,7 +82,7 @@ jobs:
       - name: build
         env:
           GOOS: linux
-          CGO_ENABLED: "1"
+          CGO_ENABLED: "0"
         run: |
           make build-static-ci
 


### PR DESCRIPTION
companion to https://github.com/go-vela/worker/pull/644 (this was the origin for it being enabled in go-vela/worker in the first place - copy pasta issue as i was updating workflows). as far as i can tell, this has always been enabled 🤔 