### PR TITLE
fix(scm): inherit custom props in translation to Vela repo

### DIFF
--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -594,15 +594,16 @@ func toAPIRepo(gr github.Repository) *api.Repo {
 	}
 
 	return &api.Repo{
-		Org:        gr.GetOwner().Login,
-		Name:       gr.Name,
-		FullName:   gr.FullName,
-		Link:       gr.HTMLURL,
-		Clone:      gr.CloneURL,
-		Branch:     gr.DefaultBranch,
-		Topics:     &gr.Topics,
-		Private:    gr.Private,
-		Visibility: &visibility,
+		Org:         gr.GetOwner().Login,
+		Name:        gr.Name,
+		FullName:    gr.FullName,
+		Link:        gr.HTMLURL,
+		Clone:       gr.CloneURL,
+		Branch:      gr.DefaultBranch,
+		Topics:      &gr.Topics,
+		Private:     gr.Private,
+		Visibility:  &visibility,
+		CustomProps: &gr.CustomProperties,
 	}
 }
 

--- a/scm/github/repo_test.go
+++ b/scm/github/repo_test.go
@@ -1298,6 +1298,10 @@ func TestGithub_GetRepo(t *testing.T) {
 	want.SetPrivate(false)
 	want.SetTopics([]string{"octocat", "atom", "electron", "api"})
 	want.SetVisibility("public")
+	want.SetCustomProps(map[string]any{
+		"prop_1": "foo",
+		"prop_2": "bar",
+	})
 
 	client, _ := NewTest(s.URL)
 


### PR DESCRIPTION
Very rare occurrence when a repo's first build is a schedule, it will not have accurate custom props because there is no SCM webhook payload to populate them.