### PR TITLE
enhance: use installation token for status updates when available

### DIFF
--- a/api/build/compile_publish.go
+++ b/api/build/compile_publish.go
@@ -296,8 +296,8 @@ func CompileAndPublish(
 			// set build to successful status
 			b.SetStatus(constants.StatusSkipped)
 
-			// send API call to set the status on the commit
-			err = scm.Status(ctx, u, b, repo.GetOrg(), repo.GetName())
+			// send API call to set the status on the commit using installation OR owner token
+			err = scm.Status(ctx, b, repo.GetOrg(), repo.GetName(), p.Token)
 			if err != nil {
 				logger.Errorf("unable to set commit status for %s/%d: %v", repo.GetFullName(), b.GetNumber(), err)
 			}

--- a/api/build/gatekeep.go
+++ b/api/build/gatekeep.go
@@ -16,7 +16,7 @@ import (
 
 // GatekeepBuild is a helper function that will set the status of a build to 'pending approval' and
 // send a status update to the SCM.
-func GatekeepBuild(c *gin.Context, b *types.Build, r *types.Repo) error {
+func GatekeepBuild(c *gin.Context, b *types.Build, r *types.Repo, token string) error {
 	l := c.MustGet("logger").(*logrus.Entry)
 
 	l = l.WithFields(logrus.Fields{
@@ -45,7 +45,7 @@ func GatekeepBuild(c *gin.Context, b *types.Build, r *types.Repo) error {
 	}
 
 	// send API call to set the status on the commit
-	err = scm.FromContext(c).Status(c, r.GetOwner(), b, r.GetOrg(), r.GetName())
+	err = scm.FromContext(c).Status(c, b, r.GetOrg(), r.GetName(), token)
 	if err != nil {
 		l.Errorf("unable to set commit status for %s/%d: %v", r.GetFullName(), b.GetNumber(), err)
 	}

--- a/api/build/restart.go
+++ b/api/build/restart.go
@@ -156,7 +156,7 @@ func RestartBuild(c *gin.Context) {
 	}
 
 	// generate queue items
-	_, item, code, err := CompileAndPublish(
+	p, item, code, err := CompileAndPublish(
 		c,
 		config,
 		database.FromContext(c),
@@ -180,7 +180,7 @@ func RestartBuild(c *gin.Context) {
 
 	if shouldEnqueue {
 		// send API call to set the status on the commit
-		err := scm.Status(c.Request.Context(), r.GetOwner(), b, r.GetOrg(), r.GetName())
+		err := scm.Status(c.Request.Context(), b, r.GetOrg(), r.GetName(), p.Token)
 		if err != nil {
 			l.Errorf("unable to set commit status for %s/%d: %v", r.GetFullName(), b.GetNumber(), err)
 		}
@@ -194,7 +194,7 @@ func RestartBuild(c *gin.Context) {
 			item.Build.GetRoute(),
 		)
 	} else {
-		err := GatekeepBuild(c, item.Build, item.Build.GetRepo())
+		err := GatekeepBuild(c, item.Build, item.Build.GetRepo(), p.Token)
 		if err != nil {
 			util.HandleError(c, http.StatusInternalServerError, err)
 

--- a/api/step/plan.go
+++ b/api/step/plan.go
@@ -107,8 +107,8 @@ func planStep(ctx context.Context, database database.Interface, scm scm.Service,
 	}).Info("log for step created")
 
 	if len(s.GetReportAs()) > 0 {
-		// send API call to set the status on the commit
-		err = scm.StepStatus(ctx, b.GetRepo().GetOwner(), b, s, b.GetRepo().GetOrg(), b.GetRepo().GetName())
+		// send API call to set the status on the commit using token in environment
+		err = scm.StepStatus(ctx, b, s, b.GetRepo().GetOrg(), b.GetRepo().GetName(), c.Environment["VELA_NETRC_PASSWORD"])
 		if err != nil {
 			logrus.Errorf("unable to set commit status for build: %v", err)
 		}

--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -476,7 +476,7 @@ func PostWebhook(c *gin.Context) {
 
 		util.HandleError(c, code, err)
 
-		err = scm.FromContext(c).Status(ctx, repo.GetOwner(), b, repo.GetOrg(), repo.GetName())
+		err = scm.FromContext(c).Status(ctx, b, repo.GetOrg(), repo.GetName(), p.Token)
 		if err != nil {
 			l.Debugf("unable to set commit status for %s/%d: %v", repo.GetFullName(), b.GetNumber(), err)
 		}
@@ -609,7 +609,7 @@ func PostWebhook(c *gin.Context) {
 
 	if shouldEnqueue {
 		// send API call to set the status on the commit
-		err := scm.FromContext(c).Status(c.Request.Context(), repo.GetOwner(), b, repo.GetOrg(), repo.GetName())
+		err := scm.FromContext(c).Status(c.Request.Context(), b, repo.GetOrg(), repo.GetName(), p.Token)
 		if err != nil {
 			l.Errorf("unable to set commit status for %s/%d: %v", repo.GetFullName(), b.GetNumber(), err)
 		}
@@ -623,7 +623,7 @@ func PostWebhook(c *gin.Context) {
 			b.GetRoute(),
 		)
 	} else {
-		err := build.GatekeepBuild(c, item.Build, item.Build.GetRepo())
+		err := build.GatekeepBuild(c, item.Build, item.Build.GetRepo(), p.Token)
 		if err != nil {
 			retErr := fmt.Errorf("unable to gate build: %w", err)
 			util.HandleError(c, http.StatusInternalServerError, err)

--- a/compiler/native/transform.go
+++ b/compiler/native/transform.go
@@ -74,6 +74,10 @@ func (c *Client) TransformStages(r *pipeline.RuleData, p *yaml.Build) (*pipeline
 		Deployment: *p.Deployment.ToPipeline(),
 	}
 
+	if c.netrc != nil {
+		pipeline.Token = *c.netrc
+	}
+
 	// set the unique ID for the executable pipeline
 	pipeline.ID = fmt.Sprintf(pipelineID, org, name, number)
 
@@ -159,6 +163,10 @@ func (c *Client) TransformSteps(r *pipeline.RuleData, p *yaml.Build) (*pipeline.
 		Secrets:    *p.Secrets.ToPipeline(),
 		Services:   *p.Services.ToPipeline(),
 		Worker:     *p.Worker.ToPipeline(),
+	}
+
+	if c.netrc != nil {
+		pipeline.Token = *c.netrc
 	}
 
 	// set the unique ID for the executable pipeline

--- a/compiler/types/pipeline/build.go
+++ b/compiler/types/pipeline/build.go
@@ -16,6 +16,7 @@ import (
 // swagger:model PipelineBuild
 type Build struct {
 	ID          string             `json:"id,omitempty"          yaml:"id,omitempty"`
+	Token       string             `json:"token,omitempty"       yaml:"token,omitempty"`
 	Version     string             `json:"version,omitempty"     yaml:"version,omitempty"`
 	Metadata    Metadata           `json:"metadata,omitempty"    yaml:"metadata,omitempty"`
 	Environment raw.StringSliceMap `json:"environment,omitempty" yaml:"environment,omitempty"`

--- a/router/middleware/auth/auth.go
+++ b/router/middleware/auth/auth.go
@@ -16,6 +16,19 @@ func RetrieveAccessToken(r *http.Request) (accessToken string, err error) {
 	return request.AuthorizationHeaderExtractor.ExtractToken(r)
 }
 
+// RetrieveTokenHeader gets the passed in install token from the 'Token' header in the request.
+//
+// this is only used for builds that have app installation tokens that are used for status updates.
+// it is not required unless the repository has installed the Vela app.
+func RetrieveTokenHeader(r *http.Request) string {
+	tkn, ok := r.Header["Token"]
+	if !ok || len(tkn) == 0 {
+		return ""
+	}
+
+	return tkn[0]
+}
+
 // RetrieveRefreshToken gets the refresh token sent along with the request as a cookie.
 func RetrieveRefreshToken(r *http.Request) (string, error) {
 	refreshToken, err := r.Cookie(constants.RefreshTokenName)

--- a/router/middleware/auth/auth_test.go
+++ b/router/middleware/auth/auth_test.go
@@ -67,6 +67,58 @@ func TestToken_Retrieve_Access_Error(t *testing.T) {
 	}
 }
 
+func TestToken_Retrieve_TokenHeader(t *testing.T) {
+	// setup types
+	want := "foobar"
+
+	request, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
+	request.Header.Set("Token", want)
+
+	// run test
+	got := RetrieveTokenHeader(request)
+
+	if !strings.EqualFold(got, want) {
+		t.Errorf("Retrieve is %v, want %v", got, want)
+	}
+}
+
+func TestToken_Retrieve_TokenHeader_Empty(t *testing.T) {
+	// setup types
+	request, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
+
+	// run test
+	got := RetrieveTokenHeader(request)
+
+	if len(got) > 0 {
+		t.Errorf("Retrieve is %v, want \"\"", got)
+	}
+}
+
+func TestToken_Retrieve_TokenHeader_And_Access(t *testing.T) {
+	// setup types
+	wantAccess := "foo"
+	wantToken := "bar"
+
+	request, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
+	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", wantAccess))
+	request.Header.Set("Token", wantToken)
+
+	gotAccess, err := RetrieveAccessToken(request)
+	if err != nil {
+		t.Errorf("Retrieve returned err: %v", err)
+	}
+
+	gotTkn := RetrieveTokenHeader(request)
+
+	if !strings.EqualFold(gotAccess, wantAccess) {
+		t.Errorf("Retrieve is %v, want %v", gotAccess, wantAccess)
+	}
+
+	if !strings.EqualFold(gotTkn, wantToken) {
+		t.Errorf("Retrieve is %v, want %v", gotTkn, wantToken)
+	}
+}
+
 func TestToken_Retrieve_Refresh_Error(t *testing.T) {
 	// setup types
 	request, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)

--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -292,12 +292,11 @@ func (c *Client) Update(ctx context.Context, u *api.User, r *api.Repo, hookID in
 }
 
 // Status sends the commit status for the given SHA from the GitHub repo.
-func (c *Client) Status(ctx context.Context, u *api.User, b *api.Build, org, name string) error {
+func (c *Client) Status(ctx context.Context, b *api.Build, org, name, token string) error {
 	c.Logger.WithFields(logrus.Fields{
 		"build": b.GetNumber(),
 		"org":   org,
 		"repo":  name,
-		"user":  u.GetName(),
 	}).Tracef("setting commit status for %s/%s/%d @ %s", org, name, b.GetNumber(), b.GetCommit())
 
 	// only report opened, synchronize, and reopened action types for pull_request events
@@ -307,7 +306,7 @@ func (c *Client) Status(ctx context.Context, u *api.User, b *api.Build, org, nam
 	}
 
 	// create GitHub OAuth client with user's token
-	client := c.newOAuthTokenClient(ctx, *u.Token)
+	client := c.newOAuthTokenClient(ctx, token)
 
 	context := fmt.Sprintf("%s/%s", c.config.StatusContext, b.GetEvent())
 	url := fmt.Sprintf("%s/%s/%s/%d", c.config.WebUIAddress, org, name, b.GetNumber())
@@ -412,12 +411,11 @@ func (c *Client) Status(ctx context.Context, u *api.User, b *api.Build, org, nam
 }
 
 // StepStatus sends the commit status for the given SHA to the GitHub repo with the step as the context.
-func (c *Client) StepStatus(ctx context.Context, u *api.User, b *api.Build, s *api.Step, org, name string) error {
+func (c *Client) StepStatus(ctx context.Context, b *api.Build, s *api.Step, org, name, token string) error {
 	c.Logger.WithFields(logrus.Fields{
 		"build": b.GetNumber(),
 		"org":   org,
 		"repo":  name,
-		"user":  u.GetName(),
 	}).Tracef("setting commit status for %s/%s/%d @ %s", org, name, b.GetNumber(), b.GetCommit())
 
 	// no commit statuses on deployments
@@ -426,7 +424,7 @@ func (c *Client) StepStatus(ctx context.Context, u *api.User, b *api.Build, s *a
 	}
 
 	// create GitHub OAuth client with user's token
-	client := c.newOAuthTokenClient(ctx, *u.Token)
+	client := c.newOAuthTokenClient(ctx, token)
 
 	context := fmt.Sprintf("%s/%s/%s", c.config.StatusContext, b.GetEvent(), s.GetReportAs())
 	url := fmt.Sprintf("%s/%s/%s/%d#%d", c.config.WebUIAddress, org, name, b.GetNumber(), s.GetNumber())
@@ -722,6 +720,7 @@ func (c *Client) GetNetrcPassword(ctx context.Context, db database.Interface, r 
 	ghPermissions := &github.InstallationPermissions{
 		Contents: github.Ptr(AppInstallPermissionRead),
 		Checks:   github.Ptr(AppInstallPermissionWrite),
+		Statuses: github.Ptr(AppInstallPermissionWrite),
 	}
 
 	permissions := g.Permissions

--- a/scm/github/repo_test.go
+++ b/scm/github/repo_test.go
@@ -848,10 +848,6 @@ func TestGithub_Status_Deployment(t *testing.T) {
 	defer s.Close()
 
 	// setup types
-	u := new(api.User)
-	u.SetName("foo")
-	u.SetToken("bar")
-
 	r := new(api.Repo)
 	r.SetID(1)
 
@@ -867,7 +863,7 @@ func TestGithub_Status_Deployment(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	err := client.Status(context.TODO(), u, b, "foo", "bar")
+	err := client.Status(context.TODO(), b, "foo", "bar", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -896,10 +892,6 @@ func TestGithub_Status_Running(t *testing.T) {
 	defer s.Close()
 
 	// setup types
-	u := new(api.User)
-	u.SetName("foo")
-	u.SetToken("bar")
-
 	r := new(api.Repo)
 	r.SetID(1)
 
@@ -921,7 +913,7 @@ func TestGithub_Status_Running(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	err := client.Status(context.TODO(), u, b, "foo", "bar")
+	err := client.Status(context.TODO(), b, "foo", "bar", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -931,7 +923,7 @@ func TestGithub_Status_Running(t *testing.T) {
 		t.Errorf("Status returned err: %v", err)
 	}
 
-	err = client.StepStatus(context.TODO(), u, b, step, "foo", "bar")
+	err = client.StepStatus(context.TODO(), b, step, "foo", "bar", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -960,10 +952,6 @@ func TestGithub_Status_Success(t *testing.T) {
 	defer s.Close()
 
 	// setup types
-	u := new(api.User)
-	u.SetName("foo")
-	u.SetToken("bar")
-
 	r := new(api.Repo)
 	r.SetID(1)
 
@@ -985,7 +973,7 @@ func TestGithub_Status_Success(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	err := client.Status(context.TODO(), u, b, "foo", "bar")
+	err := client.Status(context.TODO(), b, "foo", "bar", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -995,7 +983,7 @@ func TestGithub_Status_Success(t *testing.T) {
 		t.Errorf("Status returned err: %v", err)
 	}
 
-	err = client.StepStatus(context.TODO(), u, b, step, "foo", "bar")
+	err = client.StepStatus(context.TODO(), b, step, "foo", "bar", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -1024,10 +1012,6 @@ func TestGithub_Status_Failure(t *testing.T) {
 	defer s.Close()
 
 	// setup types
-	u := new(api.User)
-	u.SetName("foo")
-	u.SetToken("bar")
-
 	r := new(api.Repo)
 	r.SetID(1)
 
@@ -1049,7 +1033,7 @@ func TestGithub_Status_Failure(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	err := client.Status(context.TODO(), u, b, "foo", "bar")
+	err := client.Status(context.TODO(), b, "foo", "bar", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -1059,7 +1043,7 @@ func TestGithub_Status_Failure(t *testing.T) {
 		t.Errorf("Status returned err: %v", err)
 	}
 
-	err = client.StepStatus(context.TODO(), u, b, step, "foo", "bar")
+	err = client.StepStatus(context.TODO(), b, step, "foo", "bar", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -1088,10 +1072,6 @@ func TestGithub_Status_Killed(t *testing.T) {
 	defer s.Close()
 
 	// setup types
-	u := new(api.User)
-	u.SetName("foo")
-	u.SetToken("bar")
-
 	r := new(api.Repo)
 	r.SetID(1)
 
@@ -1113,7 +1093,7 @@ func TestGithub_Status_Killed(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	err := client.Status(context.TODO(), u, b, "foo", "bar")
+	err := client.Status(context.TODO(), b, "foo", "bar", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -1123,7 +1103,7 @@ func TestGithub_Status_Killed(t *testing.T) {
 		t.Errorf("Status returned err: %v", err)
 	}
 
-	err = client.StepStatus(context.TODO(), u, b, step, "foo", "bar")
+	err = client.StepStatus(context.TODO(), b, step, "foo", "bar", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -1152,10 +1132,6 @@ func TestGithub_Status_Skipped(t *testing.T) {
 	defer s.Close()
 
 	// setup types
-	u := new(api.User)
-	u.SetName("foo")
-	u.SetToken("bar")
-
 	r := new(api.Repo)
 	r.SetID(1)
 
@@ -1177,7 +1153,7 @@ func TestGithub_Status_Skipped(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	err := client.Status(context.TODO(), u, b, "foo", "bar")
+	err := client.Status(context.TODO(), b, "foo", "bar", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -1187,7 +1163,7 @@ func TestGithub_Status_Skipped(t *testing.T) {
 		t.Errorf("Status returned err: %v", err)
 	}
 
-	err = client.StepStatus(context.TODO(), u, b, step, "foo", "bar")
+	err = client.StepStatus(context.TODO(), b, step, "foo", "bar", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -1216,10 +1192,6 @@ func TestGithub_Status_Error(t *testing.T) {
 	defer s.Close()
 
 	// setup types
-	u := new(api.User)
-	u.SetName("foo")
-	u.SetToken("bar")
-
 	r := new(api.Repo)
 	r.SetID(1)
 
@@ -1241,7 +1213,7 @@ func TestGithub_Status_Error(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	err := client.Status(context.TODO(), u, b, "foo", "bar")
+	err := client.Status(context.TODO(), b, "foo", "bar", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)
@@ -1251,7 +1223,7 @@ func TestGithub_Status_Error(t *testing.T) {
 		t.Errorf("Status returned err: %v", err)
 	}
 
-	err = client.StepStatus(context.TODO(), u, b, step, "foo", "bar")
+	err = client.StepStatus(context.TODO(), b, step, "foo", "bar", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Status returned %v, want %v", resp.Code, http.StatusOK)

--- a/scm/service.go
+++ b/scm/service.go
@@ -118,10 +118,10 @@ type Service interface {
 	Update(context.Context, *api.User, *api.Repo, int64) (bool, error)
 	// Status defines a function that sends the
 	// commit status for the given SHA from a repo.
-	Status(context.Context, *api.User, *api.Build, string, string) error
+	Status(context.Context, *api.Build, string, string, string) error
 	// StepStatus defines a function that sends the
 	// commit status for the given SHA for a specified step context.
-	StepStatus(context.Context, *api.User, *api.Build, *api.Step, string, string) error
+	StepStatus(context.Context, *api.Build, *api.Step, string, string, string) error
 	// ListUserRepos defines a function that retrieves
 	// all repos with admin rights for the user.
 	ListUserRepos(context.Context, *api.User) ([]string, error)


### PR DESCRIPTION
This change allows for the worker to provide the installation token it receives in the pipeline object to use as auth for status updates. This adds the ability for users to specify Vela as the "source" for status checks on commits. 

Few changes:

- PUTs for build and step will now look for `Authorization` _and_ `Token` headers, where the former is the usual build token, and the latter is the install token OR owner token. If it's empty, it will use the owner token anyway.
- Status functions in the SCM take a token instead of a user struct
- `pipeline.Build` struct now has a `Token` field. This is just for easy access rather than combing through the environment maps inside the containers. This is _not_ introducing _new_ sensitive info to this struct.

This double auth header is kind of annoying, but I don't think we want to store these install tokens on the build object. If you have another idea, lmk!