### PR TITLE
chore(lint): address linter issues from upgrade

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,7 +53,7 @@ linters:
     - unparam # reports unused function parameters
     - unused # checks for unused constants, variables, functions and types
     - whitespace # detects leading and trailing whitespace
-    - wsl # forces code to use empty lines
+    - wsl_v5
 
   # static list of linters we know golangci can run but we've
   # chosen to leave disabled for now
@@ -129,11 +129,14 @@ linters:
       require-explanation: true # require an explanation for nolint directives
       require-specific: true # require nolint directives to be specific about which linter is being skipped
       allow-unused: false # allow nolint directives that don't address a linting issue
-    # https://golangci-lint.run/usage/linters/#tagalign
-    # ensure struct tags are aligned
-    # will auto fix with `make lintfix`
-    tagalign:
-      sort: false
+    revive:
+      rules:
+        - name: var-naming
+          disabled: false
+          arguments:
+            - []
+            - []
+            - - skip-package-name-checks: true
     # static check to ignore QFI (Quality Function Interface) issues
     staticcheck:
       checks:
@@ -141,6 +144,15 @@ linters:
         - "-QF1003"
         - "-QF1004"
         - "-QF1008"
+    # https://golangci-lint.run/usage/linters/#tagalign
+    # ensure struct tags are aligned
+    # will auto fix with `make lintfix`
+    tagalign:
+      sort: false
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2 
   exclusions:
     generated: lax
     presets:

--- a/api/admin/log_test.go
+++ b/api/admin/log_test.go
@@ -120,6 +120,7 @@ func TestAdmin_CleanLogs(t *testing.T) {
 			if !test.wantError && resp.Code == http.StatusOK {
 				// verify response structure for successful requests
 				var response types.LogCleanupResponse
+
 				err := json.Unmarshal(resp.Body.Bytes(), &response)
 				if err != nil {
 					t.Errorf("unable to unmarshal response: %v", err)
@@ -129,12 +130,15 @@ func TestAdmin_CleanLogs(t *testing.T) {
 				if response.DeletedCount < 0 {
 					t.Errorf("DeletedCount should be >= 0, got %d", response.DeletedCount)
 				}
+
 				if response.BatchesProcessed < 0 {
 					t.Errorf("BatchesProcessed should be >= 0, got %d", response.BatchesProcessed)
 				}
+
 				if response.DurationSeconds < 0 {
 					t.Errorf("DurationSeconds should be >= 0, got %f", response.DurationSeconds)
 				}
+
 				if response.Message == "" {
 					t.Errorf("Message should not be empty")
 				}

--- a/api/build/graph.go
+++ b/api/build/graph.go
@@ -139,7 +139,7 @@ const (
 // GetBuildGraph represents the API handler to get a
 // directed a-cyclical graph for a build.
 //
-//nolint:funlen,goconst,gocyclo // ignore function length and constants
+//nolint:funlen,gocyclo // ignore function length and constants
 func GetBuildGraph(c *gin.Context) {
 	// capture middleware values
 	m := c.MustGet("metadata").(*internal.Metadata)
@@ -454,11 +454,11 @@ func GetBuildGraph(c *gin.Context) {
 
 		// override the cluster id for built-in nodes
 		// this allows for better layout control because all stages need 'clone'
-		if stage.Name == "init" {
+		if stage.Name == constants.InitName {
 			cluster = BuiltInCluster
 		}
 
-		if stage.Name == "clone" {
+		if stage.Name == constants.CloneName {
 			cluster = BuiltInCluster
 		}
 
@@ -546,8 +546,8 @@ func GetBuildGraph(c *gin.Context) {
 			if len((*destinationNode.Stage).Needs) > 0 {
 				// check destination node needs
 				for _, need := range (*destinationNode.Stage).Needs {
-					// all stages need "clone"
-					if need == "clone" {
+					// all stages need constants.CloneName
+					if need == constants.CloneName {
 						continue
 					}
 

--- a/api/build/skip.go
+++ b/api/build/skip.go
@@ -4,31 +4,32 @@ package build
 
 import (
 	"github.com/go-vela/server/compiler/types/pipeline"
+	"github.com/go-vela/server/constants"
 )
 
 // SkipEmptyBuild checks if the build should be skipped due to it
 // not containing any steps besides init or clone.
 func SkipEmptyBuild(p *pipeline.Build) string {
 	if len(p.Stages) == 1 {
-		if p.Stages[0].Name == "init" {
+		if p.Stages[0].Name == constants.InitName {
 			return "skipping build since only init stage found — it is likely no rulesets matched for the webhook payload"
 		}
 	}
 
 	if len(p.Stages) == 2 {
-		if p.Stages[0].Name == "init" && p.Stages[1].Name == "clone" {
+		if p.Stages[0].Name == constants.InitName && p.Stages[1].Name == constants.CloneName {
 			return "skipping build since only init and clone stages found — it is likely no rulesets matched for the webhook payload"
 		}
 	}
 
 	if len(p.Steps) == 1 {
-		if p.Steps[0].Name == "init" {
+		if p.Steps[0].Name == constants.InitName {
 			return "skipping build since only init step found — it is likely no rulesets matched for the webhook payload"
 		}
 	}
 
 	if len(p.Steps) == 2 {
-		if p.Steps[0].Name == "init" && p.Steps[1].Name == "clone" {
+		if p.Steps[0].Name == constants.InitName && p.Steps[1].Name == constants.CloneName {
 			return "skipping build since only init and clone steps found — it is likely no rulesets matched for the webhook payload"
 		}
 	}

--- a/api/deployment/create.go
+++ b/api/deployment/create.go
@@ -114,7 +114,6 @@ func CreateDeployment(c *gin.Context) {
 
 	if !deployConfig.Empty() {
 		err := deployConfig.Validate(input.GetTarget(), input.GetPayload())
-
 		if err != nil {
 			retErr := fmt.Errorf("unable to validate deployment config for %s: %w", r.GetFullName(), err)
 

--- a/api/pipeline/compile_test.go
+++ b/api/pipeline/compile_test.go
@@ -73,7 +73,7 @@ func TestPrepareRuleData(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/", nil)
+			req, _ := http.NewRequestWithContext(t.Context(), "GET", "/", nil)
 
 			q := req.URL.Query()
 			for key, value := range tt.parameters {

--- a/api/schedule/create_test.go
+++ b/api/schedule/create_test.go
@@ -12,6 +12,7 @@ func Test_validateEntry(t *testing.T) {
 		minimum time.Duration
 		entry   string
 	}
+
 	tests := []struct {
 		name    string
 		args    args

--- a/cmd/vela-server/flags_test.go
+++ b/cmd/vela-server/flags_test.go
@@ -41,6 +41,7 @@ func TestDatabase_Flags(t *testing.T) {
 				t.Fatalf("unsupported flag type: %T", f)
 			}
 		}
+
 		return copiedFlags
 	}
 
@@ -216,6 +217,7 @@ func TestDatabase_Flags(t *testing.T) {
 				if len(value) == 0 {
 					continue
 				}
+
 				args = append(args, `--`+key+"="+value)
 			}
 

--- a/cmd/vela-server/schedule.go
+++ b/cmd/vela-server/schedule.go
@@ -219,7 +219,6 @@ func processSchedule(ctx context.Context, s *api.Schedule, settings *settings.Pl
 		compiler,
 		queue,
 	)
-
 	if err != nil {
 		return err
 	}

--- a/compiler/context.go
+++ b/compiler/context.go
@@ -52,7 +52,6 @@ func FromGinContext(c *gin.Context) Engine {
 func WithContext(c context.Context, e Engine) context.Context {
 	// set the compiler Engine in the context.Context
 	//
-	//nolint:revive // ignore using string with context value
 	return context.WithValue(c, key, e)
 }
 

--- a/compiler/context_test.go
+++ b/compiler/context_test.go
@@ -20,7 +20,7 @@ func TestCompiler_FromContext(t *testing.T) {
 		want    Engine
 	}{
 		{
-			//nolint:revive // ignore using string with context value
+
 			context: context.WithValue(context.Background(), key, _engine),
 			want:    _engine,
 		},
@@ -29,7 +29,7 @@ func TestCompiler_FromContext(t *testing.T) {
 			want:    nil,
 		},
 		{
-			//nolint:revive // ignore using string with context value
+
 			context: context.WithValue(context.Background(), key, "foo"),
 			want:    nil,
 		},
@@ -90,7 +90,6 @@ func TestCompiler_WithContext(t *testing.T) {
 	// setup types
 	var _engine Engine
 
-	//nolint:revive // ignore using string with context value
 	want := context.WithValue(context.Background(), key, _engine)
 
 	// run test

--- a/compiler/native/clone.go
+++ b/compiler/native/clone.go
@@ -7,13 +7,6 @@ import (
 	"github.com/go-vela/server/constants"
 )
 
-const (
-	// default name for clone stage.
-	cloneStageName = "clone"
-	// default name for clone step.
-	cloneStepName = "clone"
-)
-
 // CloneStage injects the clone stage process into a yaml configuration.
 func (c *Client) CloneStage(p *yaml.Build) (*yaml.Build, error) {
 	// check if the compiler is setup for a local pipeline
@@ -26,12 +19,12 @@ func (c *Client) CloneStage(p *yaml.Build) (*yaml.Build, error) {
 
 	// create new clone stage
 	clone := &yaml.Stage{
-		Name: cloneStageName,
+		Name: constants.CloneName,
 		Steps: yaml.StepSlice{
 			&yaml.Step{
 				Detach:     false,
 				Image:      c.GetCloneImage(),
-				Name:       cloneStepName,
+				Name:       constants.CloneName,
 				Privileged: false,
 				Pull:       constants.PullNotPresent,
 			},
@@ -64,7 +57,7 @@ func (c *Client) CloneStep(p *yaml.Build) (*yaml.Build, error) {
 	clone := &yaml.Step{
 		Detach:     false,
 		Image:      c.GetCloneImage(),
-		Name:       cloneStepName,
+		Name:       constants.CloneName,
 		Privileged: false,
 		Pull:       constants.PullNotPresent,
 	}

--- a/compiler/native/compile_test.go
+++ b/compiler/native/compile_test.go
@@ -345,6 +345,7 @@ func TestNative_Compile_StagesPipeline_Modification(t *testing.T) {
 				repo:     &api.Repo{Name: &author},
 				build:    &api.Build{Author: &name, Number: &number},
 			}
+
 			_, _, err := compiler.Compile(context.Background(), yaml)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Compile() error = %v, wantErr %v", err, tt.wantErr)
@@ -433,6 +434,7 @@ func TestNative_Compile_StepsPipeline_Modification(t *testing.T) {
 				build:    tt.args.apiBuild,
 				metadata: m,
 			}
+
 			_, _, err := compiler.Compile(context.Background(), yaml)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Compile() error = %v, wantErr %v", err, tt.wantErr)
@@ -647,6 +649,7 @@ func TestNative_Compile_StagesPipelineTemplate(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 
@@ -916,6 +919,7 @@ func TestNative_Compile_StepsPipelineTemplate(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 
@@ -1140,6 +1144,7 @@ func TestNative_Compile_StepsPipelineTemplate_VelaFunction_TemplateName(t *testi
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 
@@ -1252,6 +1257,7 @@ func TestNative_Compile_StepsPipelineTemplate_VelaFunction_TemplateName_Inline(t
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 
@@ -1363,6 +1369,7 @@ func TestNative_Compile_InvalidType(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 
@@ -2429,6 +2436,7 @@ func Test_client_modifyConfig(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 
@@ -2526,29 +2534,36 @@ func Test_client_modifyConfig(t *testing.T) {
 
 	engine.POST("/config/unmodified", func(c *gin.Context) {
 		c.Header("Content-Type", "application/json")
+
 		response, err := convertResponse(want)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
+
 		c.JSON(http.StatusOK, response)
 	})
 
 	engine.POST("/config/timeout", func(c *gin.Context) {
 		time.Sleep(3 * time.Second)
 		c.Header("Content-Type", "application/json")
+
 		response, err := convertResponse(want)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
+
 		c.JSON(http.StatusOK, response)
 	})
 
 	engine.POST("/config/modified", func(c *gin.Context) {
 		c.Header("Content-Type", "application/json")
+
 		output := want
+
 		var steps []*yaml.Step
+
 		steps = append(steps, want.Steps...)
 		steps = append(steps, &yaml.Step{
 			Image:       "alpine",
@@ -2558,11 +2573,13 @@ func Test_client_modifyConfig(t *testing.T) {
 			Commands:    []string{"echo hello from modification"},
 		})
 		output.Steps = steps
+
 		response, err := convertResponse(want)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
+
 		c.JSON(http.StatusOK, response)
 	})
 
@@ -2572,11 +2589,13 @@ func Test_client_modifyConfig(t *testing.T) {
 
 	engine.POST("/config/unauthorized", func(c *gin.Context) {
 		c.Header("Content-Type", "application/json")
+
 		response, err := convertResponse(want)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
+
 		c.JSON(http.StatusForbidden, response)
 	})
 
@@ -2647,6 +2666,7 @@ func Test_client_modifyConfig(t *testing.T) {
 					Endpoint: tt.args.endpoint,
 				},
 			}
+
 			got, err := compiler.modifyConfig(tt.args.build, tt.args.apiBuild, tt.args.repo)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("modifyConfig() error = %v, wantErr %v", err, tt.wantErr)
@@ -2697,6 +2717,7 @@ func Test_Compile_Inline(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 
@@ -3455,6 +3476,7 @@ func Test_Compile_Inline(t *testing.T) {
 			if err != nil {
 				t.Errorf("Reading yaml file return err: %v", err)
 			}
+
 			compiler, err := FromCLICommand(context.Background(), testCommand(t, s.URL))
 			if err != nil {
 				t.Errorf("Creating compiler returned err: %v", err)
@@ -3507,6 +3529,7 @@ func Test_CompileLite(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 
@@ -4442,6 +4465,7 @@ func Test_CompileLite(t *testing.T) {
 			}
 
 			compiler.WithMetadata(m)
+
 			if tt.args.pipelineType != "" {
 				pipelineType := tt.args.pipelineType
 				compiler.WithRepo(&api.Repo{PipelineType: &pipelineType})
@@ -4457,6 +4481,7 @@ func Test_CompileLite(t *testing.T) {
 				t.Errorf("CompileLite() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("CompileLite() mismatch (-want +got):\n%s", diff)
 			}

--- a/compiler/native/environment_test.go
+++ b/compiler/native/environment_test.go
@@ -756,6 +756,7 @@ func Test_client_EnvironmentBuild(t *testing.T) {
 				user:     tt.fields.user,
 				netrc:    tt.fields.netrc,
 			}
+
 			got := c.EnvironmentBuild()
 			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("EnvironmentBuild mismatch (-want +got):\n%s", diff)

--- a/compiler/native/expand_test.go
+++ b/compiler/native/expand_test.go
@@ -31,6 +31,7 @@ func TestNative_ExpandStages(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 
@@ -142,6 +143,7 @@ func TestNative_ExpandStages(t *testing.T) {
 	}
 
 	compiler.PrivateGithub = nil
+
 	_, _, err = compiler.ExpandStages(
 		context.Background(),
 		&yaml.Build{
@@ -153,7 +155,6 @@ func TestNative_ExpandStages(t *testing.T) {
 		new(pipeline.RuleData),
 		nil,
 	)
-
 	if err == nil {
 		t.Errorf("ExpandStages should have returned error with empty PrivateGitHub")
 	}
@@ -175,7 +176,6 @@ func TestNative_ExpandStages(t *testing.T) {
 		new(pipeline.RuleData),
 		nil,
 	)
-
 	if err != nil {
 		t.Errorf("ExpandStages returned err: %v", err)
 	}
@@ -210,6 +210,7 @@ func TestNative_ExpandSteps(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 
@@ -388,6 +389,7 @@ func TestNative_ExpandStepsWarnings(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 
@@ -480,6 +482,7 @@ func TestNative_ExpandDeployment(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 
@@ -577,6 +580,7 @@ func TestNative_ExpandStepsMulti(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 
@@ -842,6 +846,7 @@ func TestNative_ExpandStepsStarlark(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 
@@ -932,6 +937,7 @@ func TestNative_ExpandSteps_TemplateCallTemplate(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 
@@ -1126,10 +1132,12 @@ func TestNative_ExpandStepsDuplicateCalls(t *testing.T) {
 		}
 
 		testCallsMap[c.Param("path")] = true
+
 		body, err := convertFileToGithubResponse(c.Param("path"))
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 
@@ -1338,6 +1346,7 @@ func TestNative_ExpandSteps_TemplateCallTemplate_CircularFail(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 
@@ -1421,6 +1430,7 @@ func TestNative_ExpandSteps_CallTemplateWithRenderInline(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+
 		c.JSON(http.StatusOK, body)
 	})
 

--- a/compiler/native/initialize.go
+++ b/compiler/native/initialize.go
@@ -10,10 +10,6 @@ import (
 const (
 	// default image for init process.
 	initImage = "#init"
-	// default name for init stage.
-	initStageName = "init"
-	// default name for init step.
-	initStepName = "init"
 )
 
 // InitStage injects the init stage process into a yaml configuration.
@@ -22,12 +18,12 @@ func (c *Client) InitStage(p *yaml.Build) (*yaml.Build, error) {
 
 	// create new clone stage
 	init := &yaml.Stage{
-		Name: initStageName,
+		Name: constants.InitName,
 		Steps: yaml.StepSlice{
 			&yaml.Step{
 				Detach:     false,
 				Image:      initImage,
-				Name:       initStepName,
+				Name:       constants.InitName,
 				Privileged: false,
 				Pull:       constants.PullNotPresent,
 			},
@@ -54,7 +50,7 @@ func (c *Client) InitStep(p *yaml.Build) (*yaml.Build, error) {
 	init := &yaml.Step{
 		Detach:     false,
 		Image:      initImage,
-		Name:       initStepName,
+		Name:       constants.InitName,
 		Privileged: false,
 		Pull:       constants.PullNotPresent,
 	}

--- a/compiler/native/native_test.go
+++ b/compiler/native/native_test.go
@@ -26,7 +26,6 @@ func TestNative_New(t *testing.T) {
 
 	// run test
 	got, err := FromCLICommand(context.Background(), testCommand(t, ""))
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -54,7 +53,6 @@ func TestNative_New_PrivateGithub(t *testing.T) {
 
 	// run test
 	got, err := FromCLICommand(context.Background(), testCommand(t, "http://foo.example.com"))
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -87,7 +85,6 @@ func TestNative_DuplicateRetainSettings(t *testing.T) {
 
 	// run test
 	got, err := FromCLICommand(context.Background(), testCommand(t, "http://foo.example.com"))
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}

--- a/compiler/native/parse_test.go
+++ b/compiler/native/parse_test.go
@@ -85,7 +85,6 @@ func TestNative_Parse_Metadata_Invalid(t *testing.T) {
 
 	// run test
 	got, _, _, err := client.Parse(nil, "", new(yaml.Template))
-
 	if err == nil {
 		t.Error("Parse should have returned err")
 	}
@@ -524,7 +523,6 @@ func TestNative_Parse_Secrets(t *testing.T) {
 	}
 
 	got, _, _, err := client.Parse(b, "", new(yaml.Template))
-
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}
@@ -601,7 +599,6 @@ func TestNative_Parse_Stages(t *testing.T) {
 	}
 
 	got, _, _, err := client.Parse(b, "", new(yaml.Template))
-
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}
@@ -679,7 +676,6 @@ func TestNative_Parse_StagesLegacyMergeAnchor(t *testing.T) {
 	}
 
 	got, _, _, err := client.Parse(b, "", new(yaml.Template))
-
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}
@@ -738,7 +734,6 @@ func TestNative_Parse_Steps(t *testing.T) {
 	}
 
 	got, _, _, err := client.Parse(b, "", new(yaml.Template))
-
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}
@@ -767,7 +762,6 @@ func TestNative_ParseBytes_Metadata(t *testing.T) {
 	}
 
 	got, _, _, err := ParseBytes(b)
-
 	if err != nil {
 		t.Errorf("ParseBytes returned err: %v", err)
 	}
@@ -785,7 +779,6 @@ func TestNative_ParseBytes_Invalid(t *testing.T) {
 	}
 
 	got, _, _, err := ParseBytes(b)
-
 	if err == nil {
 		t.Error("ParseBytes should have returned err")
 	}
@@ -816,7 +809,6 @@ func TestNative_ParseFile_Metadata(t *testing.T) {
 	defer f.Close()
 
 	got, _, _, err := ParseFile(f)
-
 	if err != nil {
 		t.Errorf("ParseFile returned err: %v", err)
 	}
@@ -836,7 +828,6 @@ func TestNative_ParseFile_Invalid(t *testing.T) {
 	f.Close()
 
 	got, _, _, err := ParseFile(f)
-
 	if err == nil {
 		t.Error("ParseFile should have returned err")
 	}
@@ -860,7 +851,6 @@ func TestNative_ParsePath_Metadata(t *testing.T) {
 
 	// run test
 	got, _, _, err := ParsePath("testdata/metadata.yml")
-
 	if err != nil {
 		t.Errorf("ParsePath returned err: %v", err)
 	}
@@ -873,7 +863,6 @@ func TestNative_ParsePath_Metadata(t *testing.T) {
 func TestNative_ParsePath_Invalid(t *testing.T) {
 	// run test
 	got, _, _, err := ParsePath("testdata/foobar.yml")
-
 	if err == nil {
 		t.Error("ParsePath should have returned err")
 	}
@@ -902,7 +891,6 @@ func TestNative_ParseReader_Metadata(t *testing.T) {
 	}
 
 	got, _, _, err := ParseReader(bytes.NewReader(b))
-
 	if err != nil {
 		t.Errorf("ParseReader returned err: %v", err)
 	}
@@ -915,7 +903,6 @@ func TestNative_ParseReader_Metadata(t *testing.T) {
 func TestNative_ParseReader_Invalid(t *testing.T) {
 	// run test
 	got, _, _, err := ParseReader(FailReader{})
-
 	if err == nil {
 		t.Error("ParseFile should have returned err")
 	}
@@ -944,7 +931,6 @@ func TestNative_ParseString_Metadata(t *testing.T) {
 	}
 
 	got, _, _, err := ParseString(string(b))
-
 	if err != nil {
 		t.Errorf("ParseString returned err: %v", err)
 	}
@@ -1024,6 +1010,7 @@ func Test_client_Parse(t *testing.T) {
 				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("Parse() mismatch (-want +got):\n%s", diff)
 			}
@@ -1057,8 +1044,11 @@ func Test_client_ParseRaw(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var content interface{}
-			var err error
+			var (
+				content interface{}
+				err     error
+			)
+
 			switch tt.args.kind {
 			case "byte":
 				content, err = os.ReadFile("testdata/metadata.yml")
@@ -1077,6 +1067,7 @@ func Test_client_ParseRaw(t *testing.T) {
 				}
 
 				content = bytes.NewReader(b)
+
 				if err != nil {
 					t.Errorf("Reading file returned err: %v", err)
 				}
@@ -1087,11 +1078,13 @@ func Test_client_ParseRaw(t *testing.T) {
 			}
 
 			c := &Client{}
+
 			got, err := c.ParseRaw(content)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseRaw() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+
 			if got != tt.want {
 				t.Errorf("ParseRaw() got = %v, want %v", got, tt.want)
 			}

--- a/compiler/native/script.go
+++ b/compiler/native/script.go
@@ -37,7 +37,7 @@ func (c *Client) ScriptSteps(s yaml.StepSlice) (yaml.StepSlice, error) {
 		}
 
 		// set the default home
-		//nolint:goconst // ignore making this a constant for now
+
 		home := "/root"
 
 		// override the home value if user is defined
@@ -62,7 +62,7 @@ func (c *Client) ScriptSteps(s yaml.StepSlice) (yaml.StepSlice, error) {
 		// set the environment variables for the step
 		step.Environment["VELA_BUILD_SCRIPT"] = script
 		step.Environment["HOME"] = home
-		//nolint:goconst // ignore making this a constant for now
+
 		step.Environment["SHELL"] = "/bin/sh"
 	}
 

--- a/compiler/native/script_test.go
+++ b/compiler/native/script_test.go
@@ -310,11 +310,13 @@ func TestNative_ScriptSteps(t *testing.T) {
 			if err != nil {
 				t.Errorf("Creating compiler returned err: %v", err)
 			}
+
 			got, err := compiler.ScriptSteps(tt.args.s)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ScriptSteps() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("ScriptSteps() mismatch (-want +got):\n%s", diff)
 			}

--- a/compiler/native/validate.go
+++ b/compiler/native/validate.go
@@ -102,7 +102,7 @@ func validateYAMLSteps(s yaml.StepSlice) error {
 			return fmt.Errorf("no image provided for step %s", step.Name)
 		}
 
-		if step.Name == "clone" || step.Name == "init" {
+		if step.Name == constants.CloneName || step.Name == constants.InitName {
 			continue
 		}
 
@@ -183,7 +183,7 @@ func validatePipelineStages(s pipeline.StageSlice) error {
 // and that the container names are unique.
 func validatePipelineContainers(s pipeline.ContainerSlice, reportCount *int, reportMap map[string]string, nameMap map[string]bool, stageName string) error {
 	for _, ctn := range s {
-		if ctn.Name == "clone" || ctn.Name == "init" {
+		if ctn.Name == constants.CloneName || ctn.Name == constants.InitName {
 			continue
 		}
 

--- a/compiler/native/validate_test.go
+++ b/compiler/native/validate_test.go
@@ -626,7 +626,6 @@ func TestNative_Validate_Steps_ExceedReportAs(t *testing.T) {
 	}
 
 	err = compiler.ValidatePipeline(p)
-
 	if err == nil {
 		t.Errorf("Validate should have returned err")
 	}
@@ -662,7 +661,6 @@ func TestNative_Validate_MultiReportAs(t *testing.T) {
 	}
 
 	err = compiler.ValidatePipeline(p)
-
 	if err == nil {
 		t.Errorf("Validate should have returned err")
 	}

--- a/compiler/registry/github/github_test.go
+++ b/compiler/registry/github/github_test.go
@@ -31,7 +31,6 @@ func TestGithub_New(t *testing.T) {
 
 	// run test
 	got, err := New(context.Background(), s.URL, "")
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -62,7 +61,6 @@ func TestGithub_NewToken(t *testing.T) {
 
 	// run test
 	got, err := New(context.Background(), s.URL, token)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -116,7 +114,6 @@ func TestGithub_NewURL(t *testing.T) {
 	for _, test := range tests {
 		// run test
 		got, err := New(context.Background(), test.address, "foobar")
-
 		if err != nil {
 			t.Errorf("New returned err: %v", err)
 		}

--- a/compiler/template/native/render_test.go
+++ b/compiler/template/native/render_test.go
@@ -46,11 +46,14 @@ func TestNative_Render(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
+
 			b := &yaml.Build{}
+
 			err = goyaml.Unmarshal(sFile, b)
 			if err != nil {
 				t.Error(err)
 			}
+
 			b.Steps[0].Environment = raw.StringSliceMap{
 				"VELA_REPO_FULL_NAME": "octocat/hello-world",
 			}
@@ -71,11 +74,14 @@ func TestNative_Render(t *testing.T) {
 				if err != nil {
 					t.Error(err)
 				}
+
 				w := &yaml.Build{}
+
 				err = goyaml.Unmarshal(wFile, w)
 				if err != nil {
 					t.Error(err)
 				}
+
 				wantSteps := w.Steps
 				wantSecrets := w.Secrets
 				wantServices := w.Services
@@ -84,12 +90,15 @@ func TestNative_Render(t *testing.T) {
 				if diff := cmp.Diff(wantSteps, tmplBuild.Steps); diff != "" {
 					t.Errorf("Render() mismatch (-want +got):\n%s", diff)
 				}
+
 				if diff := cmp.Diff(wantSecrets, tmplBuild.Secrets); diff != "" {
 					t.Errorf("Render() mismatch (-want +got):\n%s", diff)
 				}
+
 				if diff := cmp.Diff(wantServices, tmplBuild.Services); diff != "" {
 					t.Errorf("Render() mismatch (-want +got):\n%s", diff)
 				}
+
 				if diff := cmp.Diff(wantEnvironment, tmplBuild.Environment); diff != "" {
 					t.Errorf("Render() mismatch (-want +got):\n%s", diff)
 				}
@@ -135,7 +144,9 @@ func TestNative_RenderBuild(t *testing.T) {
 				if err != nil {
 					t.Error(err)
 				}
+
 				want := &yaml.Build{}
+
 				err = goyaml.Unmarshal(wFile, want)
 				if err != nil {
 					t.Error(err)

--- a/compiler/template/starlark/convert_test.go
+++ b/compiler/template/starlark/convert_test.go
@@ -84,34 +84,40 @@ func TestStarlark_Render_convertTemplateVars(t *testing.T) {
 func TestStarlark_Render_convertPlatformVars(t *testing.T) {
 	// setup types
 	build := starlark.NewDict(0)
+
 	err := build.SetKey(starlark.String("author"), starlark.String("octocat"))
 	if err != nil {
 		t.Error(err)
 	}
 
 	deployment := starlark.NewDict(0)
+
 	err = deployment.SetKey(starlark.String("image"), starlark.String("alpine:3.14"))
 	if err != nil {
 		t.Error(err)
 	}
 
 	repo := starlark.NewDict(0)
+
 	err = repo.SetKey(starlark.String("full_name"), starlark.String("go-vela/hello-world"))
 	if err != nil {
 		t.Error(err)
 	}
 
 	user := starlark.NewDict(0)
+
 	err = user.SetKey(starlark.String("admin"), starlark.String("true"))
 	if err != nil {
 		t.Error(err)
 	}
 
 	system := starlark.NewDict(0)
+
 	err = system.SetKey(starlark.String("template_name"), starlark.String("foo"))
 	if err != nil {
 		t.Error(err)
 	}
+
 	err = system.SetKey(starlark.String("workspace"), starlark.String("/vela/src/github.com/go-vela/hello-world"))
 	if err != nil {
 		t.Error(err)
@@ -119,22 +125,27 @@ func TestStarlark_Render_convertPlatformVars(t *testing.T) {
 
 	// setup full dictionary
 	withAll := starlark.NewDict(0)
+
 	err = withAll.SetKey(starlark.String("build"), build)
 	if err != nil {
 		t.Error(err)
 	}
+
 	err = withAll.SetKey(starlark.String("deployment"), deployment)
 	if err != nil {
 		t.Error(err)
 	}
+
 	err = withAll.SetKey(starlark.String("repo"), repo)
 	if err != nil {
 		t.Error(err)
 	}
+
 	err = withAll.SetKey(starlark.String("user"), user)
 	if err != nil {
 		t.Error(err)
 	}
+
 	err = withAll.SetKey(starlark.String("system"), system)
 	if err != nil {
 		t.Error(err)
@@ -142,22 +153,27 @@ func TestStarlark_Render_convertPlatformVars(t *testing.T) {
 
 	// setup vela dictionary
 	withAllVela := starlark.NewDict(0)
+
 	err = withAllVela.SetKey(starlark.String("build"), build)
 	if err != nil {
 		t.Error(err)
 	}
+
 	err = withAllVela.SetKey(starlark.String("deployment"), starlark.NewDict(0))
 	if err != nil {
 		t.Error(err)
 	}
+
 	err = withAllVela.SetKey(starlark.String("repo"), repo)
 	if err != nil {
 		t.Error(err)
 	}
+
 	err = withAllVela.SetKey(starlark.String("user"), user)
 	if err != nil {
 		t.Error(err)
 	}
+
 	err = withAllVela.SetKey(starlark.String("system"), system)
 	if err != nil {
 		t.Error(err)
@@ -165,27 +181,34 @@ func TestStarlark_Render_convertPlatformVars(t *testing.T) {
 
 	// setup deployment dictionary
 	withAllDeployment := starlark.NewDict(0)
+
 	err = withAllDeployment.SetKey(starlark.String("build"), starlark.NewDict(0))
 	if err != nil {
 		t.Error(err)
 	}
+
 	err = withAllDeployment.SetKey(starlark.String("deployment"), deployment)
 	if err != nil {
 		t.Error(err)
 	}
+
 	err = withAllDeployment.SetKey(starlark.String("repo"), starlark.NewDict(0))
 	if err != nil {
 		t.Error(err)
 	}
+
 	err = withAllDeployment.SetKey(starlark.String("user"), starlark.NewDict(0))
 	if err != nil {
 		t.Error(err)
 	}
+
 	system = starlark.NewDict(0)
+
 	err = system.SetKey(starlark.String("template_name"), starlark.String("foo"))
 	if err != nil {
 		t.Error(err)
 	}
+
 	err = withAllDeployment.SetKey(starlark.String("system"), system)
 	if err != nil {
 		t.Error(err)

--- a/compiler/template/starlark/render_test.go
+++ b/compiler/template/starlark/render_test.go
@@ -78,11 +78,14 @@ func TestStarlark_Render(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
+
 			b := &yaml.Build{}
+
 			err = goyaml.Unmarshal(sFile, b)
 			if err != nil {
 				t.Error(err)
 			}
+
 			b.Steps[0].Environment = raw.StringSliceMap{
 				"VELA_REPO_FULL_NAME": "octocat/hello-world",
 			}
@@ -103,11 +106,14 @@ func TestStarlark_Render(t *testing.T) {
 				if err != nil {
 					t.Error(err)
 				}
+
 				w := &yaml.Build{}
+
 				err = goyaml.Unmarshal(wFile, w)
 				if err != nil {
 					t.Error(err)
 				}
+
 				wantSteps := w.Steps
 				wantSecrets := w.Secrets
 				wantServices := w.Services
@@ -116,12 +122,15 @@ func TestStarlark_Render(t *testing.T) {
 				if diff := cmp.Diff(wantSteps, tmplBuild.Steps); diff != "" {
 					t.Errorf("Render() mismatch (-want +got):\n%s", diff)
 				}
+
 				if diff := cmp.Diff(wantSecrets, tmplBuild.Secrets); diff != "" {
 					t.Errorf("Render() mismatch (-want +got):\n%s", diff)
 				}
+
 				if diff := cmp.Diff(wantServices, tmplBuild.Services); diff != "" {
 					t.Errorf("Render() mismatch (-want +got):\n%s", diff)
 				}
+
 				if diff := cmp.Diff(wantEnvironment, tmplBuild.Environment); diff != "" {
 					t.Errorf("Render() mismatch (-want +got):\n%s", diff)
 				}
@@ -222,7 +231,9 @@ func TestNative_RenderBuild(t *testing.T) {
 				if err != nil {
 					t.Error(err)
 				}
+
 				want := &yaml.Build{}
+
 				err = goyaml.Unmarshal(wFile, want)
 				if err != nil {
 					t.Error(err)

--- a/compiler/template/starlark/starlark_test.go
+++ b/compiler/template/starlark/starlark_test.go
@@ -56,6 +56,7 @@ func TestStarlark_toStarlark(t *testing.T) {
 				t.Errorf("toStarlark() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("toStarlark() got = %v, want %v", got, tt.want)
 			}

--- a/compiler/types/yaml/buildkite/build_test.go
+++ b/compiler/types/yaml/buildkite/build_test.go
@@ -743,7 +743,6 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 		}
 
 		err = yaml.Unmarshal(b, got)
-
 		if err != nil {
 			t.Errorf("UnmarshalYAML returned err: %v", err)
 		}

--- a/compiler/types/yaml/buildkite/ruleset_test.go
+++ b/compiler/types/yaml/buildkite/ruleset_test.go
@@ -186,7 +186,6 @@ func TestYaml_Ruleset_UnmarshalYAML(t *testing.T) {
 		}
 
 		err = yaml.Unmarshal(b, got)
-
 		if err != nil {
 			t.Errorf("UnmarshalYAML returned err: %v", err)
 		}

--- a/compiler/types/yaml/buildkite/stage.go
+++ b/compiler/types/yaml/buildkite/stage.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-vela/server/compiler/types/pipeline"
 	"github.com/go-vela/server/compiler/types/raw"
 	"github.com/go-vela/server/compiler/types/yaml/yaml"
+	"github.com/go-vela/server/constants"
 )
 
 type (
@@ -82,16 +83,16 @@ func (s *StageSlice) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 
 		// implicitly set the stage `needs`
-		if stage.Name != "clone" && stage.Name != "init" {
+		if stage.Name != constants.CloneName && stage.Name != constants.InitName {
 			// add clone if not present
 			stage.Needs = func(needs []string) []string {
 				for _, s := range needs {
-					if s == "clone" {
+					if s == constants.CloneName {
 						return needs
 					}
 				}
 
-				return append(needs, "clone")
+				return append(needs, constants.CloneName)
 			}(stage.Needs)
 		}
 		// append stage to stage slice

--- a/compiler/types/yaml/yaml/build_test.go
+++ b/compiler/types/yaml/yaml/build_test.go
@@ -743,7 +743,6 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 		}
 
 		err = yaml.Unmarshal(b, got)
-
 		if err != nil {
 			t.Errorf("UnmarshalYAML returned err: %v", err)
 		}

--- a/compiler/types/yaml/yaml/stage.go
+++ b/compiler/types/yaml/yaml/stage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-vela/server/compiler/types/pipeline"
 	"github.com/go-vela/server/compiler/types/raw"
+	"github.com/go-vela/server/constants"
 )
 
 type (
@@ -75,16 +76,16 @@ func (s *StageSlice) UnmarshalYAML(v *yaml.Node) error {
 		}
 
 		// implicitly set the stage `needs`
-		if stage.Name != "clone" && stage.Name != "init" {
+		if stage.Name != constants.CloneName && stage.Name != constants.InitName {
 			// add clone if not present
 			stage.Needs = func(needs []string) []string {
 				for _, s := range needs {
-					if s == "clone" {
+					if s == constants.CloneName {
 						return needs
 					}
 				}
 
-				return append(needs, "clone")
+				return append(needs, constants.CloneName)
 			}(stage.Needs)
 		}
 		// append stage to stage slice

--- a/constants/pipeline.go
+++ b/constants/pipeline.go
@@ -12,4 +12,10 @@ const (
 
 	// PipelineTemplate defines the type for a pipeline as a template.
 	PipelineTemplate = "template"
+
+	// InitName defines the name for the initialization step.
+	InitName = "init"
+
+	// CloneName defines the name for the clone step.
+	CloneName = "clone"
 )

--- a/database/build/build_test.go
+++ b/database/build/build_test.go
@@ -135,6 +135,7 @@ func (t NowTimestamp) Match(v driver.Value) bool {
 	if !ok {
 		return false
 	}
+
 	now := time.Now().Unix()
 
 	return now-ts < 10

--- a/database/build/clean_test.go
+++ b/database/build/clean_test.go
@@ -63,6 +63,7 @@ func TestBuild_Engine_CleanBuilds(t *testing.T) {
 	_buildFour.SetStatus("running")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the name query
@@ -71,6 +72,7 @@ func TestBuild_Engine_CleanBuilds(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 2))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)

--- a/database/build/count_deployment_test.go
+++ b/database/build/count_deployment_test.go
@@ -53,6 +53,7 @@ func TestBuild_Engine_CountBuildsForDeployment(t *testing.T) {
 	_deployment.SetURL("https://github.com/github/octocat/deployments/1")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -62,6 +63,7 @@ func TestBuild_Engine_CountBuildsForDeployment(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "builds" WHERE source = $1`).WithArgs("https://github.com/github/octocat/deployments/1").WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)

--- a/database/build/count_org_test.go
+++ b/database/build/count_org_test.go
@@ -58,6 +58,7 @@ func TestBuild_Engine_CountBuildsForOrg(t *testing.T) {
 	_buildTwo.SetEvent("push")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result without filters in mock
@@ -71,6 +72,7 @@ func TestBuild_Engine_CountBuildsForOrg(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "builds" JOIN repos ON builds.repo_id = repos.id WHERE repos.org = $1 AND "builds"."event" = $2`).WithArgs("foo", "push").WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)

--- a/database/build/count_repo_test.go
+++ b/database/build/count_repo_test.go
@@ -44,6 +44,7 @@ func TestBuild_Engine_CountBuildsForRepo(t *testing.T) {
 	_buildTwo.SetCreated(2)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -53,6 +54,7 @@ func TestBuild_Engine_CountBuildsForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "builds" WHERE repo_id = $1 AND created < $2 AND created > $3`).WithArgs(1, AnyArgument{}, 0).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)

--- a/database/build/count_status_test.go
+++ b/database/build/count_status_test.go
@@ -43,6 +43,7 @@ func TestBuild_Engine_CountBuildsForStatus(t *testing.T) {
 	_buildTwo.SetStatus("running")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -52,6 +53,7 @@ func TestBuild_Engine_CountBuildsForStatus(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "builds" WHERE status = $1`).WithArgs("running").WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)

--- a/database/build/count_test.go
+++ b/database/build/count_test.go
@@ -41,6 +41,7 @@ func TestBuild_Engine_CountBuilds(t *testing.T) {
 	_buildTwo.SetDeployPayload(nil)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -50,6 +51,7 @@ func TestBuild_Engine_CountBuilds(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "builds"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)

--- a/database/build/create_test.go
+++ b/database/build/create_test.go
@@ -35,6 +35,7 @@ func TestBuild_Engine_CreateBuild(t *testing.T) {
 	_build.SetDeployPayload(nil)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -48,6 +49,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/build/delete_test.go
+++ b/database/build/delete_test.go
@@ -34,6 +34,7 @@ func TestBuild_Engine_DeleteBuild(t *testing.T) {
 	_build.SetDeployPayload(nil)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -42,6 +43,7 @@ func TestBuild_Engine_DeleteBuild(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _build)

--- a/database/build/get_repo_test.go
+++ b/database/build/get_repo_test.go
@@ -41,6 +41,7 @@ func TestBuild_Engine_GetBuildForRepo(t *testing.T) {
 	_build.SetDeployPayload(nil)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -50,6 +51,7 @@ func TestBuild_Engine_GetBuildForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "builds" WHERE repo_id = $1 AND number = $2 LIMIT $3`).WithArgs(1, 1, 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _build)

--- a/database/build/get_test.go
+++ b/database/build/get_test.go
@@ -39,6 +39,7 @@ func TestBuild_Engine_GetBuild(t *testing.T) {
 	_build.SetDeployPayload(nil)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -54,6 +55,7 @@ func TestBuild_Engine_GetBuild(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE "users"."id" = $1`).WithArgs(1).WillReturnRows(_userRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _build)

--- a/database/build/index_test.go
+++ b/database/build/index_test.go
@@ -12,6 +12,7 @@ import (
 func TestBuild_Engine_CreateBuildIndexes(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreateCreatedIndex).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -20,6 +21,7 @@ func TestBuild_Engine_CreateBuildIndexes(t *testing.T) {
 	_mock.ExpectExec(CreateStatusIndex).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/build/interface.go
+++ b/database/build/interface.go
@@ -11,7 +11,7 @@ import (
 // BuildInterface represents the Vela interface for build
 // functions with the supported Database backends.
 //
-//nolint:revive // ignore name stutter
+
 type BuildInterface interface {
 	// Build Data Definition Language Functions
 	//

--- a/database/build/last_repo_test.go
+++ b/database/build/last_repo_test.go
@@ -40,6 +40,7 @@ func TestBuild_Engine_LastBuildForRepo(t *testing.T) {
 	_build.SetBranch("main")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -49,6 +50,7 @@ func TestBuild_Engine_LastBuildForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "builds" WHERE repo_id = $1 AND branch = $2 ORDER BY number DESC LIMIT $3`).WithArgs(1, "main", 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _build)

--- a/database/build/list_dashboard_test.go
+++ b/database/build/list_dashboard_test.go
@@ -37,6 +37,7 @@ func TestBuild_Engine_ListBuildsForDashboardRepo(t *testing.T) {
 	_buildTwo.SetBranch("main")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected query result in mock
@@ -46,6 +47,7 @@ func TestBuild_Engine_ListBuildsForDashboardRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "builds" WHERE repo_id = $1 AND branch IN ($2) AND event IN ($3,$4) ORDER BY number DESC LIMIT $5`).WithArgs(1, "main", "push", "pull_request", 5).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)

--- a/database/build/list_org_test.go
+++ b/database/build/list_org_test.go
@@ -60,6 +60,7 @@ func TestBuild_Engine_ListBuildsForOrg(t *testing.T) {
 	_buildTwo.SetEvent("push")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected query without filters result in mock
@@ -95,6 +96,7 @@ func TestBuild_Engine_ListBuildsForOrg(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE "users"."id" = $1`).WithArgs(1).WillReturnRows(_userRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)

--- a/database/build/list_pending_approval_test.go
+++ b/database/build/list_pending_approval_test.go
@@ -53,6 +53,7 @@ func TestBuild_Engine_ListPendingApprovalBuilds(t *testing.T) {
 	_buildThree.SetDeployPayload(nil)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected name query result in mock
@@ -65,6 +66,7 @@ func TestBuild_Engine_ListPendingApprovalBuilds(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "repos" WHERE "repos"."id" = $1`).WithArgs(1).WillReturnRows(_repoRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)

--- a/database/build/list_pending_running_repo_test.go
+++ b/database/build/list_pending_running_repo_test.go
@@ -69,6 +69,7 @@ func TestBuild_Engine_ListPendingAndRunningBuildsForRepo(t *testing.T) {
 	_buildThree.SetDeployPayload(nil)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected name query result in mock
@@ -78,6 +79,7 @@ func TestBuild_Engine_ListPendingAndRunningBuildsForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "builds" WHERE repo_id = $1 AND (status = 'running' OR status = 'pending' OR status = 'pending approval')`).WithArgs(1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)

--- a/database/build/list_pending_running_test.go
+++ b/database/build/list_pending_running_test.go
@@ -60,6 +60,7 @@ func TestBuild_Engine_ListPendingAndRunningBuilds(t *testing.T) {
 	_queueTwo.SetStatus("pending")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected name query result in mock
@@ -69,6 +70,7 @@ func TestBuild_Engine_ListPendingAndRunningBuilds(t *testing.T) {
 	_mock.ExpectQuery(`SELECT builds.created, builds.number, builds.status, repos.full_name FROM "builds" INNER JOIN repos ON builds.repo_id = repos.id WHERE builds.created > $1 AND (builds.status = 'running' OR builds.status = 'pending')`).WithArgs("0").WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)

--- a/database/build/list_repo_test.go
+++ b/database/build/list_repo_test.go
@@ -48,6 +48,7 @@ func TestBuild_Engine_ListBuildsForRepo(t *testing.T) {
 	_buildTwo.SetCreated(2)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected query result in mock
@@ -57,6 +58,7 @@ func TestBuild_Engine_ListBuildsForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "builds" WHERE repo_id = $1 AND created < $2 AND created > $3 ORDER BY number DESC LIMIT $4`).WithArgs(1, AnyArgument{}, 0, 10).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)

--- a/database/build/list_test.go
+++ b/database/build/list_test.go
@@ -47,6 +47,7 @@ func TestBuild_Engine_ListBuilds(t *testing.T) {
 	_buildTwo.SetDeployPayload(nil)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -60,6 +61,7 @@ func TestBuild_Engine_ListBuilds(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE "users"."id" = $1`).WithArgs(1).WillReturnRows(_userRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _buildOne)

--- a/database/build/table_test.go
+++ b/database/build/table_test.go
@@ -12,11 +12,13 @@ import (
 func TestBuild_Engine_CreateBuildTable(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreatePostgresTable).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/build/update_test.go
+++ b/database/build/update_test.go
@@ -37,6 +37,7 @@ func TestBuild_Engine_UpdateBuild(t *testing.T) {
 	_build.SetDeployPayload(nil)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -47,6 +48,7 @@ WHERE "id" = $37`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateBuild(context.TODO(), _build)

--- a/database/dashboard/create_test.go
+++ b/database/dashboard/create_test.go
@@ -38,6 +38,7 @@ func TestDashboard_Engine_CreateDashboard(t *testing.T) {
 	_dashboard.SetRepos(_dashRepos)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -51,6 +52,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING "id"`).
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/dashboard/dashboard_test.go
+++ b/database/dashboard/dashboard_test.go
@@ -177,6 +177,7 @@ func (t NowTimestamp) Match(v driver.Value) bool {
 	if !ok {
 		return false
 	}
+
 	now := time.Now().Unix()
 
 	return now-ts < 10

--- a/database/dashboard/delete_test.go
+++ b/database/dashboard/delete_test.go
@@ -24,6 +24,7 @@ func TestDashboard_Engine_DeleteDashboard(t *testing.T) {
 	_dashboard.SetRepos([]*api.DashboardRepo{testutils.APIDashboardRepo()})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -32,6 +33,7 @@ func TestDashboard_Engine_DeleteDashboard(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateDashboard(context.TODO(), _dashboard)

--- a/database/dashboard/get_test.go
+++ b/database/dashboard/get_test.go
@@ -40,6 +40,7 @@ func TestRepo_Engine_GetDashboard(t *testing.T) {
 	// uuid, _ := uuid.Parse("c8da1302-07d6-11ea-882f-4893bca275b8")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -49,6 +50,7 @@ func TestRepo_Engine_GetDashboard(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "dashboards" WHERE id = $1 LIMIT $2`).WithArgs("c8da1302-07d6-11ea-882f-4893bca275b8", 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateDashboard(context.TODO(), _dashboard)

--- a/database/dashboard/interface.go
+++ b/database/dashboard/interface.go
@@ -11,7 +11,7 @@ import (
 // DashboardInterface represents the Vela interface for repo
 // functions with the supported Database backends.
 //
-//nolint:revive // ignore name stutter
+
 type DashboardInterface interface {
 	// Dashboard Data Definition Language Functions
 	//

--- a/database/dashboard/table_test.go
+++ b/database/dashboard/table_test.go
@@ -12,11 +12,13 @@ import (
 func TestDashboard_Engine_CreateDashboardTable(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreatePostgresTable).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/dashboard/update_test.go
+++ b/database/dashboard/update_test.go
@@ -38,6 +38,7 @@ func TestDashboard_Engine_UpdateDashboard(t *testing.T) {
 	_dashboard.SetAdmins(_admins)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -47,6 +48,7 @@ SET "name"=$1,"created_at"=$2,"created_by"=$3,"updated_at"=$4,"updated_by"=$5,"a
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateDashboard(context.TODO(), _dashboard)

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -327,9 +327,11 @@ func TestDatabase_Engine_PartitionConfiguration(t *testing.T) {
 			if engineCast.config.LogPartitioned != test.wantPartitioned {
 				t.Errorf("config.LogPartitioned for %s = %v, want %v", test.name, engineCast.config.LogPartitioned, test.wantPartitioned)
 			}
+
 			if engineCast.config.LogPartitionPattern != test.wantPattern {
 				t.Errorf("config.LogPartitionPattern for %s = %s, want %s", test.name, engineCast.config.LogPartitionPattern, test.wantPattern)
 			}
+
 			if engineCast.config.LogPartitionSchema != test.wantSchema {
 				t.Errorf("config.LogPartitionSchema for %s = %s, want %s", test.name, engineCast.config.LogPartitionSchema, test.wantSchema)
 			}

--- a/database/deployment/count_repo_test.go
+++ b/database/deployment/count_repo_test.go
@@ -60,6 +60,7 @@ func TestDeployment_Engine_CountDeploymentsForRepo(t *testing.T) {
 	_deploymentTwo.SetBuilds(builds)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -69,6 +70,7 @@ func TestDeployment_Engine_CountDeploymentsForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "deployments" WHERE repo_id = $1`).WithArgs(1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateDeployment(context.TODO(), _deploymentOne)

--- a/database/deployment/count_test.go
+++ b/database/deployment/count_test.go
@@ -52,6 +52,7 @@ func TestDeployment_Engine_CountDeployments(t *testing.T) {
 	_deploymentTwo.SetBuilds([]*api.Build{testutils.APIBuild()})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -61,6 +62,7 @@ func TestDeployment_Engine_CountDeployments(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "deployments"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateDeployment(context.TODO(), _deploymentOne)

--- a/database/deployment/create_test.go
+++ b/database/deployment/create_test.go
@@ -35,6 +35,7 @@ func TestDeployment_Engine_CreateDeployment(t *testing.T) {
 	_deploymentOne.SetCreatedBy("octocat")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -48,6 +49,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13) RETURNING "id"`).
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/deployment/delete_test.go
+++ b/database/deployment/delete_test.go
@@ -36,6 +36,7 @@ func TestDeployment_Engine_DeleteDeployment(t *testing.T) {
 	_deploymentOne.SetBuilds([]*api.Build{testutils.APIBuild()})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -44,6 +45,7 @@ func TestDeployment_Engine_DeleteDeployment(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateDeployment(context.TODO(), _deploymentOne)

--- a/database/deployment/get_repo_test.go
+++ b/database/deployment/get_repo_test.go
@@ -59,6 +59,7 @@ func TestDeployment_Engine_GetDeploymentForRepo(t *testing.T) {
 	_deploymentOne.SetBuilds([]*api.Build{_build})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -71,6 +72,7 @@ func TestDeployment_Engine_GetDeploymentForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "builds" WHERE id = $1 LIMIT $2`).WithArgs(1, 1).WillReturnRows(_buildRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	sqlitePopulateTables(

--- a/database/deployment/get_test.go
+++ b/database/deployment/get_test.go
@@ -48,6 +48,7 @@ func TestDeployment_Engine_GetDeployment(t *testing.T) {
 	_deploymentOne.SetCreatedBy("octocat")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -63,6 +64,7 @@ func TestDeployment_Engine_GetDeployment(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE "users"."id" = $1`).WithArgs(1).WillReturnRows(_userRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	sqlitePopulateTables(

--- a/database/deployment/index_test.go
+++ b/database/deployment/index_test.go
@@ -12,11 +12,13 @@ import (
 func TestDeployment_Engine_CreateDeploymentIndexes(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreateRepoIDIndex).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/deployment/interface.go
+++ b/database/deployment/interface.go
@@ -11,7 +11,7 @@ import (
 // DeploymentInterface represents the Vela interface for deployment
 // functions with the supported Database backends.
 //
-//nolint:revive // ignore name stutter
+
 type DeploymentInterface interface {
 	// Deployment Data Definition Language Functions
 	//

--- a/database/deployment/list_repo_test.go
+++ b/database/deployment/list_repo_test.go
@@ -85,6 +85,7 @@ func TestDeployment_Engine_ListDeploymentsForRepo(t *testing.T) {
 	_deploymentTwo.SetCreatedBy("octocat")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -97,6 +98,7 @@ func TestDeployment_Engine_ListDeploymentsForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "builds" WHERE id = $1 LIMIT $2`).WithArgs(1, 1).WillReturnRows(_buildRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	sqlitePopulateTables(

--- a/database/deployment/list_test.go
+++ b/database/deployment/list_test.go
@@ -73,6 +73,7 @@ func TestDeployment_Engine_ListDeployments(t *testing.T) {
 	_deploymentTwo.SetCreatedBy("octocat")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -91,6 +92,7 @@ func TestDeployment_Engine_ListDeployments(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "builds" WHERE id = $1 LIMIT $2`).WithArgs(1, 1).WillReturnRows(_buildRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	sqlitePopulateTables(

--- a/database/deployment/table_test.go
+++ b/database/deployment/table_test.go
@@ -12,11 +12,13 @@ import (
 func TestDeployment_Engine_CreateDeploymentTable(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreatePostgresTable).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/deployment/update_test.go
+++ b/database/deployment/update_test.go
@@ -35,6 +35,7 @@ func TestDeployment_Engine_UpdateDeployment(t *testing.T) {
 	_deploymentOne.SetCreatedBy("octocat")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -45,6 +46,7 @@ WHERE "id" = $13`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateDeployment(context.TODO(), _deploymentOne)

--- a/database/executable/clean_test.go
+++ b/database/executable/clean_test.go
@@ -43,6 +43,7 @@ func TestExecutable_Engine_CleanExecutables(t *testing.T) {
 	_bExecutableTwo.SetData([]byte("bar"))
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec("DELETE FROM build_executables USING builds WHERE builds.id = build_executables.build_id AND builds.status = 'error';").
@@ -51,6 +52,7 @@ func TestExecutable_Engine_CleanExecutables(t *testing.T) {
 	_mock.ExpectQuery(`DELETE FROM "build_executables" WHERE build_id = $1 RETURNING *`).WithArgs(2).WillReturnError(fmt.Errorf("not found"))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	err := _sqlite.CreateBuildExecutable(context.TODO(), _bExecutableOne)

--- a/database/executable/create_test.go
+++ b/database/executable/create_test.go
@@ -16,6 +16,7 @@ func TestExecutable_Engine_CreateBuildExecutable(t *testing.T) {
 	_bExecutable.SetBuildID(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -29,6 +30,7 @@ VALUES ($1,$2,$3) RETURNING "id"`).
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/executable/pop_test.go
+++ b/database/executable/pop_test.go
@@ -20,6 +20,7 @@ func TestExecutable_Engine_PopBuildExecutable(t *testing.T) {
 	_bExecutable.SetData([]byte("foo"))
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -41,6 +42,7 @@ func TestExecutable_Engine_PopBuildExecutable(t *testing.T) {
 	_mock.ExpectQuery(`DELETE FROM "build_executables" WHERE build_id = $1 RETURNING *`).WithArgs(1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	err = _sqlite.CreateBuildExecutable(context.TODO(), _bExecutable)

--- a/database/executable/table_test.go
+++ b/database/executable/table_test.go
@@ -12,11 +12,13 @@ import (
 func TestExecutable_Engine_CreateBuildExecutableTable(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreatePostgresTable).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/flags_test.go
+++ b/database/flags_test.go
@@ -37,6 +37,7 @@ func TestDatabase_Flags(t *testing.T) {
 				t.Fatalf("unsupported flag type: %T", f)
 			}
 		}
+
 		return copiedFlags
 	}
 
@@ -119,6 +120,7 @@ func TestDatabase_Flags(t *testing.T) {
 				if len(value) == 0 {
 					continue
 				}
+
 				args = append(args, `--`+key+"="+value)
 			}
 

--- a/database/hook/count_repo_test.go
+++ b/database/hook/count_repo_test.go
@@ -51,6 +51,7 @@ func TestHook_Engine_CountHooksForRepo(t *testing.T) {
 	_hookTwo.SetWebhookID(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -60,6 +61,7 @@ func TestHook_Engine_CountHooksForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "hooks" WHERE repo_id = $1`).WithArgs(1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateHook(context.TODO(), _hookOne)

--- a/database/hook/count_test.go
+++ b/database/hook/count_test.go
@@ -49,6 +49,7 @@ func TestHook_Engine_CountHooks(t *testing.T) {
 	_hookTwo.SetWebhookID(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -58,6 +59,7 @@ func TestHook_Engine_CountHooks(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "hooks"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateHook(context.TODO(), _hookOne)

--- a/database/hook/create_test.go
+++ b/database/hook/create_test.go
@@ -28,6 +28,7 @@ func TestHook_Engine_CreateHook(t *testing.T) {
 	_hook.SetWebhookID(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -41,6 +42,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14) RETURNING "id"`).
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/hook/delete_test.go
+++ b/database/hook/delete_test.go
@@ -29,6 +29,7 @@ func TestHook_Engine_DeleteHook(t *testing.T) {
 	_hook.SetWebhookID(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -37,6 +38,7 @@ func TestHook_Engine_DeleteHook(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	sqlitePopulateTables(t, _sqlite, []*api.Hook{_hook}, nil, nil, nil)

--- a/database/hook/get_repo_test.go
+++ b/database/hook/get_repo_test.go
@@ -52,6 +52,7 @@ func TestHook_Engine_GetHookForRepo(t *testing.T) {
 	_hook.SetWebhookID(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -64,6 +65,7 @@ func TestHook_Engine_GetHookForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "builds" WHERE "builds"."id" = $1`).WithArgs(1).WillReturnRows(_buildRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	sqlitePopulateTables(

--- a/database/hook/get_test.go
+++ b/database/hook/get_test.go
@@ -51,6 +51,7 @@ func TestHook_Engine_GetHook(t *testing.T) {
 	_hook.SetWebhookID(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -69,6 +70,7 @@ func TestHook_Engine_GetHook(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE "users"."id" = $1`).WithArgs(1).WillReturnRows(_userRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	sqlitePopulateTables(t, _sqlite, []*api.Hook{_hook}, []*api.User{_owner}, []*api.Repo{_repo}, []*api.Build{_build})

--- a/database/hook/get_webhook_test.go
+++ b/database/hook/get_webhook_test.go
@@ -50,6 +50,7 @@ func TestHook_Engine_GetHookByWebhookID(t *testing.T) {
 	_hook.SetWebhookID(123456)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -68,6 +69,7 @@ func TestHook_Engine_GetHookByWebhookID(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE "users"."id" = $1`).WithArgs(1).WillReturnRows(_userRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	sqlitePopulateTables(t, _sqlite, []*api.Hook{_hook}, []*api.User{_owner}, []*api.Repo{_repo}, []*api.Build{_build})

--- a/database/hook/index_test.go
+++ b/database/hook/index_test.go
@@ -12,11 +12,13 @@ import (
 func TestHook_Engine_CreateHookIndexes(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreateRepoIDIndex).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/hook/interface.go
+++ b/database/hook/interface.go
@@ -11,7 +11,7 @@ import (
 // HookInterface represents the Vela interface for hook
 // functions with the supported Database backends.
 //
-//nolint:revive // ignore name stutter
+
 type HookInterface interface {
 	// Hook Data Definition Language Functions
 	//

--- a/database/hook/last_repo_test.go
+++ b/database/hook/last_repo_test.go
@@ -50,6 +50,7 @@ func TestHook_Engine_LastHookForRepo(t *testing.T) {
 	_hook.SetWebhookID(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -62,6 +63,7 @@ func TestHook_Engine_LastHookForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "builds" WHERE "builds"."id" = $1`).WithArgs(1).WillReturnRows(_buildRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	sqlitePopulateTables(t, _sqlite, []*api.Hook{_hook}, []*api.User{}, []*api.Repo{}, []*api.Build{_build})

--- a/database/hook/list_repo_test.go
+++ b/database/hook/list_repo_test.go
@@ -58,6 +58,7 @@ func TestHook_Engine_ListHooksForRepo(t *testing.T) {
 	_hookTwo.SetWebhookID(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -70,6 +71,7 @@ func TestHook_Engine_ListHooksForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "builds" WHERE "builds"."id" = $1`).WithArgs(1).WillReturnRows(_buildRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	sqlitePopulateTables(

--- a/database/hook/list_test.go
+++ b/database/hook/list_test.go
@@ -58,6 +58,7 @@ func TestHook_Engine_ListHooks(t *testing.T) {
 	_hookTwo.SetWebhookID(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -76,6 +77,7 @@ func TestHook_Engine_ListHooks(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE "users"."id" = $1`).WithArgs(1).WillReturnRows(_userRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	sqlitePopulateTables(

--- a/database/hook/table_test.go
+++ b/database/hook/table_test.go
@@ -12,11 +12,13 @@ import (
 func TestHook_Engine_CreateHookTable(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreatePostgresTable).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/hook/update_test.go
+++ b/database/hook/update_test.go
@@ -29,6 +29,7 @@ func TestHook_Engine_UpdateHook(t *testing.T) {
 	_hook.SetWebhookID(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -39,6 +40,7 @@ WHERE "id" = $14`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	sqlitePopulateTables(t, _sqlite, []*api.Hook{_hook}, nil, nil, nil)

--- a/database/integration_test.go
+++ b/database/integration_test.go
@@ -226,6 +226,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to create build %d: %v", build.GetID(), err)
 		}
 	}
+
 	methods["CreateBuild"] = true
 
 	// count the builds
@@ -233,9 +234,11 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count builds: %v", err)
 	}
+
 	if int(count) != len(resources.Builds) {
 		t.Errorf("CountBuilds() is %v, want %v", count, len(resources.Builds))
 	}
+
 	methods["CountBuilds"] = true
 
 	// count the builds for a deployment
@@ -243,9 +246,11 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count builds for deployment %d: %v", resources.Deployments[0].GetID(), err)
 	}
+
 	if int(count) != len(resources.Builds) {
 		t.Errorf("CountBuildsForDeployment() is %v, want %v", count, len(resources.Builds))
 	}
+
 	methods["CountBuildsForDeployment"] = true
 
 	// count the builds for an org
@@ -253,9 +258,11 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count builds for org %s: %v", resources.Repos[0].GetOrg(), err)
 	}
+
 	if int(count) != len(resources.Builds) {
 		t.Errorf("CountBuildsForOrg() is %v, want %v", count, len(resources.Builds))
 	}
+
 	methods["CountBuildsForOrg"] = true
 
 	// count the builds for a repo
@@ -263,9 +270,11 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count builds for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
+
 	if int(count) != len(resources.Builds) {
 		t.Errorf("CountBuildsForRepo() is %v, want %v", count, len(resources.Builds))
 	}
+
 	methods["CountBuildsForRepo"] = true
 
 	// count the builds for a status
@@ -273,9 +282,11 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count builds for status %s: %v", "running", err)
 	}
+
 	if int(count) != len(resources.Builds) {
 		t.Errorf("CountBuildsForStatus() is %v, want %v", count, len(resources.Builds))
 	}
+
 	methods["CountBuildsForStatus"] = true
 
 	// list the builds
@@ -283,9 +294,11 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list builds: %v", err)
 	}
+
 	if diff := cmp.Diff(resources.Builds, list); diff != "" {
 		t.Errorf("ListBuilds() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["ListBuilds"] = true
 
 	// list the builds for an org
@@ -293,9 +306,11 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list builds for org %s: %v", resources.Repos[0].GetOrg(), err)
 	}
+
 	if diff := cmp.Diff(resources.Builds, list); diff != "" {
 		t.Errorf("ListBuildsForOrg() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["ListBuildsForOrg"] = true
 
 	// list the builds for a repo
@@ -303,15 +318,18 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list builds for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
+
 	if diff := cmp.Diff([]*api.Build{resources.Builds[1], resources.Builds[0]}, list); diff != "" {
 		t.Errorf("ListBuildsForRepo() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["ListBuildsForRepo"] = true
 
 	list, err = db.ListBuildsForDashboardRepo(context.TODO(), resources.Repos[0], []string{"main"}, []string{"push"})
 	if err != nil {
 		t.Errorf("unable to list build for dashboard repo %d: %v", resources.Repos[0].GetID(), err)
 	}
+
 	if len(list) != 1 {
 		t.Errorf("Number of results for ListBuildsForDashboardRepo() is %v, want %v", len(list), 1)
 	}
@@ -319,6 +337,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	if diff := cmp.Diff([]*api.Build{resources.Hooks[0].GetBuild()}, list); diff != "" {
 		t.Errorf("ListBuildsForDashboardRepo() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["ListBuildsForDashboardRepo"] = true
 
 	// list the pending / running builds for a repo
@@ -326,12 +345,15 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list pending and running builds for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
+
 	if int(count) != len(resources.Builds) {
 		t.Errorf("ListPendingAndRunningBuildsForRepo() is %v, want %v", count, len(resources.Builds))
 	}
+
 	if diff := cmp.Diff([]*api.Build{resources.Builds[0], resources.Builds[1]}, list); diff != "" {
 		t.Errorf("ListPendingAndRunningBuildsForRepo() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["ListPendingAndRunningBuildsForRepo"] = true
 
 	// list the pending and running builds
@@ -339,9 +361,11 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list pending and running builds: %v", err)
 	}
+
 	if diff := cmp.Diff(queueBuilds, queueList); diff != "" {
 		t.Errorf("ListPendingAndRunningBuilds() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["ListPendingAndRunningBuilds"] = true
 
 	// lookup the last build by repo
@@ -349,22 +373,27 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to get last build for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
+
 	if diff := cmp.Diff(resources.Builds[1], got); diff != "" {
 		t.Errorf("LastBuildForRepo() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["LastBuildForRepo"] = true
 
 	// lookup the builds by repo and number
 	for _, build := range resources.Builds {
 		repo := resources.Repos[build.GetRepo().GetID()-1]
+
 		got, err = db.GetBuildForRepo(context.TODO(), repo, build.GetNumber())
 		if err != nil {
 			t.Errorf("unable to get build %d for repo %d: %v", build.GetID(), repo.GetID(), err)
 		}
+
 		if diff := cmp.Diff(build, got); diff != "" {
 			t.Errorf("GetBuildForRepo() mismatch (-want +got):\n%s", diff)
 		}
 	}
+
 	methods["GetBuildForRepo"] = true
 
 	// clean the builds
@@ -372,9 +401,11 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to clean builds: %v", err)
 	}
+
 	if int(count) != len(resources.Builds) {
 		t.Errorf("CleanBuilds() is %v, want %v", count, len(resources.Builds))
 	}
+
 	methods["CleanBuilds"] = true
 
 	// update the builds
@@ -382,6 +413,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 		prevStatus := build.GetStatus()
 
 		build.SetStatus("pending approval")
+
 		_, err = db.UpdateBuild(context.TODO(), build)
 		if err != nil {
 			t.Errorf("unable to update build %d: %v", build.GetID(), err)
@@ -392,6 +424,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 		if err != nil {
 			t.Errorf("unable to get build %d by ID: %v", build.GetID(), err)
 		}
+
 		if diff := cmp.Diff(build, got); diff != "" {
 			t.Errorf("GetBuild() mismatch (-want +got):\n%s", diff)
 		}
@@ -409,6 +442,7 @@ func testBuilds(t *testing.T, db Interface, resources *Resources) {
 
 		build.SetStatus(prevStatus)
 	}
+
 	methods["UpdateBuild"] = true
 	methods["GetBuild"] = true
 	methods["ListPendingApprovalBuilds"] = true
@@ -474,6 +508,7 @@ func testDashboards(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to create dashboard %s: %v", dashboard.GetID(), err)
 		}
 	}
+
 	methods["CreateDashboard"] = true
 
 	// lookup the dashboards by ID
@@ -488,17 +523,20 @@ func testDashboards(t *testing.T, db Interface, resources *Resources) {
 		for _, admin := range got.GetAdmins() {
 			cmpAdmins = append(cmpAdmins, admin.Crop())
 		}
+
 		got.SetAdmins(cmpAdmins)
 
 		if !cmp.Equal(got, dashboard, CmpOptApproxUpdatedAt()) {
 			t.Errorf("GetDashboard() is %v, want %v", got, dashboard)
 		}
 	}
+
 	methods["GetDashboard"] = true
 
 	// update the dashboards
 	for _, dashboard := range resources.Dashboards {
 		dashboard.SetUpdatedAt(time.Now().UTC().Unix())
+
 		got, err := db.UpdateDashboard(ctx, dashboard)
 		if err != nil {
 			t.Errorf("unable to update dashboard %s: %v", dashboard.GetID(), err)
@@ -514,6 +552,7 @@ func testDashboards(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("UpdateDashboard() mismatch (-want +got):\n%s", diff)
 		}
 	}
+
 	methods["UpdateDashboard"] = true
 
 	// delete the schedules
@@ -523,6 +562,7 @@ func testDashboards(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to delete dashboard %s: %v", dashboard.GetID(), err)
 		}
 	}
+
 	methods["DeleteDashboard"] = true
 
 	// ensure we called all the methods we expected to
@@ -558,6 +598,7 @@ func testExecutables(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to create executable %d: %v", executable.GetID(), err)
 		}
 	}
+
 	methods["CreateBuildExecutable"] = true
 
 	// pop executables for builds
@@ -566,10 +607,12 @@ func testExecutables(t *testing.T, db Interface, resources *Resources) {
 		if err != nil {
 			t.Errorf("unable to get executable %d for build %d: %v", executable.GetID(), executable.GetBuildID(), err)
 		}
+
 		if diff := cmp.Diff(executable, got); diff != "" {
 			t.Errorf("PopBuildExecutable() mismatch (-want +got):\n%s", diff)
 		}
 	}
+
 	methods["PopBuildExecutable"] = true
 
 	prevBuildStatus := resources.Builds[0].GetStatus()
@@ -668,6 +711,7 @@ func testDeployments(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to create deployment %d: %v", deployment.GetID(), err)
 		}
 	}
+
 	methods["CreateDeployment"] = true
 
 	// count the deployments
@@ -675,9 +719,11 @@ func testDeployments(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count deployment: %v", err)
 	}
+
 	if int(count) != len(resources.Deployments) {
 		t.Errorf("CountDeployments() is %v, want %v", count, len(resources.Deployments))
 	}
+
 	methods["CountDeployments"] = true
 
 	// count the deployments for a repo
@@ -685,9 +731,11 @@ func testDeployments(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count deployments for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
+
 	if int(count) != len(resources.Builds) {
 		t.Errorf("CountDeploymentsForRepo() is %v, want %v", count, len(resources.Builds))
 	}
+
 	methods["CountDeploymentsForRepo"] = true
 
 	// list the deployments
@@ -695,9 +743,11 @@ func testDeployments(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list deployments: %v", err)
 	}
+
 	if diff := cmp.Diff(resources.Deployments, list); diff != "" {
 		t.Errorf("ListDeployments() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["ListDeployments"] = true
 
 	// list the deployments for a repo
@@ -705,25 +755,31 @@ func testDeployments(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list deployments for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
+
 	if int(count) != len(resources.Deployments) {
 		t.Errorf("ListDeploymentsForRepo() is %v, want %v", count, len(resources.Deployments))
 	}
+
 	if diff := cmp.Diff([]*api.Deployment{resources.Deployments[1], resources.Deployments[0]}, list); diff != "" {
 		t.Errorf("ListDeploymentsForRepo() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["ListDeploymentsForRepo"] = true
 
 	// lookup the deployments by name
 	for _, deployment := range resources.Deployments {
 		repo := resources.Repos[deployment.GetRepo().GetID()-1]
+
 		got, err := db.GetDeploymentForRepo(context.TODO(), repo, deployment.GetNumber())
 		if err != nil {
 			t.Errorf("unable to get deployment %d for repo %d: %v", deployment.GetID(), repo.GetID(), err)
 		}
+
 		if diff := cmp.Diff(deployment, got); diff != "" {
 			t.Errorf("GetDeploymentForRepo() mismatch (-want +got):\n%s", diff)
 		}
 	}
+
 	methods["GetDeploymentForRepo"] = true
 
 	// update the deployments
@@ -738,10 +794,12 @@ func testDeployments(t *testing.T, db Interface, resources *Resources) {
 		if err != nil {
 			t.Errorf("unable to get deployment %d by ID: %v", deployment.GetID(), err)
 		}
+
 		if diff := cmp.Diff(deployment, got); diff != "" {
 			t.Errorf("GetDeployment() mismatch (-want +got):\n%s", diff)
 		}
 	}
+
 	methods["UpdateDeployment"] = true
 	methods["GetDeployment"] = true
 
@@ -752,6 +810,7 @@ func testDeployments(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to delete hook %d: %v", deployment.GetID(), err)
 		}
 	}
+
 	methods["DeleteDeployment"] = true
 
 	// delete the builds
@@ -835,6 +894,7 @@ func testHooks(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to create hook %d: %v", hook.GetID(), err)
 		}
 	}
+
 	methods["CreateHook"] = true
 
 	// count the hooks
@@ -842,9 +902,11 @@ func testHooks(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count hooks: %v", err)
 	}
+
 	if int(count) != len(resources.Hooks) {
 		t.Errorf("CountHooks() is %v, want %v", count, len(resources.Hooks))
 	}
+
 	methods["CountHooks"] = true
 
 	// count the hooks for a repo
@@ -852,9 +914,11 @@ func testHooks(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count hooks for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
+
 	if int(count) != len(resources.Builds) {
 		t.Errorf("CountHooksForRepo() is %v, want %v", count, len(resources.Builds))
 	}
+
 	methods["CountHooksForRepo"] = true
 
 	// list the hooks
@@ -862,9 +926,11 @@ func testHooks(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list hooks: %v", err)
 	}
+
 	if diff := cmp.Diff(resources.Hooks, list); diff != "" {
 		t.Errorf("ListHooks() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["ListHooks"] = true
 
 	// list the hooks for a repo
@@ -872,9 +938,11 @@ func testHooks(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list hooks for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
+
 	if diff := cmp.Diff([]*api.Hook{resources.Hooks[2], resources.Hooks[0]}, list); diff != "" {
 		t.Errorf("ListHooksForRepo() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["ListHooksForRepo"] = true
 
 	// lookup the last build by repo
@@ -882,9 +950,11 @@ func testHooks(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to get last hook for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
+
 	if diff := cmp.Diff(resources.Hooks[2], got); diff != "" {
 		t.Errorf("LastHookForRepo() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["LastHookForRepo"] = true
 
 	// lookup a hook with matching webhook_id
@@ -892,9 +962,11 @@ func testHooks(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to get last hook for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
+
 	if diff := cmp.Diff(resources.Hooks[2], got); diff != "" {
 		t.Errorf("GetHookByWebhookID() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["GetHookByWebhookID"] = true
 
 	// lookup the hooks by name
@@ -903,15 +975,18 @@ func testHooks(t *testing.T, db Interface, resources *Resources) {
 		if err != nil {
 			t.Errorf("unable to get hook %d for repo %d: %v", hook.GetID(), hook.GetRepo().GetID(), err)
 		}
+
 		if diff := cmp.Diff(hook, got); diff != "" {
 			t.Errorf("GetHookForRepo() mismatch (-want +got):\n%s", diff)
 		}
 	}
+
 	methods["GetHookForRepo"] = true
 
 	// update the hooks
 	for _, hook := range resources.Hooks {
 		hook.SetStatus("success")
+
 		_, err = db.UpdateHook(context.TODO(), hook)
 		if err != nil {
 			t.Errorf("unable to update hook %d: %v", hook.GetID(), err)
@@ -922,10 +997,12 @@ func testHooks(t *testing.T, db Interface, resources *Resources) {
 		if err != nil {
 			t.Errorf("unable to get hook %d by ID: %v", hook.GetID(), err)
 		}
+
 		if diff := cmp.Diff(hook, got); diff != "" {
 			t.Errorf("GetHook() mismatch (-want +got):\n%s", diff)
 		}
 	}
+
 	methods["UpdateHook"] = true
 	methods["GetHook"] = true
 
@@ -936,6 +1013,7 @@ func testHooks(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to delete hook %d: %v", hook.GetID(), err)
 		}
 	}
+
 	methods["DeleteHook"] = true
 
 	// delete the builds
@@ -1002,6 +1080,7 @@ func testJWKs(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to create jwk %s: %v", kid, err)
 		}
 	}
+
 	methods["CreateJWK"] = true
 
 	list, err := db.ListJWKs(context.TODO())
@@ -1093,6 +1172,7 @@ func testLogs(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to create log %d: %v", log.GetID(), err)
 		}
 	}
+
 	methods["CreateLog"] = true
 
 	// count the logs
@@ -1100,9 +1180,11 @@ func testLogs(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count logs: %v", err)
 	}
+
 	if int(count) != len(resources.Logs) {
 		t.Errorf("CountLogs() is %v, want %v", count, len(resources.Logs))
 	}
+
 	methods["CountLogs"] = true
 
 	// count the logs for a build
@@ -1110,9 +1192,11 @@ func testLogs(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count logs for build %d: %v", resources.Builds[0].GetID(), err)
 	}
+
 	if int(count) != len(resources.Logs) {
 		t.Errorf("CountLogs() is %v, want %v", count, len(resources.Logs))
 	}
+
 	methods["CountLogsForBuild"] = true
 
 	// list the logs
@@ -1120,9 +1204,11 @@ func testLogs(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list logs: %v", err)
 	}
+
 	if diff := cmp.Diff(resources.Logs, list); diff != "" {
 		t.Errorf("ListLogs() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["ListLogs"] = true
 
 	// list the logs for a build
@@ -1130,40 +1216,49 @@ func testLogs(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list logs for build %d: %v", resources.Builds[0].GetID(), err)
 	}
+
 	if diff := cmp.Diff(resources.Logs, list); diff != "" {
 		t.Errorf("ListLogsForBuild() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["ListLogsForBuild"] = true
 
 	// lookup the logs by service
 	for _, log := range []*api.Log{resources.Logs[0], resources.Logs[1]} {
 		service := resources.Services[log.GetServiceID()-1]
+
 		got, err := db.GetLogForService(context.TODO(), service)
 		if err != nil {
 			t.Errorf("unable to get log %d for service %d: %v", log.GetID(), service.GetID(), err)
 		}
+
 		if !cmp.Equal(got, log) {
 			t.Errorf("GetLogForService() is %v, want %v", got, log)
 		}
 	}
+
 	methods["GetLogForService"] = true
 
 	// lookup the logs by service
 	for _, log := range []*api.Log{resources.Logs[2], resources.Logs[3]} {
 		step := resources.Steps[log.GetStepID()-1]
+
 		got, err := db.GetLogForStep(context.TODO(), step)
 		if err != nil {
 			t.Errorf("unable to get log %d for step %d: %v", log.GetID(), step.GetID(), err)
 		}
+
 		if !cmp.Equal(got, log) {
 			t.Errorf("GetLogForStep() is %v, want %v", got, log)
 		}
 	}
+
 	methods["GetLogForStep"] = true
 
 	// update the logs
 	for _, log := range resources.Logs {
 		log.SetData([]byte("bar"))
+
 		err = db.UpdateLog(context.TODO(), log)
 		if err != nil {
 			t.Errorf("unable to update log %d: %v", log.GetID(), err)
@@ -1174,10 +1269,12 @@ func testLogs(t *testing.T, db Interface, resources *Resources) {
 		if err != nil {
 			t.Errorf("unable to get log %d by ID: %v", log.GetID(), err)
 		}
+
 		if !cmp.Equal(got, log) {
 			t.Errorf("GetLog() is %v, want %v", got, log)
 		}
 	}
+
 	methods["UpdateLog"] = true
 	methods["GetLog"] = true
 
@@ -1188,6 +1285,7 @@ func testLogs(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to delete log %d: %v", log.GetID(), err)
 		}
 	}
+
 	methods["DeleteLog"] = true
 
 	// clean the logs
@@ -1195,6 +1293,7 @@ func testLogs(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to clean logs: %v", err)
 	}
+
 	methods["CleanLogs"] = true
 
 	// ensure we called all the methods we expected to
@@ -1246,6 +1345,7 @@ func testPipelines(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to create pipeline %d: %v", pipeline.GetID(), err)
 		}
 	}
+
 	methods["CreatePipeline"] = true
 
 	// count the pipelines
@@ -1253,9 +1353,11 @@ func testPipelines(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count pipelines: %v", err)
 	}
+
 	if int(count) != len(resources.Pipelines) {
 		t.Errorf("CountPipelines() is %v, want %v", count, len(resources.Pipelines))
 	}
+
 	methods["CountPipelines"] = true
 
 	// count the pipelines for a repo
@@ -1263,9 +1365,11 @@ func testPipelines(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count pipelines for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
+
 	if int(count) != len(resources.Pipelines) {
 		t.Errorf("CountPipelinesForRepo() is %v, want %v", count, len(resources.Pipelines))
 	}
+
 	methods["CountPipelinesForRepo"] = true
 
 	// list the pipelines
@@ -1273,9 +1377,11 @@ func testPipelines(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list pipelines: %v", err)
 	}
+
 	if diff := cmp.Diff(resources.Pipelines, list); diff != "" {
 		t.Errorf("ListPipelines() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["ListPipelines"] = true
 
 	// list the pipelines for a repo
@@ -1283,27 +1389,33 @@ func testPipelines(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list pipelines for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
+
 	if diff := cmp.Diff(resources.Pipelines, list); diff != "" {
 		t.Errorf("ListPipelines() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["ListPipelinesForRepo"] = true
 
 	// lookup the pipelines by name
 	for _, pipeline := range resources.Pipelines {
 		repo := resources.Repos[pipeline.GetRepo().GetID()-1]
+
 		got, err := db.GetPipelineForRepo(context.TODO(), pipeline.GetCommit(), repo)
 		if err != nil {
 			t.Errorf("unable to get pipeline %d for repo %d: %v", pipeline.GetID(), repo.GetID(), err)
 		}
+
 		if diff := cmp.Diff(pipeline, got); diff != "" {
 			t.Errorf("GetPipelineForRepo() mismatch (-want +got):\n%s", diff)
 		}
 	}
+
 	methods["GetPipelineForRepo"] = true
 
 	// update the pipelines
 	for _, pipeline := range resources.Pipelines {
 		pipeline.SetVersion("2")
+
 		_, err = db.UpdatePipeline(context.TODO(), pipeline)
 		if err != nil {
 			t.Errorf("unable to update pipeline %d: %v", pipeline.GetID(), err)
@@ -1314,10 +1426,12 @@ func testPipelines(t *testing.T, db Interface, resources *Resources) {
 		if err != nil {
 			t.Errorf("unable to get pipeline %d by ID: %v", pipeline.GetID(), err)
 		}
+
 		if diff := cmp.Diff(pipeline, got); diff != "" {
 			t.Errorf("GetPipeline() mismatch (-want +got):\n%s", diff)
 		}
 	}
+
 	methods["UpdatePipeline"] = true
 	methods["GetPipeline"] = true
 
@@ -1328,6 +1442,7 @@ func testPipelines(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to delete pipeline %d: %v", pipeline.GetID(), err)
 		}
 	}
+
 	methods["DeletePipeline"] = true
 
 	// delete the repos
@@ -1387,6 +1502,7 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to create repo %d: %v", repo.GetID(), err)
 		}
 	}
+
 	methods["CreateRepo"] = true
 
 	// count the repos
@@ -1394,9 +1510,11 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count repos: %v", err)
 	}
+
 	if int(count) != len(resources.Repos) {
 		t.Errorf("CountRepos() is %v, want %v", count, len(resources.Repos))
 	}
+
 	methods["CountRepos"] = true
 
 	// count the repos for an org
@@ -1404,9 +1522,11 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count repos for org %s: %v", resources.Repos[0].GetOrg(), err)
 	}
+
 	if int(count) != len(resources.Repos) {
 		t.Errorf("CountReposForOrg() is %v, want %v", count, len(resources.Repos))
 	}
+
 	methods["CountReposForOrg"] = true
 
 	// count the repos for a user
@@ -1414,9 +1534,11 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count repos for user %d: %v", resources.Users[0].GetID(), err)
 	}
+
 	if int(count) != len(resources.Repos) {
 		t.Errorf("CountReposForUser() is %v, want %v", count, len(resources.Repos))
 	}
+
 	methods["CountReposForUser"] = true
 
 	// list the repos
@@ -1424,18 +1546,22 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list repos: %v", err)
 	}
+
 	if diff := cmp.Diff(resources.Repos, list); diff != "" {
 		t.Errorf("ListRepos() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["ListRepos"] = true
 
 	list, err = db.GetReposInList(t.Context(), []string{"github/octocat", "github/octokitty"})
 	if err != nil {
 		t.Errorf("unable to get repos in list: %v", err)
 	}
+
 	if diff := cmp.Diff(resources.Repos, list, cmpopts.IgnoreFields(api.Repo{}, "Owner", "Hash")); diff != "" {
 		t.Errorf("GetReposInList() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["GetReposInList"] = true
 
 	// list the repos for an org
@@ -1443,9 +1569,11 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list repos for org %s: %v", resources.Repos[0].GetOrg(), err)
 	}
+
 	if diff := cmp.Diff(resources.Repos, list); diff != "" {
 		t.Errorf("ListReposForOrg() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["ListReposForOrg"] = true
 
 	// list the repos for a user
@@ -1453,9 +1581,11 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list repos for user %d: %v", resources.Users[0].GetID(), err)
 	}
+
 	if diff := cmp.Diff(resources.Repos, list); diff != "" {
 		t.Errorf("ListReposForUser() mismatch (-want +got):\n%s", diff)
 	}
+
 	methods["ListReposForUser"] = true
 
 	// lookup the repos by name
@@ -1464,15 +1594,18 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 		if err != nil {
 			t.Errorf("unable to get repo %d by org: %v", repo.GetID(), err)
 		}
+
 		if diff := cmp.Diff(repo, got); diff != "" {
 			t.Errorf("GetRepoForOrg() mismatch (-want +got):\n%s", diff)
 		}
 	}
+
 	methods["GetRepoForOrg"] = true
 
 	// update the repos
 	for _, repo := range resources.Repos {
 		repo.SetActive(false)
+
 		_, err = db.UpdateRepo(context.TODO(), repo)
 		if err != nil {
 			t.Errorf("unable to update repo %d: %v", repo.GetID(), err)
@@ -1483,10 +1616,12 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 		if err != nil {
 			t.Errorf("unable to get repo %d by ID: %v", repo.GetID(), err)
 		}
+
 		if !cmp.Equal(got, repo) {
 			t.Errorf("GetRepo() is %v, want %v", got, repo)
 		}
 	}
+
 	methods["UpdateRepo"] = true
 	methods["GetRepo"] = true
 
@@ -1497,6 +1632,7 @@ func testRepos(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to delete repo %d: %v", repo.GetID(), err)
 		}
 	}
+
 	methods["DeleteRepo"] = true
 
 	// delete the owners
@@ -1556,6 +1692,7 @@ func testSchedules(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to create schedule %d: %v", schedule.GetID(), err)
 		}
 	}
+
 	methods["CreateSchedule"] = true
 
 	// count the schedules
@@ -1563,9 +1700,11 @@ func testSchedules(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count schedules: %v", err)
 	}
+
 	if int(count) != len(resources.Schedules) {
 		t.Errorf("CountSchedules() is %v, want %v", count, len(resources.Schedules))
 	}
+
 	methods["CountSchedules"] = true
 
 	// count the schedules for a repo
@@ -1573,9 +1712,11 @@ func testSchedules(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count schedules for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
+
 	if int(count) != len(resources.Schedules) {
 		t.Errorf("CountSchedulesForRepo() is %v, want %v", count, len(resources.Schedules))
 	}
+
 	methods["CountSchedulesForRepo"] = true
 
 	// list the schedules
@@ -1583,9 +1724,11 @@ func testSchedules(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list schedules: %v", err)
 	}
+
 	if !cmp.Equal(list, resources.Schedules, CmpOptApproxUpdatedAt()) {
 		t.Errorf("ListSchedules() is %v, want %v", list, resources.Schedules)
 	}
+
 	methods["ListSchedules"] = true
 
 	// list the active schedules
@@ -1593,9 +1736,11 @@ func testSchedules(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list schedules: %v", err)
 	}
+
 	if !cmp.Equal(list, resources.Schedules, CmpOptApproxUpdatedAt()) {
 		t.Errorf("ListActiveSchedules() is %v, want %v", list, resources.Schedules)
 	}
+
 	methods["ListActiveSchedules"] = true
 
 	// list the schedules for a repo
@@ -1603,27 +1748,33 @@ func testSchedules(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count schedules for repo %d: %v", resources.Repos[0].GetID(), err)
 	}
+
 	if !cmp.Equal(list, []*api.Schedule{resources.Schedules[1], resources.Schedules[0]}, CmpOptApproxUpdatedAt()) {
 		t.Errorf("ListSchedulesForRepo() is %v, want %v", list, []*api.Schedule{resources.Schedules[1], resources.Schedules[0]})
 	}
+
 	methods["ListSchedulesForRepo"] = true
 
 	// lookup the schedules by name
 	for _, schedule := range resources.Schedules {
 		repo := resources.Repos[schedule.GetRepo().GetID()-1]
+
 		got, err := db.GetScheduleForRepo(context.TODO(), repo, schedule.GetName())
 		if err != nil {
 			t.Errorf("unable to get schedule %d for repo %d: %v", schedule.GetID(), repo.GetID(), err)
 		}
+
 		if !cmp.Equal(got, schedule, CmpOptApproxUpdatedAt()) {
 			t.Errorf("GetScheduleForRepo() is %v, want %v", got, schedule)
 		}
 	}
+
 	methods["GetScheduleForRepo"] = true
 
 	// update the schedules
 	for _, schedule := range resources.Schedules {
 		schedule.SetUpdatedAt(time.Now().UTC().Unix())
+
 		got, err := db.UpdateSchedule(context.TODO(), schedule, true)
 		if err != nil {
 			t.Errorf("unable to update schedule %d: %v", schedule.GetID(), err)
@@ -1633,6 +1784,7 @@ func testSchedules(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("GetSchedule() is %v, want %v", got, schedule)
 		}
 	}
+
 	methods["UpdateSchedule"] = true
 	methods["GetSchedule"] = true
 
@@ -1643,6 +1795,7 @@ func testSchedules(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to delete schedule %d: %v", schedule.GetID(), err)
 		}
 	}
+
 	methods["DeleteSchedule"] = true
 
 	// delete the repos
@@ -1694,6 +1847,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to create secret %d: %v", secret.GetID(), err)
 		}
 	}
+
 	methods["CreateSecret"] = true
 
 	// count the secrets
@@ -1701,9 +1855,11 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count secrets: %v", err)
 	}
+
 	if int(count) != len(resources.Secrets) {
 		t.Errorf("CountSecrets() is %v, want %v", count, len(resources.Secrets))
 	}
+
 	methods["CountSecrets"] = true
 
 	for _, secret := range resources.Secrets {
@@ -1714,9 +1870,11 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			if err != nil {
 				t.Errorf("unable to count secrets for org %s: %v", secret.GetOrg(), err)
 			}
+
 			if int(count) != 1 {
 				t.Errorf("CountSecretsForOrg() is %v, want %v", count, 1)
 			}
+
 			methods["CountSecretsForOrg"] = true
 		case constants.SecretRepo:
 			// count the secrets for a repo
@@ -1724,9 +1882,11 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			if err != nil {
 				t.Errorf("unable to count secrets for repo %d: %v", resources.Repos[0].GetID(), err)
 			}
+
 			if int(count) != 1 {
 				t.Errorf("CountSecretsForRepo() is %v, want %v", count, 1)
 			}
+
 			methods["CountSecretsForRepo"] = true
 		case constants.SecretShared:
 			// count the secrets for a team
@@ -1734,9 +1894,11 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			if err != nil {
 				t.Errorf("unable to count secrets for team %s: %v", secret.GetTeam(), err)
 			}
+
 			if int(count) != 1 {
 				t.Errorf("CountSecretsForTeam() is %v, want %v", count, 1)
 			}
+
 			methods["CountSecretsForTeam"] = true
 			methods["FillSecretAllowlist"] = true
 
@@ -1745,9 +1907,11 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			if err != nil {
 				t.Errorf("unable to count secrets for teams %s: %v", []string{secret.GetTeam()}, err)
 			}
+
 			if int(count) != 1 {
 				t.Errorf("CountSecretsForTeams() is %v, want %v", count, 1)
 			}
+
 			methods["CountSecretsForTeams"] = true
 		default:
 			t.Errorf("unsupported type %s for secret %d", secret.GetType(), secret.GetID())
@@ -1759,9 +1923,11 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list secrets: %v", err)
 	}
+
 	if !cmp.Equal(list, resources.Secrets, CmpOptApproxUpdatedAt()) {
 		t.Errorf("ListSecrets() is %v, want %v", list, resources.Secrets)
 	}
+
 	methods["ListSecrets"] = true
 
 	for _, secret := range resources.Secrets {
@@ -1772,9 +1938,11 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			if err != nil {
 				t.Errorf("unable to list secrets for org %s: %v", secret.GetOrg(), err)
 			}
+
 			if !cmp.Equal(list, []*api.Secret{secret}) {
 				t.Errorf("ListSecretsForOrg() is %v, want %v", list, []*api.Secret{secret})
 			}
+
 			methods["ListSecretsForOrg"] = true
 		case constants.SecretRepo:
 			// list the secrets for a repo
@@ -1782,9 +1950,11 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			if err != nil {
 				t.Errorf("unable to list secrets for repo %d: %v", resources.Repos[0].GetID(), err)
 			}
+
 			if !cmp.Equal(list, []*api.Secret{secret}, CmpOptApproxUpdatedAt()) {
 				t.Errorf("ListSecretsForRepo() is %v, want %v", list, []*api.Secret{secret})
 			}
+
 			methods["ListSecretsForRepo"] = true
 		case constants.SecretShared:
 			// list the secrets for a team
@@ -1792,9 +1962,11 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			if err != nil {
 				t.Errorf("unable to list secrets for team %s: %v", secret.GetTeam(), err)
 			}
+
 			if !cmp.Equal(list, []*api.Secret{secret}, CmpOptApproxUpdatedAt()) {
 				t.Errorf("ListSecretsForTeam() is %v, want %v", list, []*api.Secret{secret})
 			}
+
 			methods["ListSecretsForTeam"] = true
 			methods["FillSecretsAllowlists"] = true
 
@@ -1803,9 +1975,11 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			if err != nil {
 				t.Errorf("unable to list secrets for teams %s: %v", []string{secret.GetTeam()}, err)
 			}
+
 			if !cmp.Equal(list, []*api.Secret{secret}, CmpOptApproxUpdatedAt()) {
 				t.Errorf("ListSecretsForTeams() is %v, want %v", list, []*api.Secret{secret})
 			}
+
 			methods["ListSecretsForTeams"] = true
 		default:
 			t.Errorf("unsupported type %s for secret %d", secret.GetType(), secret.GetID())
@@ -1820,9 +1994,11 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			if err != nil {
 				t.Errorf("unable to get secret %d for org %s: %v", secret.GetID(), secret.GetOrg(), err)
 			}
+
 			if !cmp.Equal(got, secret, CmpOptApproxUpdatedAt()) {
 				t.Errorf("GetSecretForOrg() is %v, want %v", got, secret)
 			}
+
 			methods["GetSecretForOrg"] = true
 		case constants.SecretRepo:
 			// lookup the secret by repo
@@ -1830,9 +2006,11 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			if err != nil {
 				t.Errorf("unable to get secret %d for repo %d: %v", secret.GetID(), resources.Repos[0].GetID(), err)
 			}
+
 			if !cmp.Equal(got, secret, CmpOptApproxUpdatedAt()) {
 				t.Errorf("GetSecretForRepo() is %v, want %v", got, secret)
 			}
+
 			methods["GetSecretForRepo"] = true
 		case constants.SecretShared:
 			// lookup the secret by team
@@ -1840,9 +2018,11 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			if err != nil {
 				t.Errorf("unable to get secret %d for team %s: %v", secret.GetID(), secret.GetTeam(), err)
 			}
+
 			if !cmp.Equal(got, secret, CmpOptApproxUpdatedAt()) {
 				t.Errorf("GetSecretForTeam() is %v, want %v", got, secret)
 			}
+
 			methods["GetSecretForTeam"] = true
 		default:
 			t.Errorf("unsupported type %s for secret %d", secret.GetType(), secret.GetID())
@@ -1852,6 +2032,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 	// update the secrets
 	for _, secret := range resources.Secrets {
 		secret.SetUpdatedAt(time.Now().UTC().Unix())
+
 		got, err := db.UpdateSecret(context.TODO(), secret)
 		if err != nil {
 			t.Errorf("unable to update secret %d: %v", secret.GetID(), err)
@@ -1861,6 +2042,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("GetSecret() is %v, want %v", got, secret)
 		}
 	}
+
 	methods["UpdateSecret"] = true
 	methods["GetSecret"] = true
 
@@ -1877,6 +2059,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to get secret foo for repo: %v", err)
 	}
+
 	if renamedRepoSecret.GetOrg() != "github" && renamedRepoSecret.GetRepo() != "octokitty" {
 		t.Errorf("secret foo org/repo is %s/%s, want github/octokitty", renamedRepoSecret.GetOrg(), renamedRepoSecret.GetRepo())
 	}
@@ -1885,6 +2068,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to get secret foo for team %s: %v", "octocat", err)
 	}
+
 	if !reflect.DeepEqual(adjustedSharedSecret.GetRepoAllowlist(), []string{"github/octokitty"}) {
 		t.Errorf("secret foo repo allowlist is %v, want %v", adjustedSharedSecret.GetRepoAllowlist(), []string{"github/octokitty"})
 	}
@@ -1898,6 +2082,7 @@ func testSecrets(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to delete secret %d: %v", secret.GetID(), err)
 		}
 	}
+
 	methods["DeleteSecret"] = true
 
 	// ensure we called all the methods we expected to
@@ -1933,6 +2118,7 @@ func testServices(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to create service %d: %v", service.GetID(), err)
 		}
 	}
+
 	methods["CreateService"] = true
 
 	// count the services
@@ -1940,9 +2126,11 @@ func testServices(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count services: %v", err)
 	}
+
 	if int(count) != len(resources.Services) {
 		t.Errorf("CountServices() is %v, want %v", count, len(resources.Services))
 	}
+
 	methods["CountServices"] = true
 
 	// count the services for a build
@@ -1950,9 +2138,11 @@ func testServices(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count services for build %d: %v", resources.Builds[0].GetID(), err)
 	}
+
 	if int(count) != len(resources.Services) {
 		t.Errorf("CountServicesForBuild() is %v, want %v", count, len(resources.Services))
 	}
+
 	methods["CountServicesForBuild"] = true
 
 	// list the services
@@ -1960,9 +2150,11 @@ func testServices(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list services: %v", err)
 	}
+
 	if !cmp.Equal(list, resources.Services) {
 		t.Errorf("ListServices() is %v, want %v", list, resources.Services)
 	}
+
 	methods["ListServices"] = true
 
 	// list the services for a build
@@ -1970,22 +2162,27 @@ func testServices(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list services for build %d: %v", resources.Builds[0].GetID(), err)
 	}
+
 	if !cmp.Equal(list, []*api.Service{resources.Services[1], resources.Services[0]}) {
 		t.Errorf("ListServicesForBuild() is %v, want %v", list, []*api.Service{resources.Services[1], resources.Services[0]})
 	}
+
 	methods["ListServicesForBuild"] = true
 
 	expected := map[string]float64{
 		"#init":                        1,
 		"target/vela-git-slim:v0.12.0": 1,
 	}
+
 	images, err := db.ListServiceImageCount(context.TODO())
 	if err != nil {
 		t.Errorf("unable to list service image count: %v", err)
 	}
+
 	if !cmp.Equal(images, expected) {
 		t.Errorf("ListServiceImageCount() is %v, want %v", images, expected)
 	}
+
 	methods["ListServiceImageCount"] = true
 
 	expected = map[string]float64{
@@ -1995,26 +2192,32 @@ func testServices(t *testing.T, db Interface, resources *Resources) {
 		"running": 1,
 		"success": 0,
 	}
+
 	statuses, err := db.ListServiceStatusCount(context.TODO())
 	if err != nil {
 		t.Errorf("unable to list service status count: %v", err)
 	}
+
 	if !cmp.Equal(statuses, expected) {
 		t.Errorf("ListServiceStatusCount() is %v, want %v", statuses, expected)
 	}
+
 	methods["ListServiceStatusCount"] = true
 
 	// lookup the services by name
 	for _, service := range resources.Services {
 		build := resources.Builds[service.GetBuildID()-1]
+
 		got, err := db.GetServiceForBuild(context.TODO(), build, service.GetNumber())
 		if err != nil {
 			t.Errorf("unable to get service %d for build %d: %v", service.GetID(), build.GetID(), err)
 		}
+
 		if !cmp.Equal(got, service) {
 			t.Errorf("GetServiceForBuild() is %v, want %v", got, service)
 		}
 	}
+
 	methods["GetServiceForBuild"] = true
 
 	// clean the services
@@ -2022,14 +2225,17 @@ func testServices(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to clean services: %v", err)
 	}
+
 	if int(count) != len(resources.Services) {
 		t.Errorf("CleanServices() is %v, want %v", count, len(resources.Services))
 	}
+
 	methods["CleanServices"] = true
 
 	// update the services
 	for _, service := range resources.Services {
 		service.SetStatus("success")
+
 		got, err := db.UpdateService(context.TODO(), service)
 		if err != nil {
 			t.Errorf("unable to update service %d: %v", service.GetID(), err)
@@ -2039,6 +2245,7 @@ func testServices(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("UpdateService() is %v, want %v", got, service)
 		}
 	}
+
 	methods["UpdateService"] = true
 	methods["GetService"] = true
 
@@ -2049,6 +2256,7 @@ func testServices(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to delete service %d: %v", service.GetID(), err)
 		}
 	}
+
 	methods["DeleteService"] = true
 
 	// ensure we called all the methods we expected to
@@ -2076,6 +2284,7 @@ func testSteps(t *testing.T, db Interface, resources *Resources) {
 		// add the method name to the list of functions
 		methods[element.Method(i).Name] = false
 	}
+
 	ctx := context.TODO()
 
 	// create the steps
@@ -2085,6 +2294,7 @@ func testSteps(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to create step %d: %v", step.GetID(), err)
 		}
 	}
+
 	methods["CreateStep"] = true
 
 	// count the steps
@@ -2092,9 +2302,11 @@ func testSteps(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count steps: %v", err)
 	}
+
 	if int(count) != len(resources.Steps) {
 		t.Errorf("CountSteps() is %v, want %v", count, len(resources.Steps))
 	}
+
 	methods["CountSteps"] = true
 
 	// count the steps for a build
@@ -2102,9 +2314,11 @@ func testSteps(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count steps for build %d: %v", resources.Builds[0].GetID(), err)
 	}
+
 	if int(count) != len(resources.Steps) {
 		t.Errorf("CountStepsForBuild() is %v, want %v", count, len(resources.Steps))
 	}
+
 	methods["CountStepsForBuild"] = true
 
 	// list the steps
@@ -2112,9 +2326,11 @@ func testSteps(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list steps: %v", err)
 	}
+
 	if !cmp.Equal(list, resources.Steps) {
 		t.Errorf("ListSteps() is %v, want %v", list, resources.Steps)
 	}
+
 	methods["ListSteps"] = true
 
 	// list the steps for a build
@@ -2122,22 +2338,27 @@ func testSteps(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list steps for build %d: %v", resources.Builds[0].GetID(), err)
 	}
+
 	if !cmp.Equal(list, []*api.Step{resources.Steps[1], resources.Steps[0]}) {
 		t.Errorf("ListStepsForBuild() is %v, want %v", list, []*api.Step{resources.Steps[1], resources.Steps[0]})
 	}
+
 	methods["ListStepsForBuild"] = true
 
 	expected := map[string]float64{
 		"#init":                        1,
 		"target/vela-git-slim:v0.12.0": 1,
 	}
+
 	images, err := db.ListStepImageCount(ctx)
 	if err != nil {
 		t.Errorf("unable to list step image count: %v", err)
 	}
+
 	if !cmp.Equal(images, expected) {
 		t.Errorf("ListStepImageCount() is %v, want %v", images, expected)
 	}
+
 	methods["ListStepImageCount"] = true
 
 	expected = map[string]float64{
@@ -2147,26 +2368,32 @@ func testSteps(t *testing.T, db Interface, resources *Resources) {
 		"running": 1,
 		"success": 0,
 	}
+
 	statuses, err := db.ListStepStatusCount(ctx)
 	if err != nil {
 		t.Errorf("unable to list step status count: %v", err)
 	}
+
 	if !cmp.Equal(statuses, expected) {
 		t.Errorf("ListStepStatusCount() is %v, want %v", statuses, expected)
 	}
+
 	methods["ListStepStatusCount"] = true
 
 	// lookup the steps by name
 	for _, step := range resources.Steps {
 		build := resources.Builds[step.GetBuildID()-1]
+
 		got, err := db.GetStepForBuild(ctx, build, step.GetNumber())
 		if err != nil {
 			t.Errorf("unable to get step %d for build %d: %v", step.GetID(), build.GetID(), err)
 		}
+
 		if !cmp.Equal(got, step) {
 			t.Errorf("GetStepForBuild() is %v, want %v", got, step)
 		}
 	}
+
 	methods["GetStepForBuild"] = true
 
 	// clean the steps
@@ -2174,14 +2401,17 @@ func testSteps(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to clean steps: %v", err)
 	}
+
 	if int(count) != len(resources.Steps) {
 		t.Errorf("CleanSteps() is %v, want %v", count, len(resources.Steps))
 	}
+
 	methods["CleanSteps"] = true
 
 	// update the steps
 	for _, step := range resources.Steps {
 		step.SetStatus("success")
+
 		got, err := db.UpdateStep(ctx, step)
 		if err != nil {
 			t.Errorf("unable to update step %d: %v", step.GetID(), err)
@@ -2191,6 +2421,7 @@ func testSteps(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("GetStep() is %v, want %v", got, step)
 		}
 	}
+
 	methods["UpdateStep"] = true
 	methods["GetStep"] = true
 
@@ -2201,6 +2432,7 @@ func testSteps(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to delete step %d: %v", step.GetID(), err)
 		}
 	}
+
 	methods["DeleteStep"] = true
 
 	// ensure we called all the methods we expected to
@@ -2258,6 +2490,7 @@ func testUsers(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to create user %d: %v", user.GetID(), err)
 		}
 	}
+
 	methods["CreateUser"] = true
 
 	// count the users
@@ -2265,9 +2498,11 @@ func testUsers(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count users: %v", err)
 	}
+
 	if int(count) != len(resources.Users) {
 		t.Errorf("CountUsers() is %v, want %v", count, len(resources.Users))
 	}
+
 	methods["CountUsers"] = true
 
 	// list the users
@@ -2275,9 +2510,11 @@ func testUsers(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list users: %v", err)
 	}
+
 	if !cmp.Equal(list, resources.Users) {
 		t.Errorf("ListUsers() is %v, want %v", list, resources.Users)
 	}
+
 	methods["ListUsers"] = true
 
 	// lite list the users
@@ -2285,9 +2522,11 @@ func testUsers(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list lite users: %v", err)
 	}
+
 	if !cmp.Equal(list, liteUsers) {
 		t.Errorf("ListLiteUsers() is %v, want %v", list, liteUsers)
 	}
+
 	methods["ListLiteUsers"] = true
 
 	// lookup the users by name
@@ -2296,15 +2535,18 @@ func testUsers(t *testing.T, db Interface, resources *Resources) {
 		if err != nil {
 			t.Errorf("unable to get user %d by name: %v", user.GetID(), err)
 		}
+
 		if !cmp.Equal(got, user) {
 			t.Errorf("GetUserForName() is %v, want %v", got, user)
 		}
 	}
+
 	methods["GetUserForName"] = true
 
 	// update the users
 	for _, user := range resources.Users {
 		user.SetActive(false)
+
 		got, err := db.UpdateUser(context.TODO(), user)
 		if err != nil {
 			t.Errorf("unable to update user %d: %v", user.GetID(), err)
@@ -2314,6 +2556,7 @@ func testUsers(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("GetUser() is %v, want %v", got, user)
 		}
 	}
+
 	methods["UpdateUser"] = true
 	methods["GetUser"] = true
 
@@ -2324,6 +2567,7 @@ func testUsers(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to delete user %d: %v", user.GetID(), err)
 		}
 	}
+
 	methods["DeleteUser"] = true
 
 	// ensure we called all the methods we expected to
@@ -2359,6 +2603,7 @@ func testWorkers(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to create worker %d: %v", worker.GetID(), err)
 		}
 	}
+
 	methods["CreateWorker"] = true
 
 	// count the workers
@@ -2366,9 +2611,11 @@ func testWorkers(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to count workers: %v", err)
 	}
+
 	if int(count) != len(resources.Workers) {
 		t.Errorf("CountWorkers() is %v, want %v", count, len(resources.Workers))
 	}
+
 	methods["CountWorkers"] = true
 
 	// list the workers
@@ -2376,9 +2623,11 @@ func testWorkers(t *testing.T, db Interface, resources *Resources) {
 	if err != nil {
 		t.Errorf("unable to list workers: %v", err)
 	}
+
 	if !cmp.Equal(list, resources.Workers) {
 		t.Errorf("ListWorkers() is %v, want %v", list, resources.Workers)
 	}
+
 	methods["ListWorkers"] = true
 
 	// lookup the workers by hostname
@@ -2387,15 +2636,18 @@ func testWorkers(t *testing.T, db Interface, resources *Resources) {
 		if err != nil {
 			t.Errorf("unable to get worker %d by hostname: %v", worker.GetID(), err)
 		}
+
 		if !cmp.Equal(got, worker) {
 			t.Errorf("GetWorkerForHostname() is %v, want %v", got, worker)
 		}
 	}
+
 	methods["GetWorkerForHostname"] = true
 
 	// update the workers
 	for _, worker := range resources.Workers {
 		worker.SetActive(false)
+
 		got, err := db.UpdateWorker(context.TODO(), worker)
 		if err != nil {
 			t.Errorf("unable to update worker %d: %v", worker.GetID(), err)
@@ -2405,6 +2657,7 @@ func testWorkers(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("GetWorker() is %v, want %v", got, worker)
 		}
 	}
+
 	methods["UpdateWorker"] = true
 	methods["GetWorker"] = true
 
@@ -2415,6 +2668,7 @@ func testWorkers(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to delete worker %d: %v", worker.GetID(), err)
 		}
 	}
+
 	methods["DeleteWorker"] = true
 
 	// ensure we called all the methods we expected to
@@ -2450,12 +2704,14 @@ func testSettings(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("unable to create settings %d: %v", s.GetID(), err)
 		}
 	}
+
 	methods["CreateSettings"] = true
 
 	// update the settings
 	for _, s := range resources.Platform {
 		s.SetCloneImage("target/vela-git-slim:abc123")
 		s.SetRepoRoleMap(map[string]string{"foo": "bar"})
+
 		got, err := db.UpdateSettings(context.TODO(), s)
 		if err != nil {
 			t.Errorf("unable to update settings %d: %v", s.GetID(), err)
@@ -2465,6 +2721,7 @@ func testSettings(t *testing.T, db Interface, resources *Resources) {
 			t.Errorf("UpdateSettings() is %v, want %v", got, s)
 		}
 	}
+
 	methods["UpdateSettings"] = true
 	methods["GetSettings"] = true
 

--- a/database/jwk/create_test.go
+++ b/database/jwk/create_test.go
@@ -15,12 +15,14 @@ import (
 func TestJWK_Engine_CreateJWK(t *testing.T) {
 	// setup types
 	_jwk := testutils.JWK()
+
 	_jwkBytes, err := json.Marshal(_jwk)
 	if err != nil {
 		t.Errorf("unable to marshal JWK: %v", err)
 	}
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	kid, ok := _jwk.KeyID()
@@ -36,6 +38,7 @@ VALUES ($1,$2,$3)`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/jwk/get_test.go
+++ b/database/jwk/get_test.go
@@ -17,12 +17,14 @@ import (
 func TestJWK_Engine_GetJWK(t *testing.T) {
 	// setup types
 	_jwk := testutils.JWK()
+
 	_jwkBytes, err := json.Marshal(_jwk)
 	if err != nil {
 		t.Errorf("unable to marshal JWK: %v", err)
 	}
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	kid, ok := _jwk.KeyID()
@@ -39,6 +41,7 @@ func TestJWK_Engine_GetJWK(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "jwks" WHERE id = $1 AND active = $2 LIMIT $3`).WithArgs(kid, true, 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	err = _sqlite.CreateJWK(context.TODO(), _jwk)

--- a/database/jwk/interface.go
+++ b/database/jwk/interface.go
@@ -11,7 +11,7 @@ import (
 // JWKInterface represents the Vela interface for JWK
 // functions with the supported Database backends.
 //
-//nolint:revive // ignore name stutter
+
 type JWKInterface interface {
 	// JWK Data Definition Language Functions
 	//

--- a/database/jwk/list_test.go
+++ b/database/jwk/list_test.go
@@ -17,18 +17,21 @@ import (
 func TestJWK_Engine_ListJWKs(t *testing.T) {
 	// setup types
 	_jwkOne := testutils.JWK()
+
 	_jwkOneBytes, err := json.Marshal(_jwkOne)
 	if err != nil {
 		t.Errorf("unable to marshal JWK: %v", err)
 	}
 
 	_jwkTwo := testutils.JWK()
+
 	_jwkTwoBytes, err := json.Marshal(_jwkTwo)
 	if err != nil {
 		t.Errorf("unable to marshal JWK: %v", err)
 	}
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	kidOne, ok := _jwkOne.KeyID()
@@ -51,6 +54,7 @@ func TestJWK_Engine_ListJWKs(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "jwks"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	err = _sqlite.CreateJWK(context.TODO(), _jwkOne)

--- a/database/jwk/rotate_test.go
+++ b/database/jwk/rotate_test.go
@@ -15,18 +15,21 @@ import (
 func TestJWK_Engine_RotateKeys(t *testing.T) {
 	// setup types
 	_jwkOne := testutils.JWK()
+
 	_jwkOneBytes, err := json.Marshal(_jwkOne)
 	if err != nil {
 		t.Errorf("unable to marshal JWK: %v", err)
 	}
 
 	_jwkTwo := testutils.JWK()
+
 	_jwkTwoBytes, err := json.Marshal(_jwkTwo)
 	if err != nil {
 		t.Errorf("unable to marshal JWK: %v", err)
 	}
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	kidOne, ok := _jwkOne.KeyID()
@@ -64,6 +67,7 @@ func TestJWK_Engine_RotateKeys(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	err = _sqlite.CreateJWK(context.TODO(), _jwkOne)

--- a/database/jwk/table_test.go
+++ b/database/jwk/table_test.go
@@ -12,11 +12,13 @@ import (
 func TestJWK_Engine_CreateJWKTable(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreatePostgresTable).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/log/clean.go
+++ b/database/log/clean.go
@@ -163,10 +163,10 @@ func (e *Engine) acquireCleanupLock(ctx context.Context, driver string) (bool, e
 	case constants.DriverPostgres:
 		// PostgreSQL advisory lock - non-blocking attempt
 		var acquired bool
+
 		err := e.client.WithContext(ctx).
 			Raw("SELECT pg_try_advisory_lock(?)", lockID).
 			Scan(&acquired).Error
-
 		if err != nil {
 			return false, fmt.Errorf("failed to acquire PostgreSQL advisory lock: %w", err)
 		}
@@ -214,10 +214,10 @@ func (e *Engine) releaseCleanupLock(ctx context.Context, driver string) error {
 	case constants.DriverPostgres:
 		// PostgreSQL advisory lock release
 		var released bool
+
 		err := e.client.WithContext(ctx).
 			Raw("SELECT pg_advisory_unlock(?)", lockID).
 			Scan(&released).Error
-
 		if err != nil {
 			return fmt.Errorf("failed to release PostgreSQL advisory lock: %w", err)
 		}

--- a/database/log/clean_test.go
+++ b/database/log/clean_test.go
@@ -20,6 +20,7 @@ func TestLog_Engine_CleanLogs(t *testing.T) {
 
 	// setup the test database client
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// mock PostgreSQL advisory lock acquisition and release
@@ -48,6 +49,7 @@ func TestLog_Engine_CleanLogs(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"pg_advisory_unlock"}).AddRow(true))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// create test logs in sqlite for integration testing
@@ -59,6 +61,7 @@ func TestLog_Engine_CleanLogs(t *testing.T) {
 		_log.SetStepID(int64(i))
 		_log.SetData([]byte("test log data"))
 		_log.SetCreatedAt(cutoffTime - int64(i*3600)) // logs older than cutoff
+
 		err := _sqlite.CreateLog(context.TODO(), _log)
 		if err != nil {
 			t.Errorf("unable to create test log for sqlite: %v", err)
@@ -107,6 +110,7 @@ func TestLog_Engine_CleanLogs(t *testing.T) {
 				if err == nil {
 					t.Errorf("CleanLogs for %s should have returned err", test.name)
 				}
+
 				return
 			}
 
@@ -134,6 +138,7 @@ func TestLog_Engine_CleanLogs(t *testing.T) {
 func TestLog_Engine_CleanLogs_EmptyDatabase(t *testing.T) {
 	// setup the test database client
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	cutoffTime := time.Now().Add(-48 * time.Hour).Unix()
@@ -154,7 +159,6 @@ func TestLog_Engine_CleanLogs_EmptyDatabase(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"pg_advisory_unlock"}).AddRow(true))
 
 	deleted, err := _postgres.CleanLogs(context.TODO(), cutoffTime, 1000, false, constants.DriverPostgres)
-
 	if err != nil {
 		t.Errorf("CleanLogs should not have returned err: %v", err)
 	}
@@ -176,6 +180,7 @@ func TestLog_Engine_CleanLogs_EmptyDatabase(t *testing.T) {
 func TestLog_Engine_CleanLogs_ContextCancellation(t *testing.T) {
 	// setup the test database client
 	_postgres, _ := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	cutoffTime := time.Now().Add(-48 * time.Hour).Unix()
@@ -186,7 +191,6 @@ func TestLog_Engine_CleanLogs_ContextCancellation(t *testing.T) {
 
 	// the function should return early due to context cancellation
 	result, err := _postgres.CleanLogs(ctx, cutoffTime, 1000, false, constants.DriverPostgres)
-
 	if err == nil {
 		t.Errorf("CleanLogs should have returned context cancellation error")
 	}

--- a/database/log/count_build_test.go
+++ b/database/log/count_build_test.go
@@ -38,6 +38,7 @@ func TestLog_Engine_CountLogsForBuild(t *testing.T) {
 	_build.SetNumber(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -47,6 +48,7 @@ func TestLog_Engine_CountLogsForBuild(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "logs" WHERE build_id = $1`).WithArgs(1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	err := _sqlite.CreateLog(context.TODO(), _service)

--- a/database/log/count_test.go
+++ b/database/log/count_test.go
@@ -29,6 +29,7 @@ func TestLog_Engine_CountLogs(t *testing.T) {
 	_step.SetCreatedAt(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -38,6 +39,7 @@ func TestLog_Engine_CountLogs(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "logs"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	err := _sqlite.CreateLog(context.TODO(), _service)

--- a/database/log/create_test.go
+++ b/database/log/create_test.go
@@ -29,6 +29,7 @@ func TestLog_Engine_CreateLog(t *testing.T) {
 	_step.SetCreatedAt(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -49,6 +50,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING "id"`).
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/log/delete_test.go
+++ b/database/log/delete_test.go
@@ -21,6 +21,7 @@ func TestLog_Engine_DeleteLog(t *testing.T) {
 	_log.SetCreatedAt(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -29,6 +30,7 @@ func TestLog_Engine_DeleteLog(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	err := _sqlite.CreateLog(context.TODO(), _log)

--- a/database/log/get_service_test.go
+++ b/database/log/get_service_test.go
@@ -30,6 +30,7 @@ func TestLog_Engine_GetLogForService(t *testing.T) {
 	_service.SetNumber(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -39,6 +40,7 @@ func TestLog_Engine_GetLogForService(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "logs" WHERE service_id = $1 LIMIT $2`).WithArgs(1, 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	err := _sqlite.CreateLog(context.TODO(), _log)

--- a/database/log/get_step_test.go
+++ b/database/log/get_step_test.go
@@ -30,6 +30,7 @@ func TestLog_Engine_GetLogForStep(t *testing.T) {
 	_step.SetNumber(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -39,6 +40,7 @@ func TestLog_Engine_GetLogForStep(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "logs" WHERE step_id = $1 LIMIT $2`).WithArgs(1, 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	err := _sqlite.CreateLog(context.TODO(), _log)

--- a/database/log/get_test.go
+++ b/database/log/get_test.go
@@ -23,6 +23,7 @@ func TestLog_Engine_GetLog(t *testing.T) {
 	_log.SetCreatedAt(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -32,6 +33,7 @@ func TestLog_Engine_GetLog(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "logs" WHERE id = $1 LIMIT $2`).WithArgs(1, 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	err := _sqlite.CreateLog(context.TODO(), _log)

--- a/database/log/index_test.go
+++ b/database/log/index_test.go
@@ -11,6 +11,7 @@ import (
 func TestLog_Engine_CreateLogIndexes(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreateBuildIDIndex).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -19,6 +20,7 @@ func TestLog_Engine_CreateLogIndexes(t *testing.T) {
 	_mock.ExpectExec(CreateStepIDIndex).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/log/interface.go
+++ b/database/log/interface.go
@@ -11,7 +11,7 @@ import (
 // LogInterface represents the Vela interface for log
 // functions with the supported Database backends.
 //
-//nolint:revive // ignore name stutter
+
 type LogInterface interface {
 	// Log Data Definition Language Functions
 	//

--- a/database/log/list_build_test.go
+++ b/database/log/list_build_test.go
@@ -40,6 +40,7 @@ func TestLog_Engine_ListLogsForBuild(t *testing.T) {
 	_build.SetNumber(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -49,6 +50,7 @@ func TestLog_Engine_ListLogsForBuild(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "logs" WHERE build_id = $1 ORDER BY service_id ASC NULLS LAST,step_id ASC LIMIT $2`).WithArgs(1, 10).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	err := _sqlite.CreateLog(context.TODO(), _service)

--- a/database/log/list_test.go
+++ b/database/log/list_test.go
@@ -31,6 +31,7 @@ func TestLog_Engine_ListLogs(t *testing.T) {
 	_step.SetCreatedAt(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -40,6 +41,7 @@ func TestLog_Engine_ListLogs(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "logs"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	err := _sqlite.CreateLog(context.TODO(), _service)

--- a/database/log/table_test.go
+++ b/database/log/table_test.go
@@ -12,11 +12,13 @@ import (
 func TestLog_Engine_CreateLogTable(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreatePostgresTable).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/log/update_test.go
+++ b/database/log/update_test.go
@@ -31,6 +31,7 @@ func TestLog_Engine_UpdateLog(t *testing.T) {
 	_step.SetCreatedAt(1)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the service query
@@ -48,6 +49,7 @@ WHERE "id" = $7`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	err := _sqlite.CreateLog(context.TODO(), _service)

--- a/database/logger_test.go
+++ b/database/logger_test.go
@@ -20,6 +20,7 @@ func TestNewGormLogger(t *testing.T) {
 		skipNotFound  bool
 		showSQL       bool
 	}
+
 	tests := []struct {
 		name string
 		args args

--- a/database/pipeline/count_repo_test.go
+++ b/database/pipeline/count_repo_test.go
@@ -34,6 +34,7 @@ func TestPipeline_Engine_CountPipelinesForRepo(t *testing.T) {
 	_pipelineTwo.SetVersion("1")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -43,6 +44,7 @@ func TestPipeline_Engine_CountPipelinesForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "pipelines" WHERE repo_id = $1`).WithArgs(1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreatePipeline(context.TODO(), _pipelineOne)

--- a/database/pipeline/count_test.go
+++ b/database/pipeline/count_test.go
@@ -34,6 +34,7 @@ func TestPipeline_Engine_CountPipelines(t *testing.T) {
 	_pipelineTwo.SetVersion("1")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -43,6 +44,7 @@ func TestPipeline_Engine_CountPipelines(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "pipelines"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreatePipeline(context.TODO(), _pipelineOne)

--- a/database/pipeline/create_test.go
+++ b/database/pipeline/create_test.go
@@ -27,6 +27,7 @@ func TestPipeline_Engine_CreatePipeline(t *testing.T) {
 	_pipeline.SetData([]byte{})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -40,6 +41,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16) RETURNING "id"`)
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/pipeline/delete_test.go
+++ b/database/pipeline/delete_test.go
@@ -25,6 +25,7 @@ func TestPipeline_Engine_DeletePipeline(t *testing.T) {
 	_pipeline.SetVersion("1")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -33,6 +34,7 @@ func TestPipeline_Engine_DeletePipeline(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreatePipeline(context.TODO(), _pipeline)

--- a/database/pipeline/get_repo_test.go
+++ b/database/pipeline/get_repo_test.go
@@ -42,6 +42,7 @@ func TestPipeline_Engine_GetPipelineForRepo(t *testing.T) {
 	_pipeline.SetData([]byte("foo"))
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -58,6 +59,7 @@ func TestPipeline_Engine_GetPipelineForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "pipelines" WHERE repo_id = $1 AND "commit" = $2 LIMIT $3`).WithArgs(1, "48afb5bdc41ad69bf22588491333f7cf71135163", 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	sqlitePopulateTables(

--- a/database/pipeline/get_test.go
+++ b/database/pipeline/get_test.go
@@ -42,6 +42,7 @@ func TestPipeline_Engine_GetPipeline(t *testing.T) {
 	_pipeline.SetData([]byte("foo"))
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -64,6 +65,7 @@ func TestPipeline_Engine_GetPipeline(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE "users"."id" = $1`).WithArgs(1).WillReturnRows(_userRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	sqlitePopulateTables(

--- a/database/pipeline/index_test.go
+++ b/database/pipeline/index_test.go
@@ -12,11 +12,13 @@ import (
 func TestPipeline_Engine_CreatePipelineIndexes(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreateRepoIDIndex).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/pipeline/interface.go
+++ b/database/pipeline/interface.go
@@ -11,7 +11,7 @@ import (
 // PipelineInterface represents the Vela interface for pipeline
 // functions with the supported Database backends.
 //
-//nolint:revive // ignore name stutter
+
 type PipelineInterface interface {
 	// Pipeline Data Definition Language Functions
 	//

--- a/database/pipeline/list_repo_test.go
+++ b/database/pipeline/list_repo_test.go
@@ -51,6 +51,7 @@ func TestPipeline_Engine_ListPipelinesForRepo(t *testing.T) {
 	_pipelineTwo.SetData([]byte("foo"))
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	dbPipelineOne := types.PipelineFromAPI(_pipelineOne)
@@ -73,6 +74,7 @@ func TestPipeline_Engine_ListPipelinesForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "pipelines" WHERE repo_id = $1 LIMIT $2`).WithArgs(1, 10).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	sqlitePopulateTables(

--- a/database/pipeline/list_test.go
+++ b/database/pipeline/list_test.go
@@ -64,6 +64,7 @@ func TestPipeline_Engine_ListPipelines(t *testing.T) {
 	_pipelineTwo.SetData([]byte("foo"))
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	dbPipelineOne := types.PipelineFromAPI(_pipelineOne)
@@ -92,6 +93,7 @@ func TestPipeline_Engine_ListPipelines(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE "users"."id" = $1`).WithArgs(1).WillReturnRows(_userRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	sqlitePopulateTables(

--- a/database/pipeline/table_test.go
+++ b/database/pipeline/table_test.go
@@ -12,11 +12,13 @@ import (
 func TestPipeline_Engine_CreatePipelineTable(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreatePostgresTable).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/pipeline/update_test.go
+++ b/database/pipeline/update_test.go
@@ -27,6 +27,7 @@ func TestPipeline_Engine_UpdatePipeline(t *testing.T) {
 	_pipeline.SetData([]byte{})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -37,6 +38,7 @@ WHERE "id" = $16`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreatePipeline(context.TODO(), _pipeline)

--- a/database/repo/count_org_test.go
+++ b/database/repo/count_org_test.go
@@ -33,6 +33,7 @@ func TestRepo_Engine_CountReposForOrg(t *testing.T) {
 	_repoTwo.SetVisibility("public")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -42,6 +43,7 @@ func TestRepo_Engine_CountReposForOrg(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "repos" WHERE org = $1`).WithArgs("foo").WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateRepo(context.TODO(), _repoOne)

--- a/database/repo/count_test.go
+++ b/database/repo/count_test.go
@@ -33,6 +33,7 @@ func TestRepo_Engine_CountRepos(t *testing.T) {
 	_repoTwo.SetVisibility("public")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -42,6 +43,7 @@ func TestRepo_Engine_CountRepos(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "repos"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateRepo(context.TODO(), _repoOne)

--- a/database/repo/count_user_test.go
+++ b/database/repo/count_user_test.go
@@ -37,6 +37,7 @@ func TestRepo_Engine_CountReposForUser(t *testing.T) {
 	_repoTwo.SetVisibility("public")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -46,6 +47,7 @@ func TestRepo_Engine_CountReposForUser(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "repos" WHERE user_id = $1`).WithArgs(1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateRepo(context.TODO(), _repoOne)

--- a/database/repo/create_test.go
+++ b/database/repo/create_test.go
@@ -32,6 +32,7 @@ func TestRepo_Engine_CreateRepo(t *testing.T) {
 	_repo.SetCustomProps(props)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -45,6 +46,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/repo/delete_test.go
+++ b/database/repo/delete_test.go
@@ -23,6 +23,7 @@ func TestRepo_Engine_DeleteRepo(t *testing.T) {
 	_repo.SetVisibility("public")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -31,6 +32,7 @@ func TestRepo_Engine_DeleteRepo(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateRepo(context.TODO(), _repo)

--- a/database/repo/get_org_test.go
+++ b/database/repo/get_org_test.go
@@ -35,6 +35,7 @@ func TestRepo_Engine_GetRepoForOrg(t *testing.T) {
 	_repo.SetOwner(_owner)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -47,6 +48,7 @@ func TestRepo_Engine_GetRepoForOrg(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE "users"."id" = $1`).WithArgs(1).WillReturnRows(_userRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateRepo(context.TODO(), _repo)

--- a/database/repo/get_test.go
+++ b/database/repo/get_test.go
@@ -34,6 +34,7 @@ func TestRepo_Engine_GetRepo(t *testing.T) {
 	_repo.SetOwner(_owner)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -46,6 +47,7 @@ func TestRepo_Engine_GetRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE "users"."id" = $1`).WithArgs(1).WillReturnRows(_userRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateRepo(context.TODO(), _repo)

--- a/database/repo/in_list_test.go
+++ b/database/repo/in_list_test.go
@@ -46,6 +46,7 @@ func TestRepo_Engine_GetReposInList(t *testing.T) {
 	_repoTwo.SetAllowEvents(api.NewEventsFromMask(1))
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -55,6 +56,7 @@ func TestRepo_Engine_GetReposInList(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "repos" WHERE full_name IN ($1,$2)`).WithArgs("foo/bar", "bar/foo").WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateRepo(context.TODO(), _repoOne)

--- a/database/repo/index_test.go
+++ b/database/repo/index_test.go
@@ -12,11 +12,13 @@ import (
 func TestRepo_Engine_CreateRepoIndexes(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreateOrgNameIndex).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/repo/interface.go
+++ b/database/repo/interface.go
@@ -11,7 +11,7 @@ import (
 // RepoInterface represents the Vela interface for repo
 // functions with the supported Database backends.
 //
-//nolint:revive // ignore name stutter
+
 type RepoInterface interface {
 	// Repo Data Definition Language Functions
 	//

--- a/database/repo/list_org_test.go
+++ b/database/repo/list_org_test.go
@@ -59,6 +59,7 @@ func TestRepo_Engine_ListReposForOrg(t *testing.T) {
 	_buildTwo.SetCreated(time.Now().UTC().Unix())
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected name query result in mock
@@ -80,6 +81,7 @@ func TestRepo_Engine_ListReposForOrg(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE "users"."id" = $1`).WithArgs(1).WillReturnRows(_userRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateRepo(context.TODO(), _repoOne)

--- a/database/repo/list_test.go
+++ b/database/repo/list_test.go
@@ -45,6 +45,7 @@ func TestRepo_Engine_ListRepos(t *testing.T) {
 	_repoTwo.SetAllowEvents(api.NewEventsFromMask(1))
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -57,6 +58,7 @@ func TestRepo_Engine_ListRepos(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE "users"."id" = $1`).WithArgs(1).WillReturnRows(_userRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateRepo(context.TODO(), _repoOne)

--- a/database/repo/list_user_test.go
+++ b/database/repo/list_user_test.go
@@ -58,6 +58,7 @@ func TestRepo_Engine_ListReposForUser(t *testing.T) {
 	_buildTwo.SetCreated(time.Now().UTC().Unix())
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected name query result in mock
@@ -79,6 +80,7 @@ func TestRepo_Engine_ListReposForUser(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE "users"."id" = $1`).WithArgs(1).WillReturnRows(_userRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateRepo(context.TODO(), _repoOne)

--- a/database/repo/table_test.go
+++ b/database/repo/table_test.go
@@ -12,11 +12,13 @@ import (
 func TestRepo_Engine_CreateRepoTable(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreatePostgresTable).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/repo/update_test.go
+++ b/database/repo/update_test.go
@@ -33,6 +33,7 @@ func TestRepo_Engine_UpdateRepo(t *testing.T) {
 	_repo.SetCustomProps(map[string]any{"foo": "bar"})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -43,6 +44,7 @@ WHERE "id" = $24`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateRepo(context.TODO(), _repo)

--- a/database/schedule/count_active_test.go
+++ b/database/schedule/count_active_test.go
@@ -88,6 +88,7 @@ func TestSchedule_Engine_CountActiveSchedules(t *testing.T) {
 	_scheduleTwo.SetNextRun(nextTime.Unix())
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -97,6 +98,7 @@ func TestSchedule_Engine_CountActiveSchedules(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "schedules" WHERE active = $1`).WithArgs(true).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSchedule(context.TODO(), _scheduleOne)

--- a/database/schedule/count_repo_test.go
+++ b/database/schedule/count_repo_test.go
@@ -88,6 +88,7 @@ func TestSchedule_Engine_CountSchedulesForRepo(t *testing.T) {
 	_scheduleTwo.SetNextRun(nextTime.Unix())
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -97,6 +98,7 @@ func TestSchedule_Engine_CountSchedulesForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "schedules" WHERE repo_id = $1`).WithArgs(1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSchedule(context.TODO(), _scheduleOne)

--- a/database/schedule/count_test.go
+++ b/database/schedule/count_test.go
@@ -88,6 +88,7 @@ func TestSchedule_Engine_CountSchedules(t *testing.T) {
 	_scheduleTwo.SetNextRun(nextTime.Unix())
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -97,6 +98,7 @@ func TestSchedule_Engine_CountSchedules(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "schedules"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSchedule(context.TODO(), _scheduleOne)

--- a/database/schedule/create_test.go
+++ b/database/schedule/create_test.go
@@ -70,6 +70,7 @@ func TestSchedule_Engine_CreateSchedule(t *testing.T) {
 	_schedule.SetNextRun(nextTime.Unix())
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -83,6 +84,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12) RETURNING "id"`).
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/schedule/delete_test.go
+++ b/database/schedule/delete_test.go
@@ -69,6 +69,7 @@ func TestSchedule_Engine_DeleteSchedule(t *testing.T) {
 	_schedule.SetNextRun(nextTime.Unix())
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -77,6 +78,7 @@ func TestSchedule_Engine_DeleteSchedule(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSchedule(context.TODO(), _schedule)

--- a/database/schedule/get_repo_test.go
+++ b/database/schedule/get_repo_test.go
@@ -70,6 +70,7 @@ func TestSchedule_Engine_GetScheduleForRepo(t *testing.T) {
 	_schedule.SetNextRun(nextTime.Unix())
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -79,6 +80,7 @@ func TestSchedule_Engine_GetScheduleForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "schedules" WHERE repo_id = $1 AND name = $2 LIMIT $3`).WithArgs(1, "nightly", 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSchedule(context.TODO(), _schedule)

--- a/database/schedule/get_test.go
+++ b/database/schedule/get_test.go
@@ -70,6 +70,7 @@ func TestSchedule_Engine_GetSchedule(t *testing.T) {
 	_schedule.SetNextRun(nextTime.Unix())
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -85,6 +86,7 @@ func TestSchedule_Engine_GetSchedule(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE "users"."id" = $1`).WithArgs(1).WillReturnRows(_userRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSchedule(context.TODO(), _schedule)

--- a/database/schedule/index_test.go
+++ b/database/schedule/index_test.go
@@ -12,11 +12,13 @@ import (
 func TestSchedule_Engine_CreateScheduleIndexes(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreateRepoIDIndex).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/schedule/interface.go
+++ b/database/schedule/interface.go
@@ -11,7 +11,7 @@ import (
 // ScheduleInterface represents the Vela interface for schedule
 // functions with the supported Database backends.
 //
-//nolint:revive // ignore name stutter
+
 type ScheduleInterface interface {
 	// Schedule Data Definition Language Functions
 	//

--- a/database/schedule/list_active_test.go
+++ b/database/schedule/list_active_test.go
@@ -88,6 +88,7 @@ func TestSchedule_Engine_ListActiveSchedules(t *testing.T) {
 	_scheduleTwo.SetNextRun(nextTime.Unix())
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -103,6 +104,7 @@ func TestSchedule_Engine_ListActiveSchedules(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE "users"."id" = $1`).WithArgs(1).WillReturnRows(_userRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSchedule(context.TODO(), _scheduleOne)
@@ -114,6 +116,7 @@ func TestSchedule_Engine_ListActiveSchedules(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to create test schedule for sqlite: %v", err)
 	}
+
 	err = _sqlite.client.AutoMigrate(&types.Repo{})
 	if err != nil {
 		t.Errorf("unable to create build table for sqlite: %v", err)

--- a/database/schedule/list_repo_test.go
+++ b/database/schedule/list_repo_test.go
@@ -88,6 +88,7 @@ func TestSchedule_Engine_ListSchedulesForRepo(t *testing.T) {
 	_scheduleTwo.SetNextRun(nextTime.Unix())
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -97,6 +98,7 @@ func TestSchedule_Engine_ListSchedulesForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "schedules" WHERE repo_id = $1 ORDER BY id DESC LIMIT $2`).WithArgs(1, 10).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSchedule(context.TODO(), _scheduleOne)

--- a/database/schedule/list_test.go
+++ b/database/schedule/list_test.go
@@ -88,6 +88,7 @@ func TestSchedule_Engine_ListSchedules(t *testing.T) {
 	_scheduleTwo.SetNextRun(nextTime.Unix())
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -103,6 +104,7 @@ func TestSchedule_Engine_ListSchedules(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE "users"."id" = $1`).WithArgs(1).WillReturnRows(_userRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSchedule(context.TODO(), _scheduleOne)

--- a/database/schedule/schedule_test.go
+++ b/database/schedule/schedule_test.go
@@ -183,6 +183,7 @@ func (t NowTimestamp) Match(v driver.Value) bool {
 	if !ok {
 		return false
 	}
+
 	now := time.Now().Unix()
 
 	return now-ts < 10

--- a/database/schedule/table_test.go
+++ b/database/schedule/table_test.go
@@ -12,11 +12,13 @@ import (
 func TestSchedule_Engine_CreateScheduleTable(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreatePostgresTable).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/schedule/update_test.go
+++ b/database/schedule/update_test.go
@@ -70,6 +70,7 @@ func TestSchedule_Engine_UpdateSchedule_Config(t *testing.T) {
 	_schedule.SetNextRun(nextTime.Unix())
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -80,6 +81,7 @@ WHERE "id" = $12`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSchedule(context.TODO(), _schedule)
@@ -184,6 +186,7 @@ func TestSchedule_Engine_UpdateSchedule_NotConfig(t *testing.T) {
 	_schedule.SetNextRun(nextTime.Unix())
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -192,6 +195,7 @@ func TestSchedule_Engine_UpdateSchedule_NotConfig(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSchedule(context.TODO(), _schedule)

--- a/database/secret/count_org_test.go
+++ b/database/secret/count_org_test.go
@@ -40,6 +40,7 @@ func TestSecret_Engine_CountSecretsForOrg(t *testing.T) {
 	_secretTwo.SetUpdatedBy("user2")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -50,6 +51,7 @@ func TestSecret_Engine_CountSecretsForOrg(t *testing.T) {
 		WithArgs(constants.SecretOrg, "foo").WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)

--- a/database/secret/count_repo_test.go
+++ b/database/secret/count_repo_test.go
@@ -50,6 +50,7 @@ func TestSecret_Engine_CountSecretsForRepo(t *testing.T) {
 	_secretTwo.SetUpdatedBy("user2")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -60,6 +61,7 @@ func TestSecret_Engine_CountSecretsForRepo(t *testing.T) {
 		WithArgs(constants.SecretRepo, "foo", "bar").WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)

--- a/database/secret/count_team_test.go
+++ b/database/secret/count_team_test.go
@@ -40,6 +40,7 @@ func TestSecret_Engine_CountSecretsForTeam(t *testing.T) {
 	_secretTwo.SetUpdatedBy("user2")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -50,6 +51,7 @@ func TestSecret_Engine_CountSecretsForTeam(t *testing.T) {
 		WithArgs(constants.SecretShared, "foo", "bar").WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)
@@ -146,6 +148,7 @@ func TestSecret_Engine_CountSecretsForTeams(t *testing.T) {
 	_secretTwo.SetUpdatedBy("user2")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -156,6 +159,7 @@ func TestSecret_Engine_CountSecretsForTeams(t *testing.T) {
 		WithArgs(constants.SecretShared, "foo", "foo", "bar").WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)

--- a/database/secret/count_test.go
+++ b/database/secret/count_test.go
@@ -39,6 +39,7 @@ func TestSecret_Engine_CountSecrets(t *testing.T) {
 	_secretTwo.SetUpdatedBy("user2")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -48,6 +49,7 @@ func TestSecret_Engine_CountSecrets(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "secrets"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)

--- a/database/secret/create.go
+++ b/database/secret/create.go
@@ -84,7 +84,6 @@ func (e *Engine) CreateSecret(ctx context.Context, s *api.Secret) (*api.Secret, 
 
 		return nil
 	})
-
 	if transactionErr != nil {
 		return nil, transactionErr
 	}

--- a/database/secret/create_test.go
+++ b/database/secret/create_test.go
@@ -55,6 +55,7 @@ func TestSecret_Engine_CreateSecret(t *testing.T) {
 	_secretShared.SetAllowEvents(api.NewEventsFromMask(1))
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -94,6 +95,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) RETURNING "id"`).
 	_mock.ExpectCommit()
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/secret/delete_test.go
+++ b/database/secret/delete_test.go
@@ -52,6 +52,7 @@ func TestSecret_Engine_DeleteSecret(t *testing.T) {
 	_secretShared.SetRepoAllowlist([]string{"github/octocat"})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectBegin()
@@ -91,6 +92,7 @@ func TestSecret_Engine_DeleteSecret(t *testing.T) {
 	_mock.ExpectCommit()
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secretRepo)

--- a/database/secret/fill_allowlist_test.go
+++ b/database/secret/fill_allowlist_test.go
@@ -29,6 +29,7 @@ func TestSecret_Engine_FillAllowlist(t *testing.T) {
 	_secret.SetRepoAllowlist([]string{"github/octocat", "github/octokitty"})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -39,6 +40,7 @@ func TestSecret_Engine_FillAllowlist(t *testing.T) {
 		WithArgs(1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secret)

--- a/database/secret/fill_allowlists_test.go
+++ b/database/secret/fill_allowlists_test.go
@@ -43,6 +43,7 @@ func TestSecret_Engine_FillAllowlists(t *testing.T) {
 	_secretTwo.SetRepoAllowlist([]string{"alpha/beta", "gamma/delta"})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -53,6 +54,7 @@ func TestSecret_Engine_FillAllowlists(t *testing.T) {
 		WithArgs(1, 2).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)

--- a/database/secret/get_org_test.go
+++ b/database/secret/get_org_test.go
@@ -32,6 +32,7 @@ func TestSecret_Engine_GetSecretForOrg(t *testing.T) {
 	_secret.SetRepoAllowlist([]string{})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -44,6 +45,7 @@ func TestSecret_Engine_GetSecretForOrg(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "secret_repo_allowlists" WHERE secret_id = $1`).WithArgs(1).WillReturnRows(sqlmock.NewRows([]string{}))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secret)

--- a/database/secret/get_repo_test.go
+++ b/database/secret/get_repo_test.go
@@ -42,6 +42,7 @@ func TestSecret_Engine_GetSecretForRepo(t *testing.T) {
 	_secret.SetRepoAllowlist([]string{})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -54,6 +55,7 @@ func TestSecret_Engine_GetSecretForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "secret_repo_allowlists" WHERE secret_id = $1`).WithArgs(1).WillReturnRows(sqlmock.NewRows([]string{}))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secret)

--- a/database/secret/get_team_test.go
+++ b/database/secret/get_team_test.go
@@ -30,6 +30,7 @@ func TestSecret_Engine_GetSecretForTeam(t *testing.T) {
 	_secret.SetRepoAllowlist([]string{"github/octocat", "github/octokitty"})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -44,6 +45,7 @@ func TestSecret_Engine_GetSecretForTeam(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "secret_repo_allowlists" WHERE secret_id = $1`).WithArgs(1).WillReturnRows(_allowlistRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secret)

--- a/database/secret/get_test.go
+++ b/database/secret/get_test.go
@@ -31,6 +31,7 @@ func TestSecret_Engine_GetSecret(t *testing.T) {
 	_secret.SetRepoAllowlist([]string{})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -42,6 +43,7 @@ func TestSecret_Engine_GetSecret(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "secret_repo_allowlists" WHERE secret_id = $1`).WithArgs(1).WillReturnRows(sqlmock.NewRows([]string{}))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secret)

--- a/database/secret/index_test.go
+++ b/database/secret/index_test.go
@@ -12,6 +12,7 @@ import (
 func TestSecret_Engine_CreateSecretIndexes(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreateSecretID).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -20,6 +21,7 @@ func TestSecret_Engine_CreateSecretIndexes(t *testing.T) {
 	_mock.ExpectExec(CreateTypeOrg).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/secret/insert_allowlist_test.go
+++ b/database/secret/insert_allowlist_test.go
@@ -29,6 +29,7 @@ func TestSecret_Engine_InsertAllowlist(t *testing.T) {
 	_secret.SetRepoAllowlist([]string{"github/octocat", "github/octokitty"})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -42,6 +43,7 @@ VALUES ($1,$2),($3,$4) ON CONFLICT DO NOTHING RETURNING "id"`).
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/secret/interface.go
+++ b/database/secret/interface.go
@@ -11,7 +11,7 @@ import (
 // SecretInterface represents the Vela interface for secret
 // functions with the supported Database backends.
 //
-//nolint:revive // ignore name stutter
+
 type SecretInterface interface {
 	// Secret Data Definition Language Functions
 	//

--- a/database/secret/list_org_test.go
+++ b/database/secret/list_org_test.go
@@ -46,6 +46,7 @@ func TestSecret_Engine_ListSecretsForOrg(t *testing.T) {
 	_secretTwo.SetRepoAllowlist([]string{})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected name query result in mock
@@ -58,6 +59,7 @@ func TestSecret_Engine_ListSecretsForOrg(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "secret_repo_allowlists" WHERE secret_id IN ($1,$2)`).WithArgs(2, 1).WillReturnRows(sqlmock.NewRows([]string{}))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)

--- a/database/secret/list_repo_test.go
+++ b/database/secret/list_repo_test.go
@@ -56,6 +56,7 @@ func TestSecret_Engine_ListSecretsForRepo(t *testing.T) {
 	_secretTwo.SetRepoAllowlist([]string{})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected name query result in mock
@@ -68,6 +69,7 @@ func TestSecret_Engine_ListSecretsForRepo(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "secret_repo_allowlists" WHERE secret_id IN ($1,$2)`).WithArgs(2, 1).WillReturnRows(sqlmock.NewRows([]string{}))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)

--- a/database/secret/list_team_test.go
+++ b/database/secret/list_team_test.go
@@ -46,6 +46,7 @@ func TestSecret_Engine_ListSecretsForTeam(t *testing.T) {
 	_secretTwo.SetRepoAllowlist([]string{})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected name query result in mock
@@ -60,6 +61,7 @@ func TestSecret_Engine_ListSecretsForTeam(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "secret_repo_allowlists" WHERE secret_id IN ($1,$2)`).WithArgs(2, 1).WillReturnRows(_allowlistRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)
@@ -150,6 +152,7 @@ func TestSecret_Engine_ListSecretsForTeams(t *testing.T) {
 	_secretTwo.SetRepoAllowlist([]string{"alpha/beta", "github/octocat"})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected name query result in mock
@@ -173,6 +176,7 @@ func TestSecret_Engine_ListSecretsForTeams(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "secret_repo_allowlists" WHERE secret_id IN ($1,$2)`).WithArgs(2, 1).WillReturnRows(_allowlistRows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)

--- a/database/secret/list_test.go
+++ b/database/secret/list_test.go
@@ -45,6 +45,7 @@ func TestSecret_Engine_ListSecrets(t *testing.T) {
 	_secretTwo.SetRepoAllowlist([]string{})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -56,6 +57,7 @@ func TestSecret_Engine_ListSecrets(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "secret_repo_allowlists" WHERE secret_id IN ($1,$2)`).WithArgs(1, 2).WillReturnRows(sqlmock.NewRows([]string{}))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secretOne)

--- a/database/secret/migrate_secrets_test.go
+++ b/database/secret/migrate_secrets_test.go
@@ -57,6 +57,7 @@ func TestSecret_Engine_MigrateSecrets(t *testing.T) {
 	_secretShared.SetRepoAllowlist([]string{"foo/bar", "github/octokitty"})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectBegin()
@@ -74,6 +75,7 @@ SET "repo"=$1 WHERE repo = $2`).
 	_mock.ExpectCommit()
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secretRepo)

--- a/database/secret/prune_allowlist_test.go
+++ b/database/secret/prune_allowlist_test.go
@@ -28,6 +28,7 @@ func TestSecret_Engine_PruneAllowlist(t *testing.T) {
 	_secret.SetRepoAllowlist([]string{"github/octocat", "github/octokitty"})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the repo query
@@ -36,6 +37,7 @@ func TestSecret_Engine_PruneAllowlist(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secret)
@@ -100,6 +102,7 @@ func TestSecret_Engine_PruneAllowlistEmpty(t *testing.T) {
 	_secret.SetRepoAllowlist([]string{})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the repo query
@@ -108,6 +111,7 @@ func TestSecret_Engine_PruneAllowlistEmpty(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secret)

--- a/database/secret/table_test.go
+++ b/database/secret/table_test.go
@@ -12,12 +12,14 @@ import (
 func TestSecret_Engine_CreateSecretTables(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreatePostgresAllowlistTable).WillReturnResult(sqlmock.NewResult(1, 1))
 	_mock.ExpectExec(CreatePostgresTable).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/secret/update.go
+++ b/database/secret/update.go
@@ -89,7 +89,6 @@ func (e *Engine) UpdateSecret(ctx context.Context, s *api.Secret) (*api.Secret, 
 
 		return nil
 	})
-
 	if transactionErr != nil {
 		return nil, transactionErr
 	}

--- a/database/secret/update_test.go
+++ b/database/secret/update_test.go
@@ -58,6 +58,7 @@ func TestSecret_Engine_UpdateSecret(t *testing.T) {
 	_secretShared.SetRepoAllowlist([]string{"github/octocat", "github/octokitty"})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectBegin()
@@ -113,6 +114,7 @@ VALUES ($1,$2),($3,$4) ON CONFLICT DO NOTHING RETURNING "id"`).
 	_mock.ExpectCommit()
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSecret(context.TODO(), _secretRepo)

--- a/database/service/clean_test.go
+++ b/database/service/clean_test.go
@@ -55,6 +55,7 @@ func TestService_Engine_CleanService(t *testing.T) {
 	_serviceFour.SetStatus("pending")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the name query
@@ -63,6 +64,7 @@ func TestService_Engine_CleanService(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 2))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateService(context.TODO(), _serviceOne)

--- a/database/service/count_build_test.go
+++ b/database/service/count_build_test.go
@@ -36,6 +36,7 @@ func TestService_Engine_CountServicesForBuild(t *testing.T) {
 	_serviceTwo.SetImage("bar")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -45,6 +46,7 @@ func TestService_Engine_CountServicesForBuild(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "services" WHERE build_id = $1`).WithArgs(1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateService(context.TODO(), _serviceOne)

--- a/database/service/count_test.go
+++ b/database/service/count_test.go
@@ -31,6 +31,7 @@ func TestService_Engine_CountServices(t *testing.T) {
 	_serviceTwo.SetImage("bar")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -40,6 +41,7 @@ func TestService_Engine_CountServices(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "services"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateService(context.TODO(), _serviceOne)

--- a/database/service/create_test.go
+++ b/database/service/create_test.go
@@ -23,6 +23,7 @@ func TestService_Engine_CreateService(t *testing.T) {
 	_service.SetImage("bar")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -36,6 +37,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) RETURNING "id"`).
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/service/delete_test.go
+++ b/database/service/delete_test.go
@@ -22,6 +22,7 @@ func TestService_Engine_DeleteService(t *testing.T) {
 	_service.SetImage("bar")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -30,6 +31,7 @@ func TestService_Engine_DeleteService(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateService(context.TODO(), _service)

--- a/database/service/get_build_test.go
+++ b/database/service/get_build_test.go
@@ -28,6 +28,7 @@ func TestService_Engine_GetServiceForBuild(t *testing.T) {
 	_service.SetImage("bar")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -37,6 +38,7 @@ func TestService_Engine_GetServiceForBuild(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "services" WHERE build_id = $1 AND number = $2 LIMIT $3`).WithArgs(1, 1, 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateService(context.TODO(), _service)

--- a/database/service/get_test.go
+++ b/database/service/get_test.go
@@ -23,6 +23,7 @@ func TestService_Engine_GetService(t *testing.T) {
 	_service.SetImage("bar")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -32,6 +33,7 @@ func TestService_Engine_GetService(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "services" WHERE id = $1 LIMIT $2`).WithArgs(1, 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateService(context.TODO(), _service)

--- a/database/service/interface.go
+++ b/database/service/interface.go
@@ -11,7 +11,7 @@ import (
 // ServiceInterface represents the Vela interface for service
 // functions with the supported Database backends.
 //
-//nolint:revive // ignore name stutter
+
 type ServiceInterface interface {
 	// Service Data Definition Language Functions
 	//

--- a/database/service/list_build_test.go
+++ b/database/service/list_build_test.go
@@ -36,6 +36,7 @@ func TestService_Engine_ListServicesForBuild(t *testing.T) {
 	_serviceTwo.SetImage("bar")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -45,6 +46,7 @@ func TestService_Engine_ListServicesForBuild(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "services" WHERE build_id = $1 ORDER BY id DESC LIMIT $2`).WithArgs(1, 10).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateService(context.TODO(), _serviceOne)

--- a/database/service/list_image_test.go
+++ b/database/service/list_image_test.go
@@ -31,6 +31,7 @@ func TestService_Engine_ListServiceImageCount(t *testing.T) {
 	_serviceTwo.SetImage("bar")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -40,6 +41,7 @@ func TestService_Engine_ListServiceImageCount(t *testing.T) {
 	_mock.ExpectQuery(`SELECT "image", count(image) as count FROM "services" GROUP BY "image"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateService(context.TODO(), _serviceOne)

--- a/database/service/list_status_test.go
+++ b/database/service/list_status_test.go
@@ -31,6 +31,7 @@ func TestService_Engine_ListServiceStatusCount(t *testing.T) {
 	_serviceTwo.SetImage("bar")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -45,6 +46,7 @@ func TestService_Engine_ListServiceStatusCount(t *testing.T) {
 	_mock.ExpectQuery(`SELECT "status", count(status) as count FROM "services" GROUP BY "status"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateService(context.TODO(), _serviceOne)

--- a/database/service/list_test.go
+++ b/database/service/list_test.go
@@ -31,6 +31,7 @@ func TestService_Engine_ListServices(t *testing.T) {
 	_serviceTwo.SetImage("foo")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -40,6 +41,7 @@ func TestService_Engine_ListServices(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "services"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateService(context.TODO(), _serviceOne)

--- a/database/service/service_test.go
+++ b/database/service/service_test.go
@@ -177,6 +177,7 @@ func (t NowTimestamp) Match(v driver.Value) bool {
 	if !ok {
 		return false
 	}
+
 	now := time.Now().Unix()
 
 	return now-ts < 10

--- a/database/service/table_test.go
+++ b/database/service/table_test.go
@@ -12,11 +12,13 @@ import (
 func TestService_Engine_CreateServiceTable(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreatePostgresTable).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/service/update_test.go
+++ b/database/service/update_test.go
@@ -23,6 +23,7 @@ func TestService_Engine_UpdateService(t *testing.T) {
 	_service.SetImage("bar")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -31,6 +32,7 @@ func TestService_Engine_UpdateService(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateService(context.TODO(), _service)

--- a/database/settings/create_test.go
+++ b/database/settings/create_test.go
@@ -30,6 +30,7 @@ func TestSettings_Engine_CreateSettings(t *testing.T) {
 	_settings.SetUpdatedBy("")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -42,6 +43,7 @@ func TestSettings_Engine_CreateSettings(t *testing.T) {
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/settings/get_test.go
+++ b/database/settings/get_test.go
@@ -32,6 +32,7 @@ func TestSettings_Engine_GetSettings(t *testing.T) {
 	_settings.SetUpdatedBy("octocat")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -41,6 +42,7 @@ func TestSettings_Engine_GetSettings(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "settings" WHERE id = $1 LIMIT $2`).WithArgs(1, 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSettings(context.TODO(), _settings)

--- a/database/settings/interface.go
+++ b/database/settings/interface.go
@@ -11,7 +11,7 @@ import (
 // SettingsInterface represents the Vela interface for settings
 // functions with the supported Database backends.
 //
-//nolint:revive // ignore name stutter
+
 type SettingsInterface interface {
 	// CreateSettings defines a function that creates a platform settings record.
 	CreateSettings(context.Context, *settings.Platform) (*settings.Platform, error)

--- a/database/settings/table_test.go
+++ b/database/settings/table_test.go
@@ -12,11 +12,13 @@ import (
 func TestSettings_Engine_CreateSettingsTable(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreatePostgresTable).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/settings/update_test.go
+++ b/database/settings/update_test.go
@@ -32,6 +32,7 @@ func TestSettings_Engine_UpdateSettings(t *testing.T) {
 	_settings.SetUpdatedBy("octocat")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -41,6 +42,7 @@ func TestSettings_Engine_UpdateSettings(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateSettings(context.TODO(), _settings)

--- a/database/step/clean_test.go
+++ b/database/step/clean_test.go
@@ -57,6 +57,7 @@ func TestStep_Engine_CleanStep(t *testing.T) {
 	_postgres, _mock := testPostgres(t)
 
 	ctx := context.TODO()
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the name query
@@ -65,6 +66,7 @@ func TestStep_Engine_CleanStep(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 2))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateStep(ctx, _stepOne)

--- a/database/step/count_build_test.go
+++ b/database/step/count_build_test.go
@@ -38,6 +38,7 @@ func TestStep_Engine_CountStepsForBuild(t *testing.T) {
 	_postgres, _mock := testPostgres(t)
 
 	ctx := context.TODO()
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -47,6 +48,7 @@ func TestStep_Engine_CountStepsForBuild(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "steps" WHERE build_id = $1`).WithArgs(1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateStep(ctx, _stepOne)

--- a/database/step/count_test.go
+++ b/database/step/count_test.go
@@ -43,6 +43,7 @@ func TestStep_Engine_CountSteps(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "steps"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateStep(ctx, _stepOne)

--- a/database/step/create_test.go
+++ b/database/step/create_test.go
@@ -24,6 +24,7 @@ func TestStep_Engine_CreateStep(t *testing.T) {
 	_step.SetReportAs("test")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -37,6 +38,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17) RETURNING "i
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/step/delete_test.go
+++ b/database/step/delete_test.go
@@ -33,7 +33,9 @@ func TestStep_Engine_DeleteStep(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
+
 	_, err := _sqlite.CreateStep(ctx, _step)
 	if err != nil {
 		t.Errorf("unable to create test step for sqlite: %v", err)

--- a/database/step/get_build_test.go
+++ b/database/step/get_build_test.go
@@ -41,7 +41,9 @@ func TestStep_Engine_GetStepForBuild(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "steps" WHERE build_id = $1 AND number = $2 LIMIT $3`).WithArgs(1, 1, 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
+
 	_, err := _sqlite.CreateStep(ctx, _step)
 	if err != nil {
 		t.Errorf("unable to create test step for sqlite: %v", err)

--- a/database/step/get_test.go
+++ b/database/step/get_test.go
@@ -25,6 +25,7 @@ func TestStep_Engine_GetStep(t *testing.T) {
 	ctx := context.TODO()
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -34,6 +35,7 @@ func TestStep_Engine_GetStep(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "steps" WHERE id = $1 LIMIT $2`).WithArgs(1, 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateStep(ctx, _step)

--- a/database/step/interface.go
+++ b/database/step/interface.go
@@ -11,7 +11,7 @@ import (
 // StepInterface represents the Vela interface for step
 // functions with the supported Database backends.
 //
-//nolint:revive // ignore name stutter
+
 type StepInterface interface {
 	// Step Data Definition Language Functions
 	//

--- a/database/step/list_build_test.go
+++ b/database/step/list_build_test.go
@@ -39,6 +39,7 @@ func TestStep_Engine_ListStepsForBuild(t *testing.T) {
 	_postgres, _mock := testPostgres(t)
 
 	ctx := context.TODO()
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -48,6 +49,7 @@ func TestStep_Engine_ListStepsForBuild(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "steps" WHERE build_id = $1 ORDER BY id DESC LIMIT $2`).WithArgs(1, 10).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateStep(ctx, _stepOne)

--- a/database/step/list_image_test.go
+++ b/database/step/list_image_test.go
@@ -33,6 +33,7 @@ func TestStep_Engine_ListStepImageCount(t *testing.T) {
 	_postgres, _mock := testPostgres(t)
 
 	ctx := context.TODO()
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -42,6 +43,7 @@ func TestStep_Engine_ListStepImageCount(t *testing.T) {
 	_mock.ExpectQuery(`SELECT "image", count(image) as count FROM "steps" GROUP BY "image"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateStep(ctx, _stepOne)

--- a/database/step/list_status_test.go
+++ b/database/step/list_status_test.go
@@ -33,6 +33,7 @@ func TestStep_Engine_ListStepStatusCount(t *testing.T) {
 	_postgres, _mock := testPostgres(t)
 
 	ctx := context.TODO()
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -47,6 +48,7 @@ func TestStep_Engine_ListStepStatusCount(t *testing.T) {
 	_mock.ExpectQuery(`SELECT "status", count(status) as count FROM "steps" GROUP BY "status"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateStep(ctx, _stepOne)

--- a/database/step/list_test.go
+++ b/database/step/list_test.go
@@ -33,6 +33,7 @@ func TestStep_Engine_ListSteps(t *testing.T) {
 	_postgres, _mock := testPostgres(t)
 
 	ctx := context.TODO()
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -42,6 +43,7 @@ func TestStep_Engine_ListSteps(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "steps"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateStep(ctx, _stepOne)

--- a/database/step/step_test.go
+++ b/database/step/step_test.go
@@ -177,6 +177,7 @@ func (t NowTimestamp) Match(v driver.Value) bool {
 	if !ok {
 		return false
 	}
+
 	now := time.Now().Unix()
 
 	return now-ts < 10

--- a/database/step/table_test.go
+++ b/database/step/table_test.go
@@ -20,6 +20,7 @@ func TestStep_Engine_CreateStepTable(t *testing.T) {
 	_mock.ExpectExec(CreatePostgresTable).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/step/update_test.go
+++ b/database/step/update_test.go
@@ -36,6 +36,7 @@ WHERE "id" = $17`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateStep(ctx, _step)

--- a/database/user/count_test.go
+++ b/database/user/count_test.go
@@ -25,6 +25,7 @@ func TestUser_Engine_CountUsers(t *testing.T) {
 	_userTwo.SetToken("bar")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -34,6 +35,7 @@ func TestUser_Engine_CountUsers(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "users"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateUser(context.TODO(), _userOne)

--- a/database/user/create_test.go
+++ b/database/user/create_test.go
@@ -20,6 +20,7 @@ func TestUser_Engine_CreateUser(t *testing.T) {
 	_user.SetToken("bar")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -33,6 +34,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING "id"`).
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/user/delete_test.go
+++ b/database/user/delete_test.go
@@ -19,6 +19,7 @@ func TestUser_Engine_DeleteUser(t *testing.T) {
 	_user.SetToken("bar")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -27,6 +28,7 @@ func TestUser_Engine_DeleteUser(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateUser(context.TODO(), _user)

--- a/database/user/get_name_test.go
+++ b/database/user/get_name_test.go
@@ -23,6 +23,7 @@ func TestUser_Engine_GetUserForName(t *testing.T) {
 	_user.SetDashboards([]string{})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -32,6 +33,7 @@ func TestUser_Engine_GetUserForName(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE name = $1 LIMIT $2`).WithArgs("foo", 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateUser(context.TODO(), _user)

--- a/database/user/get_test.go
+++ b/database/user/get_test.go
@@ -23,6 +23,7 @@ func TestUser_Engine_GetUser(t *testing.T) {
 	_user.SetDashboards([]string{})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -32,6 +33,7 @@ func TestUser_Engine_GetUser(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users" WHERE id = $1 LIMIT $2`).WithArgs(1, 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateUser(context.TODO(), _user)

--- a/database/user/index_test.go
+++ b/database/user/index_test.go
@@ -12,11 +12,13 @@ import (
 func TestUser_Engine_CreateUserIndexes(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreateUserRefreshIndex).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/user/interface.go
+++ b/database/user/interface.go
@@ -11,7 +11,7 @@ import (
 // UserInterface represents the Vela interface for user
 // functions with the supported Database backends.
 //
-//nolint:revive // ignore name stutter
+
 type UserInterface interface {
 	// User Data Definition Language Functions
 	//

--- a/database/user/list_lite_test.go
+++ b/database/user/list_lite_test.go
@@ -30,6 +30,7 @@ func TestUser_Engine_ListLiteUsers(t *testing.T) {
 	_userTwo.SetDashboards([]string{})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -42,6 +43,7 @@ func TestUser_Engine_ListLiteUsers(t *testing.T) {
 	_mock.ExpectQuery(`SELECT "id","name" FROM "users" LIMIT $1`).WithArgs(10).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateUser(context.TODO(), _userOne)

--- a/database/user/list_test.go
+++ b/database/user/list_test.go
@@ -29,6 +29,7 @@ func TestUser_Engine_ListUsers(t *testing.T) {
 	_userTwo.SetDashboards([]string{})
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -38,6 +39,7 @@ func TestUser_Engine_ListUsers(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "users"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateUser(context.TODO(), _userOne)

--- a/database/user/table_test.go
+++ b/database/user/table_test.go
@@ -12,11 +12,13 @@ import (
 func TestUser_Engine_CreateUserTable(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreatePostgresTable).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/user/update_test.go
+++ b/database/user/update_test.go
@@ -20,6 +20,7 @@ func TestUser_Engine_UpdateUser(t *testing.T) {
 	_user.SetToken("bar")
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -30,6 +31,7 @@ WHERE "id" = $8`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateUser(context.TODO(), _user)

--- a/database/worker/count_test.go
+++ b/database/worker/count_test.go
@@ -25,6 +25,7 @@ func TestWorker_Engine_CountWorkers(t *testing.T) {
 	_workerTwo.SetActive(true)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -34,6 +35,7 @@ func TestWorker_Engine_CountWorkers(t *testing.T) {
 	_mock.ExpectQuery(`SELECT count(*) FROM "workers"`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateWorker(context.TODO(), _workerOne)

--- a/database/worker/create_test.go
+++ b/database/worker/create_test.go
@@ -19,6 +19,7 @@ func TestWorker_Engine_CreateWorker(t *testing.T) {
 	_worker.SetActive(true)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -32,6 +33,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12) RETURNING "id"`).
 		WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/worker/delete_test.go
+++ b/database/worker/delete_test.go
@@ -18,6 +18,7 @@ func TestWorker_Engine_DeleteWorker(t *testing.T) {
 	_worker.SetActive(true)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -26,6 +27,7 @@ func TestWorker_Engine_DeleteWorker(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateWorker(context.TODO(), _worker)

--- a/database/worker/get_hostname_test.go
+++ b/database/worker/get_hostname_test.go
@@ -22,6 +22,7 @@ func TestWorker_Engine_GetWorkerForName(t *testing.T) {
 	_worker.SetRunningBuilds(nil) // sqlmock cannot parse string array values
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -31,6 +32,7 @@ func TestWorker_Engine_GetWorkerForName(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "workers" WHERE hostname = $1 LIMIT $2`).WithArgs("worker_0", 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateWorker(context.TODO(), _worker)

--- a/database/worker/get_test.go
+++ b/database/worker/get_test.go
@@ -22,6 +22,7 @@ func TestWorker_Engine_GetWorker(t *testing.T) {
 	_worker.SetRunningBuilds(nil)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -31,6 +32,7 @@ func TestWorker_Engine_GetWorker(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "workers" WHERE id = $1 LIMIT $2`).WithArgs(1, 1).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateWorker(context.TODO(), _worker)

--- a/database/worker/index_test.go
+++ b/database/worker/index_test.go
@@ -12,11 +12,13 @@ import (
 func TestWorker_Engine_CreateWorkerIndexes(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreateHostnameAddressIndex).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/worker/interface.go
+++ b/database/worker/interface.go
@@ -11,7 +11,7 @@ import (
 // WorkerInterface represents the Vela interface for worker
 // functions with the supported Database backends.
 //
-//nolint:revive // ignore name stutter
+
 type WorkerInterface interface {
 	// Worker Data Definition Language Functions
 	//

--- a/database/worker/list_test.go
+++ b/database/worker/list_test.go
@@ -43,6 +43,7 @@ func TestWorker_Engine_ListWorkers(t *testing.T) {
 	_workerThree.SetRunningBuilds(nil)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// create expected result in mock
@@ -52,6 +53,7 @@ func TestWorker_Engine_ListWorkers(t *testing.T) {
 	_mock.ExpectQuery(`SELECT * FROM "workers" WHERE last_checked_in < $1 AND last_checked_in > $2`).WillReturnRows(_rows)
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateWorker(context.TODO(), _workerOne)

--- a/database/worker/table_test.go
+++ b/database/worker/table_test.go
@@ -12,11 +12,13 @@ import (
 func TestWorker_Engine_CreateWorkerTable(t *testing.T) {
 	// setup types
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	_mock.ExpectExec(CreatePostgresTable).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	// setup tests

--- a/database/worker/update_test.go
+++ b/database/worker/update_test.go
@@ -19,6 +19,7 @@ func TestWorker_Engine_UpdateWorker(t *testing.T) {
 	_worker.SetActive(true)
 
 	_postgres, _mock := testPostgres(t)
+
 	defer func() { _sql, _ := _postgres.client.DB(); _sql.Close() }()
 
 	// ensure the mock expects the query
@@ -29,6 +30,7 @@ WHERE "id" = $12`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)
+
 	defer func() { _sql, _ := _sqlite.client.DB(); _sql.Close() }()
 
 	_, err := _sqlite.CreateWorker(context.TODO(), _worker)

--- a/internal/token/mint_test.go
+++ b/internal/token/mint_test.go
@@ -8,6 +8,7 @@ func Test_imageParse(t *testing.T) {
 	type args struct {
 		image string
 	}
+
 	tests := []struct {
 		name     string
 		args     args
@@ -59,9 +60,11 @@ func Test_imageParse(t *testing.T) {
 				t.Errorf("imageParse() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+
 			if gotName != tt.wantName {
 				t.Errorf("imageParse() gotName = %v, wantName %v", gotName, tt.wantName)
 			}
+
 			if gotTag != tt.wantTag {
 				t.Errorf("imageParse() gotTag = %v, wantTag %v", gotTag, tt.wantTag)
 			}

--- a/internal/token/parse.go
+++ b/internal/token/parse.go
@@ -44,7 +44,6 @@ func (tm *Manager) ParseToken(token string) (*Claims, error) {
 
 		return []byte(tm.PrivateKeyHMAC), err
 	})
-
 	if err != nil {
 		return nil, errors.New("failed parsing: " + err.Error())
 	}

--- a/mock/server/authentication.go
+++ b/mock/server/authentication.go
@@ -66,6 +66,7 @@ func getTokenRefresh(c *gin.Context) {
 	data := []byte(TokenRefreshResp)
 
 	var body api.Token
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -88,6 +89,7 @@ func getAuthenticate(c *gin.Context) {
 	}
 
 	var body api.Token
+
 	_ = json.Unmarshal(data, &body)
 
 	c.SetCookie(constants.RefreshTokenName, "refresh", 2, "/", "", true, true)
@@ -108,6 +110,7 @@ func getAuthenticateFromToken(c *gin.Context) {
 	}
 
 	var body api.Token
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -146,6 +149,7 @@ func openIDConfig(c *gin.Context) {
 	data := []byte(OpenIDConfigResp)
 
 	var body api.OpenIDConfig
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -156,6 +160,7 @@ func getJWKS(c *gin.Context) {
 	data := []byte(JWKSResp)
 
 	var body jwk.RSAPublicKey
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)

--- a/mock/server/build.go
+++ b/mock/server/build.go
@@ -233,6 +233,7 @@ func getBuilds(c *gin.Context) {
 	data := []byte(BuildsResp)
 
 	var body []api.Build
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -253,6 +254,7 @@ func getBuild(c *gin.Context) {
 	data := []byte(BuildResp)
 
 	var body api.Build
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -275,6 +277,7 @@ func getLogs(c *gin.Context) {
 	data := []byte(BuildLogsResp)
 
 	var body []api.Log
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -285,6 +288,7 @@ func addBuild(c *gin.Context) {
 	data := []byte(BuildResp)
 
 	var body api.Build
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusCreated, body)
@@ -309,6 +313,7 @@ func updateBuild(c *gin.Context) {
 	data := []byte(BuildResp)
 
 	var body api.Build
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -348,6 +353,7 @@ func restartBuild(c *gin.Context) {
 	data := []byte(BuildResp)
 
 	var body api.Build
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusCreated, body)
@@ -402,6 +408,7 @@ func buildQueue(c *gin.Context) {
 	data := []byte(BuildQueueResp)
 
 	var body []api.QueueBuild
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -429,6 +436,7 @@ func buildToken(c *gin.Context) {
 	data := []byte(BuildTokenResp)
 
 	var body api.Token
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -449,6 +457,7 @@ func idToken(c *gin.Context) {
 	data := []byte(IDTokenResp)
 
 	var body api.Token
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -469,6 +478,7 @@ func idTokenRequestToken(c *gin.Context) {
 	data := []byte(IDTokenRequestTokenResp)
 
 	var body api.Token
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -491,6 +501,7 @@ func buildExecutable(c *gin.Context) {
 	data := []byte(BuildExecutableResp)
 
 	var body api.BuildExecutable
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)

--- a/mock/server/dashboard.go
+++ b/mock/server/dashboard.go
@@ -208,6 +208,7 @@ func getDashboards(c *gin.Context) {
 	data := []byte(DashCardsResp)
 
 	var body []api.DashCard
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -228,6 +229,7 @@ func getDashboard(c *gin.Context) {
 	data := []byte(DashCardResp)
 
 	var body api.DashCard
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -238,6 +240,7 @@ func addDashboard(c *gin.Context) {
 	data := []byte(DashboardResp)
 
 	var body api.Dashboard
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusCreated, body)
@@ -248,6 +251,7 @@ func updateDashboard(c *gin.Context) {
 	data := []byte(DashboardResp)
 
 	var body api.Dashboard
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)

--- a/mock/server/dashboard_test.go
+++ b/mock/server/dashboard_test.go
@@ -42,6 +42,7 @@ func TestDashboard_ActiveDashboardResp(t *testing.T) {
 	}
 
 	testDashCards := []api.DashCard{}
+
 	err = json.Unmarshal([]byte(DashCardsResp), &testDashCards)
 	if err != nil {
 		t.Errorf("error unmarshaling dash cards: %v", err)

--- a/mock/server/deployment.go
+++ b/mock/server/deployment.go
@@ -425,6 +425,7 @@ func getDeployments(c *gin.Context) {
 	data := []byte(DeploymentsResp)
 
 	var body []api.Deployment
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -445,6 +446,7 @@ func getDeployment(c *gin.Context) {
 	data := []byte(DeploymentResp)
 
 	var body api.Deployment
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -455,6 +457,7 @@ func addDeployment(c *gin.Context) {
 	data := []byte(DeploymentResp)
 
 	var body api.Deployment
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusCreated, body)
@@ -465,6 +468,7 @@ func updateDeployment(c *gin.Context) {
 	data := []byte(DeploymentResp)
 
 	var body api.Deployment
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)

--- a/mock/server/hook.go
+++ b/mock/server/hook.go
@@ -282,6 +282,7 @@ func getHooks(c *gin.Context) {
 	data := []byte(HooksResp)
 
 	var body []api.Hook
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -304,6 +305,7 @@ func getHook(c *gin.Context) {
 	data := []byte(HookResp)
 
 	var body api.Hook
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -314,6 +316,7 @@ func addHook(c *gin.Context) {
 	data := []byte(HookResp)
 
 	var body api.Hook
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusCreated, body)
@@ -338,6 +341,7 @@ func updateHook(c *gin.Context) {
 	data := []byte(HookResp)
 
 	var body api.Hook
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)

--- a/mock/server/log.go
+++ b/mock/server/log.go
@@ -43,6 +43,7 @@ func getServiceLog(c *gin.Context) {
 	data := []byte(LogResp)
 
 	var body api.Log
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -104,6 +105,7 @@ func getStepLog(c *gin.Context) {
 	data := []byte(LogResp)
 
 	var body api.Log
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)

--- a/mock/server/pipeline.go
+++ b/mock/server/pipeline.go
@@ -331,6 +331,7 @@ func getPipelines(c *gin.Context) {
 	data := []byte(PipelinesResp)
 
 	var body []api.Pipeline
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -353,6 +354,7 @@ func getPipeline(c *gin.Context) {
 	data := []byte(PipelineResp)
 
 	var body api.Pipeline
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -363,6 +365,7 @@ func addPipeline(c *gin.Context) {
 	data := []byte(PipelineResp)
 
 	var body api.Pipeline
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusCreated, body)
@@ -387,6 +390,7 @@ func updatePipeline(c *gin.Context) {
 	data := []byte(PipelineResp)
 
 	var body api.Pipeline
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -426,6 +430,7 @@ func compilePipeline(c *gin.Context) {
 	data := []byte(CompileResp)
 
 	var body yaml.Build
+
 	_ = yml.Unmarshal(data, &body)
 
 	c.YAML(http.StatusOK, body)
@@ -448,6 +453,7 @@ func expandPipeline(c *gin.Context) {
 	data := []byte(ExpandResp)
 
 	var body yaml.Build
+
 	_ = yml.Unmarshal(data, &body)
 
 	c.YAML(http.StatusOK, body)

--- a/mock/server/repo.go
+++ b/mock/server/repo.go
@@ -111,6 +111,7 @@ func getRepos(c *gin.Context) {
 	data := []byte(ReposResp)
 
 	var body []api.Repo
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -133,6 +134,7 @@ func getRepo(c *gin.Context) {
 	data := []byte(RepoResp)
 
 	var body api.Repo
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -143,6 +145,7 @@ func addRepo(c *gin.Context) {
 	data := []byte(RepoResp)
 
 	var body api.Repo
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusCreated, body)
@@ -167,6 +170,7 @@ func updateRepo(c *gin.Context) {
 	data := []byte(RepoResp)
 
 	var body api.Repo
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)

--- a/mock/server/repo_test.go
+++ b/mock/server/repo_test.go
@@ -24,6 +24,7 @@ func TestRepo_ActiveRepoResp(t *testing.T) {
 		if tRepo.Field(i).Name == "Hash" {
 			continue
 		}
+
 		if reflect.ValueOf(testRepo).Field(i).IsNil() {
 			t.Errorf("RepoResp missing field %s", tRepo.Field(i).Name)
 		}

--- a/mock/server/schedule.go
+++ b/mock/server/schedule.go
@@ -204,6 +204,7 @@ func getSchedules(c *gin.Context) {
 	data := []byte(SchedulesResp)
 
 	var body []api.Schedule
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -226,6 +227,7 @@ func getSchedule(c *gin.Context) {
 	data := []byte(ScheduleResp)
 
 	var body api.Schedule
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -236,6 +238,7 @@ func addSchedule(c *gin.Context) {
 	data := []byte(ScheduleResp)
 
 	var body api.Schedule
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusCreated, body)
@@ -260,6 +263,7 @@ func updateSchedule(c *gin.Context) {
 	data := []byte(ScheduleResp)
 
 	var body api.Schedule
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)

--- a/mock/server/secret.go
+++ b/mock/server/secret.go
@@ -101,6 +101,7 @@ func getSecrets(c *gin.Context) {
 	data := []byte(SecretsResp)
 
 	var body []api.Secret
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -123,6 +124,7 @@ func getSecret(c *gin.Context) {
 	data := []byte(SecretResp)
 
 	var body api.Secret
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -133,6 +135,7 @@ func addSecret(c *gin.Context) {
 	data := []byte(SecretResp)
 
 	var body api.Secret
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusCreated, body)
@@ -157,6 +160,7 @@ func updateSecret(c *gin.Context) {
 	data := []byte(SecretResp)
 
 	var body api.Secret
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)

--- a/mock/server/service.go
+++ b/mock/server/service.go
@@ -69,6 +69,7 @@ func getServices(c *gin.Context) {
 	data := []byte(ServicesResp)
 
 	var body []api.Service
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -91,6 +92,7 @@ func getService(c *gin.Context) {
 	data := []byte(ServiceResp)
 
 	var body api.Service
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -101,6 +103,7 @@ func addService(c *gin.Context) {
 	data := []byte(ServiceResp)
 
 	var body api.Service
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusCreated, body)
@@ -125,6 +128,7 @@ func updateService(c *gin.Context) {
 	data := []byte(ServiceResp)
 
 	var body api.Service
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)

--- a/mock/server/settings.go
+++ b/mock/server/settings.go
@@ -138,6 +138,7 @@ func getSettings(c *gin.Context) {
 	data := []byte(SettingsResp)
 
 	var body settings.Platform
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -148,6 +149,7 @@ func updateSettings(c *gin.Context) {
 	data := []byte(UpdateSettingsResp)
 
 	var body settings.Platform
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -158,6 +160,7 @@ func restoreSettings(c *gin.Context) {
 	data := []byte(RestoreSettingsResp)
 
 	var body settings.Platform
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)

--- a/mock/server/step.go
+++ b/mock/server/step.go
@@ -79,6 +79,7 @@ func getSteps(c *gin.Context) {
 	data := []byte(StepsResp)
 
 	var body []api.Step
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -101,6 +102,7 @@ func getStep(c *gin.Context) {
 	data := []byte(StepResp)
 
 	var body api.Step
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -111,6 +113,7 @@ func addStep(c *gin.Context) {
 	data := []byte(StepResp)
 
 	var body api.Step
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusCreated, body)
@@ -135,6 +138,7 @@ func updateStep(c *gin.Context) {
 	data := []byte(StepResp)
 
 	var body api.Step
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)

--- a/mock/server/user.go
+++ b/mock/server/user.go
@@ -54,6 +54,7 @@ func getUsers(c *gin.Context) {
 	data := []byte(UsersResp)
 
 	var body []api.User
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -76,6 +77,7 @@ func getUser(c *gin.Context) {
 	data := []byte(UserResp)
 
 	var body api.User
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -98,6 +100,7 @@ func currentUser(c *gin.Context) {
 	data := []byte(UserResp)
 
 	var body api.User
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -108,6 +111,7 @@ func addUser(c *gin.Context) {
 	data := []byte(UserResp)
 
 	var body api.User
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusCreated, body)
@@ -132,6 +136,7 @@ func updateUser(c *gin.Context) {
 	data := []byte(UserResp)
 
 	var body api.User
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)

--- a/mock/server/user_test.go
+++ b/mock/server/user_test.go
@@ -24,6 +24,7 @@ func TestUser_ActiveUserResp(t *testing.T) {
 		if tUser.Field(i).Name == "Token" || tUser.Field(i).Name == "RefreshToken" || tUser.Field(i).Name == "Hash" {
 			continue
 		}
+
 		if reflect.ValueOf(testUser).Field(i).IsNil() {
 			t.Errorf("UserResp missing field %s", tUser.Field(i).Name)
 		}

--- a/mock/server/worker.go
+++ b/mock/server/worker.go
@@ -195,6 +195,7 @@ func getWorkers(c *gin.Context) {
 	data := []byte(WorkersResp)
 
 	var body []api.Worker
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -215,6 +216,7 @@ func getWorker(c *gin.Context) {
 	data := []byte(WorkerResp)
 
 	var body api.Worker
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -225,6 +227,7 @@ func addWorker(c *gin.Context) {
 	data := []byte(AddWorkerResp)
 
 	var body api.Token
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusCreated, body)
@@ -247,6 +250,7 @@ func updateWorker(c *gin.Context) {
 	data := []byte(WorkerResp)
 
 	var body api.Worker
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -269,6 +273,7 @@ func refreshWorkerAuth(c *gin.Context) {
 	data := []byte(RefreshWorkerAuthResp)
 
 	var body api.Token
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusOK, body)
@@ -308,6 +313,7 @@ func registerToken(c *gin.Context) {
 	data := []byte(RegisterTokenResp)
 
 	var body api.Token
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusCreated, body)
@@ -330,6 +336,7 @@ func getQueueCreds(c *gin.Context) {
 	data := []byte(QueueInfoResp)
 
 	var body api.QueueInfo
+
 	_ = json.Unmarshal(data, &body)
 
 	c.JSON(http.StatusCreated, body)

--- a/queue/context_test.go
+++ b/queue/context_test.go
@@ -20,7 +20,7 @@ func TestExecutor_FromContext(t *testing.T) {
 		want    Service
 	}{
 		{
-			//nolint:revive // ignore using string with context value
+
 			context: context.WithValue(context.Background(), key, _service),
 			want:    _service,
 		},
@@ -29,7 +29,7 @@ func TestExecutor_FromContext(t *testing.T) {
 			want:    nil,
 		},
 		{
-			//nolint:revive // ignore using string with context value
+
 			context: context.WithValue(context.Background(), key, "foo"),
 			want:    nil,
 		},

--- a/queue/flags_test.go
+++ b/queue/flags_test.go
@@ -40,6 +40,7 @@ func TestDatabase_Flags(t *testing.T) {
 				t.Fatalf("unsupported flag type: %T", f)
 			}
 		}
+
 		return copiedFlags
 	}
 
@@ -125,6 +126,7 @@ func TestDatabase_Flags(t *testing.T) {
 				if len(value) == 0 {
 					continue
 				}
+
 				args = append(args, `--`+key+"="+value)
 			}
 

--- a/queue/redis/length_test.go
+++ b/queue/redis/length_test.go
@@ -57,6 +57,7 @@ func TestRedis_Length(t *testing.T) {
 				t.Errorf("unable to push item to queue: %v", err)
 			}
 		}
+
 		got, err := _redis.Length(context.Background())
 		if err != nil {
 			t.Errorf("Length returned err: %v", err)

--- a/queue/redis/opts_test.go
+++ b/queue/redis/opts_test.go
@@ -173,7 +173,6 @@ func TestRedis_ClientOpt_WithCluster(t *testing.T) {
 			WithAddress(test.address),
 			WithCluster(test.cluster),
 		)
-
 		if err != nil {
 			t.Errorf("WithCluster returned err: %v", err)
 		}

--- a/queue/redis/ping_test.go
+++ b/queue/redis/ping_test.go
@@ -33,7 +33,6 @@ func TestRedis_Ping_Good(t *testing.T) {
 
 	// run tests
 	err = goodRedis.Ping(context.Background())
-
 	if err != nil {
 		t.Errorf("Ping returned err: %v", err)
 	}

--- a/queue/redis/pop_test.go
+++ b/queue/redis/pop_test.go
@@ -21,8 +21,10 @@ func TestRedis_Pop(t *testing.T) {
 		Build: _build,
 	}
 
-	var signed []byte
-	var out []byte
+	var (
+		signed []byte
+		out    []byte
+	)
 
 	// setup queue item
 	bytes, err := json.Marshal(_item)

--- a/queue/redis/route_length_test.go
+++ b/queue/redis/route_length_test.go
@@ -56,6 +56,7 @@ func TestRedis_RouteLength(t *testing.T) {
 				t.Errorf("unable to push item to queue: %v", err)
 			}
 		}
+
 		got, err := _redis.RouteLength(context.Background(), "vela")
 		if err != nil {
 			t.Errorf("RouteLength returned err: %v", err)

--- a/router/middleware/app_webhook_secret_test.go
+++ b/router/middleware/app_webhook_secret_test.go
@@ -21,7 +21,7 @@ func TestMiddleware_AppWebhookSecret(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(AppWebhookSecret(want))

--- a/router/middleware/build/build_test.go
+++ b/router/middleware/build/build_test.go
@@ -129,7 +129,7 @@ func TestBuild_Establish(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar/builds/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar/builds/1", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -168,7 +168,7 @@ func TestBuild_Establish_NoRepo(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar/builds/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar/builds/1", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -215,7 +215,7 @@ func TestBuild_Establish_NoBuildParameter(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar/builds", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar/builds", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -267,7 +267,7 @@ func TestBuild_Establish_InvalidBuildParameter(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar/builds/foo", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar/builds/foo", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -316,7 +316,7 @@ func TestBuild_Establish_NoBuild(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar/builds/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar/builds/1", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })

--- a/router/middleware/claims/claims_test.go
+++ b/router/middleware/claims/claims_test.go
@@ -182,12 +182,13 @@ func TestClaims_Establish(t *testing.T) {
 		t.Run(tt.TokenType, func(t *testing.T) {
 			resp := httptest.NewRecorder()
 			context, engine := gin.CreateTestContext(resp)
-			context.Request, _ = http.NewRequest(http.MethodPut, tt.CtxRequest, nil)
+			context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodPut, tt.CtxRequest, nil)
 
 			var tkn string
 
 			if strings.EqualFold(tt.TokenType, constants.ServerWorkerTokenType) {
 				tkn = "very-secret"
+
 				engine.Use(func(c *gin.Context) { c.Set("secret", "very-secret") })
 			} else {
 				tkn, _ = tm.MintToken(tt.Mto)
@@ -238,7 +239,7 @@ func TestClaims_Establish_NoToken(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/workers/host", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/workers/host", nil)
 
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
 	engine.Use(func(c *gin.Context) { c.Set("token-manager", tm) })
@@ -264,7 +265,7 @@ func TestClaims_Establish_BadToken(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/workers/host", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/workers/host", nil)
 
 	u := new(api.User)
 	u.SetID(1)

--- a/router/middleware/cli_test.go
+++ b/router/middleware/cli_test.go
@@ -25,7 +25,7 @@ func TestMiddleware_CLI(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(CLI(want))

--- a/router/middleware/compiler_test.go
+++ b/router/middleware/compiler_test.go
@@ -36,6 +36,7 @@ func TestMiddleware_CompilerNative(t *testing.T) {
 	want.SetCloneImage(wantCloneImage)
 
 	var got compiler.Engine
+
 	got, _ = native.FromCLICommand(context.Background(), c)
 
 	// setup context
@@ -60,7 +61,7 @@ func TestMiddleware_CompilerNative(t *testing.T) {
 
 	engine.Use(Compiler(got))
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	engine.GET("/health", func(c *gin.Context) {
 		got = compiler.FromContext(c)

--- a/router/middleware/dashboard/dashboard_test.go
+++ b/router/middleware/dashboard/dashboard_test.go
@@ -79,7 +79,7 @@ func TestDashboard_Establish(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/c8da1302-07d6-11ea-882f-4893bca275b8", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/c8da1302-07d6-11ea-882f-4893bca275b8", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -116,7 +116,7 @@ func TestDashboard_Establish_NoDashboardParameter(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "//test", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "//test", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -147,7 +147,7 @@ func TestDashboard_Establish_NoDashboard(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/c8da1302-07d6-11ea-882f-4893bca275b8", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/c8da1302-07d6-11ea-882f-4893bca275b8", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })

--- a/router/middleware/database_test.go
+++ b/router/middleware/database_test.go
@@ -28,7 +28,7 @@ func TestMiddleware_Database(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(Database(want))

--- a/router/middleware/default_build_limit_test.go
+++ b/router/middleware/default_build_limit_test.go
@@ -22,7 +22,7 @@ func TestMiddleware_DefaultBuildLimit(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(DefaultBuildLimit(want))

--- a/router/middleware/default_repo_settings_test.go
+++ b/router/middleware/default_repo_settings_test.go
@@ -24,7 +24,7 @@ func TestMiddleware_DefaultRepoEvents(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(DefaultRepoEvents(want))
@@ -57,7 +57,7 @@ func TestMiddleware_DefaultRepoEventsMask(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(DefaultRepoEventsMask(want))
@@ -90,7 +90,7 @@ func TestMiddleware_DefaultRepoApproveBuild(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(DefaultRepoApproveBuild(want))

--- a/router/middleware/default_timeout_test.go
+++ b/router/middleware/default_timeout_test.go
@@ -22,7 +22,7 @@ func TestMiddleware_DefaultTimeout(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(DefaultTimeout(want))

--- a/router/middleware/header_test.go
+++ b/router/middleware/header_test.go
@@ -26,7 +26,7 @@ func TestMiddleware_NoCache(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(NoCache)
@@ -76,7 +76,7 @@ func TestMiddleware_Options(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodOptions, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodOptions, "/health", nil)
 
 	// setup mock server
 	engine.Use(Metadata(m))
@@ -132,7 +132,7 @@ func TestMiddleware_Options_InvalidMethod(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(Metadata(m))
@@ -241,9 +241,10 @@ func TestMiddleware_Cors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gin.SetMode(gin.TestMode)
+
 			resp := httptest.NewRecorder()
 			context, engine := gin.CreateTestContext(resp)
-			context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+			context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 			context.Request.Header.Add("Origin", tt.origin)
 
 			// inject metadata
@@ -286,7 +287,7 @@ func TestMiddleware_Secure(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(Secure)
@@ -330,7 +331,7 @@ func TestMiddleware_Secure_TLS(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 	context.Request.TLS = new(tls.ConnectionState)
 
 	// setup mock server

--- a/router/middleware/hook/hook_test.go
+++ b/router/middleware/hook/hook_test.go
@@ -105,7 +105,7 @@ func TestHook_Establish(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/hooks/foo/bar/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/hooks/foo/bar/1", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -144,7 +144,7 @@ func TestHook_Establish_NoRepo(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/hooks/foo/bar/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/hooks/foo/bar/1", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -194,7 +194,7 @@ func TestHook_Establish_NoHookParameter(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/hooks/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/hooks/foo/bar", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -246,7 +246,7 @@ func TestHook_Establish_InvalidHookParameter(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/hooks/foo/bar/foo", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/hooks/foo/bar/foo", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -295,7 +295,7 @@ func TestHook_Establish_NoHook(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/hooks/foo/bar/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/hooks/foo/bar/1", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })

--- a/router/middleware/logger_test.go
+++ b/router/middleware/logger_test.go
@@ -75,7 +75,7 @@ func TestMiddleware_Logger(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodPost, "/foobar", bytes.NewBuffer(payload))
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodPost, "/foobar", bytes.NewBuffer(payload))
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { build.ToContext(c, b) })
@@ -130,7 +130,7 @@ func TestMiddleware_Logger_Error(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foobar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foobar", nil)
 
 	// setup mock server
 	engine.Use(Logger(logger, time.RFC3339))

--- a/router/middleware/max_build_limit_test.go
+++ b/router/middleware/max_build_limit_test.go
@@ -22,7 +22,7 @@ func TestMiddleware_MaxBuildLimit(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(MaxBuildLimit(want))

--- a/router/middleware/metadata_test.go
+++ b/router/middleware/metadata_test.go
@@ -23,7 +23,7 @@ func TestMiddleware_Metadata(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(Metadata(want))

--- a/router/middleware/org/org_test.go
+++ b/router/middleware/org/org_test.go
@@ -72,7 +72,7 @@ func TestOrg_Establish(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -109,7 +109,7 @@ func TestOrg_Establish_NoOrgParameter(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "//test", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "//test", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })

--- a/router/middleware/payload.go
+++ b/router/middleware/payload.go
@@ -16,6 +16,7 @@ func Payload() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// bind JSON payload from request to be added to context
 		var payload interface{}
+
 		_ = c.BindJSON(&payload)
 
 		body, _ := json.Marshal(&payload)

--- a/router/middleware/payload_test.go
+++ b/router/middleware/payload_test.go
@@ -25,7 +25,7 @@ func TestMiddleware_Payload(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodPost, "/health", bytes.NewBuffer(jsonBody))
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodPost, "/health", bytes.NewBuffer(jsonBody))
 
 	// setup mock server
 	engine.Use(Payload())

--- a/router/middleware/perm/perm_test.go
+++ b/router/middleware/perm/perm_test.go
@@ -69,7 +69,7 @@ func TestPerm_MustPlatformAdmin(t *testing.T) {
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/admin/users", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/users", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup github mock server
@@ -150,7 +150,7 @@ func TestPerm_MustPlatformAdmin_NotAdmin(t *testing.T) {
 
 	_, _ = db.CreateUser(_context.TODO(), u)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/admin/users", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/users", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup github mock server
@@ -212,7 +212,7 @@ func TestPerm_MustWorkerRegisterToken(t *testing.T) {
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup vela mock server
@@ -276,7 +276,7 @@ func TestPerm_MustWorkerRegisterToken_PlatAdmin(t *testing.T) {
 
 	_, _ = db.CreateUser(_context.TODO(), u)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup vela mock server
@@ -325,7 +325,7 @@ func TestPerm_MustWorkerAuthToken(t *testing.T) {
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup vela mock server
@@ -366,7 +366,7 @@ func TestPerm_MustWorkerAuth_ServerWorkerToken(t *testing.T) {
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", secret))
 
 	// setup vela mock server
@@ -451,7 +451,7 @@ func TestPerm_MustBuildAccess(t *testing.T) {
 	_, _ = db.CreateRepo(ctx, r)
 	_, _ = db.CreateBuild(ctx, b)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar/builds/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar/builds/1", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup vela mock server
@@ -546,7 +546,7 @@ func TestPerm_MustBuildAccess_PlatAdmin(t *testing.T) {
 	_, _ = db.CreateBuild(ctx, b)
 	_, _ = db.CreateUser(ctx, u)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar/builds/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar/builds/1", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup vela mock server
@@ -638,7 +638,7 @@ func TestPerm_MustBuildToken_WrongBuild(t *testing.T) {
 	_, _ = db.CreateRepo(ctx, r)
 	_, _ = db.CreateBuild(ctx, b)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar/builds/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar/builds/1", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup vela mock server
@@ -732,7 +732,7 @@ func TestPerm_MustIDRequestToken(t *testing.T) {
 	_, _ = db.CreateRepo(ctx, r)
 	_, _ = db.CreateBuild(ctx, b)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar/builds/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar/builds/1", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup vela mock server
@@ -831,7 +831,7 @@ func TestPerm_MustIDRequestToken_NotRunning(t *testing.T) {
 	_, _ = db.CreateBuild(ctx, b)
 	_, _ = db.CreateUser(ctx, u)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar/builds/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar/builds/1", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup vela mock server
@@ -923,7 +923,7 @@ func TestPerm_MustIDRequestToken_WrongBuild(t *testing.T) {
 	_, _ = db.CreateRepo(ctx, r)
 	_, _ = db.CreateBuild(ctx, b)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar/builds/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar/builds/1", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup vela mock server
@@ -1012,7 +1012,7 @@ func TestPerm_MustSecretAdmin_BuildToken_Repo(t *testing.T) {
 	_, _ = db.CreateRepo(ctx, r)
 	_, _ = db.CreateBuild(ctx, b)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/native/repo/foo/bar/baz", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/native/repo/foo/bar/baz", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup vela mock server
@@ -1098,7 +1098,7 @@ func TestPerm_MustSecretAdmin_BuildToken_Org(t *testing.T) {
 	_, _ = db.CreateRepo(ctx, r)
 	_, _ = db.CreateBuild(ctx, b)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/native/org/foo/*/baz", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/native/org/foo/*/baz", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup vela mock server
@@ -1184,7 +1184,7 @@ func TestPerm_MustSecretAdmin_BuildToken_Shared(t *testing.T) {
 	_, _ = db.CreateRepo(ctx, r)
 	_, _ = db.CreateBuild(ctx, b)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/native/shared/foo/*/*", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/native/shared/foo/*/*", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup vela mock server
@@ -1267,7 +1267,7 @@ func TestPerm_MustAdmin(t *testing.T) {
 	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateUser(_context.TODO(), u)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup github mock server
@@ -1367,7 +1367,7 @@ func TestPerm_MustAdmin_PlatAdmin(t *testing.T) {
 	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateUser(_context.TODO(), u)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup github mock server
@@ -1467,7 +1467,7 @@ func TestPerm_MustAdmin_NotAdmin(t *testing.T) {
 	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateUser(_context.TODO(), u)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup github mock server
@@ -1567,7 +1567,7 @@ func TestPerm_MustWrite(t *testing.T) {
 	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateUser(_context.TODO(), u)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup github mock server
@@ -1667,7 +1667,7 @@ func TestPerm_MustWrite_PlatAdmin(t *testing.T) {
 	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateUser(_context.TODO(), u)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup github mock server
@@ -1767,7 +1767,7 @@ func TestPerm_MustWrite_RepoAdmin(t *testing.T) {
 	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateUser(_context.TODO(), u)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup github mock server
@@ -1867,7 +1867,7 @@ func TestPerm_MustWrite_NotWrite(t *testing.T) {
 	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateUser(_context.TODO(), u)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup github mock server
@@ -1967,7 +1967,7 @@ func TestPerm_MustRead(t *testing.T) {
 	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateUser(_context.TODO(), u)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup github mock server
@@ -2067,7 +2067,7 @@ func TestPerm_MustRead_PlatAdmin(t *testing.T) {
 	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateUser(_context.TODO(), u)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup github mock server
@@ -2170,7 +2170,7 @@ func TestPerm_MustRead_WorkerBuildToken(t *testing.T) {
 	_, _ = db.CreateBuild(ctx, b)
 	_, _ = db.CreateRepo(ctx, r)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar/builds/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar/builds/1", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup vela mock server
@@ -2256,7 +2256,7 @@ func TestPerm_MustRead_RepoAdmin(t *testing.T) {
 	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateUser(_context.TODO(), u)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup github mock server
@@ -2356,7 +2356,7 @@ func TestPerm_MustRead_RepoWrite(t *testing.T) {
 	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateUser(_context.TODO(), u)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup github mock server
@@ -2456,7 +2456,7 @@ func TestPerm_MustRead_RepoPublic(t *testing.T) {
 	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateUser(_context.TODO(), u)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup github mock server
@@ -2556,7 +2556,7 @@ func TestPerm_MustRead_NotRead(t *testing.T) {
 	_, _ = db.CreateRepo(_context.TODO(), r)
 	_, _ = db.CreateUser(_context.TODO(), u)
 
-	context.Request, _ = http.NewRequest(http.MethodGet, "/test/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/test/foo/bar", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tok))
 
 	// setup github mock server

--- a/router/middleware/pipeline/pipeline_test.go
+++ b/router/middleware/pipeline/pipeline_test.go
@@ -124,7 +124,7 @@ func TestPipeline_Establish(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/pipelines/foo/bar/48afb5bdc41ad69bf22588491333f7cf71135163", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/pipelines/foo/bar/48afb5bdc41ad69bf22588491333f7cf71135163", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -163,7 +163,7 @@ func TestPipeline_Establish_NoRepo(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/pipelines/foo/bar/48afb5bdc41ad69bf22588491333f7cf71135163", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/pipelines/foo/bar/48afb5bdc41ad69bf22588491333f7cf71135163", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -210,7 +210,7 @@ func TestPipeline_Establish_NoPipelineParameter(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/pipelines/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/pipelines/foo/bar", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -322,7 +322,7 @@ func TestPipeline_Establish_NoPipeline(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/pipelines/foo/bar/148afb5bdc41ad69bf22588491333f7cf71135163", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/pipelines/foo/bar/148afb5bdc41ad69bf22588491333f7cf71135163", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", at))
 
 	// setup github mock server

--- a/router/middleware/queue_test.go
+++ b/router/middleware/queue_test.go
@@ -26,7 +26,7 @@ func TestMiddleware_Queue(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(Queue(want))

--- a/router/middleware/repo/repo_test.go
+++ b/router/middleware/repo/repo_test.go
@@ -92,7 +92,7 @@ func TestRepo_Establish(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -130,7 +130,7 @@ func TestRepo_Establish_NoOrgParameter(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "//bar/test", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "//bar/test", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -161,7 +161,7 @@ func TestRepo_Establish_NoRepoParameter(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo//test", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo//test", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -192,7 +192,7 @@ func TestRepo_Establish_NoRepo(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })

--- a/router/middleware/schedule_frequency_test.go
+++ b/router/middleware/schedule_frequency_test.go
@@ -15,6 +15,7 @@ import (
 func TestMiddleware_ScheduleFrequency(t *testing.T) {
 	// setup types
 	var got time.Duration
+
 	want := 30 * time.Minute
 
 	// setup context
@@ -22,7 +23,7 @@ func TestMiddleware_ScheduleFrequency(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(ScheduleFrequency(want))

--- a/router/middleware/scm_test.go
+++ b/router/middleware/scm_test.go
@@ -28,7 +28,7 @@ func TestMiddleware_Scm(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(Scm(want))

--- a/router/middleware/secret_test.go
+++ b/router/middleware/secret_test.go
@@ -25,7 +25,7 @@ func TestMiddleware_Secret(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(Secret(want))
@@ -67,7 +67,7 @@ func TestMiddleware_Secrets(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(Secrets(s))

--- a/router/middleware/secure_cookie_test.go
+++ b/router/middleware/secure_cookie_test.go
@@ -46,7 +46,7 @@ func TestCookie_SecureCookie(t *testing.T) {
 
 			resp := httptest.NewRecorder()
 			context, engine := gin.CreateTestContext(resp)
-			context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+			context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 			engine.Use(SecureCookie(tt.args.secure))
 			engine.GET("/health", func(c *gin.Context) {

--- a/router/middleware/service/service_test.go
+++ b/router/middleware/service/service_test.go
@@ -97,7 +97,7 @@ func TestService_Establish(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar/builds/1/services/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar/builds/1/services/1", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -137,7 +137,7 @@ func TestService_Establish_NoRepo(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar/builds/1/services/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar/builds/1/services/1", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -184,7 +184,7 @@ func TestService_Establish_NoBuild(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar/builds/1/services/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar/builds/1/services/1", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -243,7 +243,7 @@ func TestService_Establish_NoServiceParameter(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar/builds/1/services", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar/builds/1/services", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -303,7 +303,7 @@ func TestService_Establish_InvalidServiceParameter(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar/builds/1/services/foo", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar/builds/1/services/foo", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -360,7 +360,7 @@ func TestService_Establish_NoService(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar/builds/1/services/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar/builds/1/services/1", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })

--- a/router/middleware/settings_test.go
+++ b/router/middleware/settings_test.go
@@ -25,7 +25,7 @@ func TestMiddleware_Settings(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(Settings(&want))

--- a/router/middleware/signing_test.go
+++ b/router/middleware/signing_test.go
@@ -21,7 +21,7 @@ func TestMiddleware_QueueSigningPrivateKey(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(QueueSigningPrivateKey(want))
@@ -53,7 +53,7 @@ func TestMiddleware_QueueSigningPublicKey(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(QueueSigningPublicKey(want))
@@ -85,7 +85,7 @@ func TestMiddleware_QueueAddress(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(QueueAddress(want))

--- a/router/middleware/step/step_test.go
+++ b/router/middleware/step/step_test.go
@@ -100,7 +100,7 @@ func TestStep_Establish(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar/builds/1/steps/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar/builds/1/steps/1", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -140,7 +140,7 @@ func TestStep_Establish_NoRepo(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar/builds/1/steps/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar/builds/1/steps/1", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -190,7 +190,7 @@ func TestStep_Establish_NoBuild(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar/builds/1/steps/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar/builds/1/steps/1", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -249,7 +249,7 @@ func TestStep_Establish_NoStepParameter(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar/builds/1/steps", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar/builds/1/steps", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -309,7 +309,7 @@ func TestStep_Establish_InvalidStepParameter(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar/builds/1/steps/foo", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar/builds/1/steps/foo", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -369,7 +369,7 @@ func TestStep_Establish_NoStep(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/foo/bar/builds/1/steps/1", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/foo/bar/builds/1/steps/1", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })

--- a/router/middleware/token_manager_test.go
+++ b/router/middleware/token_manager_test.go
@@ -28,7 +28,7 @@ func TestMiddleware_TokenManager(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(TokenManager(want))

--- a/router/middleware/tracing/tracing_test.go
+++ b/router/middleware/tracing/tracing_test.go
@@ -52,7 +52,7 @@ func TestTracing_Establish(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/hello", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })

--- a/router/middleware/tracing_test.go
+++ b/router/middleware/tracing_test.go
@@ -19,6 +19,7 @@ import (
 func TestMiddleware_TracingClient(t *testing.T) {
 	// setup types
 	var got *tracing.Client
+
 	want := &tracing.Client{
 		Config: tracing.Config{
 			EnableTracing: true,
@@ -30,7 +31,7 @@ func TestMiddleware_TracingClient(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(TracingClient(want))
@@ -93,7 +94,7 @@ func TestMiddleware_TracingInstrumentation(t *testing.T) {
 		got := trace.SpanContext{}
 		resp := httptest.NewRecorder()
 		context, engine := gin.CreateTestContext(resp)
-		context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+		context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 		// setup mock server
 		engine.Use(TracingInstrumentation(test.tc))

--- a/router/middleware/user/user_test.go
+++ b/router/middleware/user/user_test.go
@@ -68,7 +68,7 @@ func TestUser_Establish(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/users/foo", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/users/foo", nil)
 
 	mto := &token.MintTokenOpts{
 		User:          want,
@@ -160,7 +160,7 @@ func TestUser_Establish_NoToken(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/users/foo", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/users/foo", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -197,7 +197,7 @@ func TestUser_Establish_DiffTokenType(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/users/foo", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/users/foo", nil)
 	context.Request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", secret))
 
 	// setup vela mock server
@@ -249,7 +249,7 @@ func TestUser_Establish_NoAuthorizeUser(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/users/foo?access_token=bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/users/foo?access_token=bar", nil)
 
 	// setup client
 	client, _ := github.NewTest("")
@@ -298,7 +298,7 @@ func TestUser_Establish_NoUser(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/users/foo?access_token=bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/users/foo?access_token=bar", nil)
 
 	mto := &token.MintTokenOpts{
 		User:          u,

--- a/router/middleware/webhook_validation_test.go
+++ b/router/middleware/webhook_validation_test.go
@@ -46,7 +46,7 @@ func TestWebhook_WebhookValidation(t *testing.T) {
 
 			resp := httptest.NewRecorder()
 			context, engine := gin.CreateTestContext(resp)
-			context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+			context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 			engine.Use(WebhookValidation(tt.args.validate))
 			engine.GET("/health", func(c *gin.Context) {

--- a/router/middleware/worker/worker_test.go
+++ b/router/middleware/worker/worker_test.go
@@ -73,7 +73,7 @@ func TestWorker_Establish(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/workers/worker_0", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/workers/worker_0", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })
@@ -110,7 +110,7 @@ func TestWorker_Establish_NoWorkerParameter(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/workers/", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/workers/", nil)
 
 	// setup mock server
 	engine.Use(func(c *gin.Context) { c.Set("logger", logrus.NewEntry(logrus.StandardLogger())) })

--- a/router/middleware/worker_test.go
+++ b/router/middleware/worker_test.go
@@ -23,7 +23,7 @@ func TestMiddleware_Worker(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/health", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 
 	// setup mock server
 	engine.Use(Worker(want))

--- a/schema/pipeline_test.go
+++ b/schema/pipeline_test.go
@@ -24,13 +24,16 @@ func TestSchema_NewPipelineSchema(t *testing.T) {
 				t.Errorf("NewPipelineSchema() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+
 			if !tt.wantErr && got == nil {
 				t.Error("NewPipelineSchema() returned nil schema without error")
 			}
+
 			if !tt.wantErr {
 				if got.Title != "Vela Pipeline Configuration" {
 					t.Errorf("NewPipelineSchema() title = %v, want %v", got.Title, "Vela Pipeline Configuration")
 				}
+
 				if got.AdditionalProperties != nil {
 					t.Error("NewPipelineSchema() AdditionalProperties should be nil")
 				}

--- a/scm/flags_test.go
+++ b/scm/flags_test.go
@@ -43,6 +43,7 @@ func TestDatabase_Flags(t *testing.T) {
 				t.Fatalf("unsupported flag type: %T", f)
 			}
 		}
+
 		return copiedFlags
 	}
 
@@ -343,6 +344,7 @@ func TestDatabase_Flags(t *testing.T) {
 				if len(value) == 0 {
 					continue
 				}
+
 				args = append(args, `--`+key+"="+value)
 			}
 

--- a/scm/github/access_test.go
+++ b/scm/github/access_test.go
@@ -115,7 +115,6 @@ func TestGithub_OrgAccess_NotFound(t *testing.T) {
 
 	// run test
 	got, err := client.OrgAccess(context.TODO(), u, "github")
-
 	if err == nil {
 		t.Errorf("OrgAccess should have returned err")
 	}
@@ -183,7 +182,6 @@ func TestGithub_OrgAccess_Personal(t *testing.T) {
 
 	// run test
 	got, err := client.OrgAccess(context.TODO(), u, "foo")
-
 	if err != nil {
 		t.Errorf("OrgAccess returned err: %v", err)
 	}
@@ -251,7 +249,6 @@ func TestGithub_RepoAccess_NotFound(t *testing.T) {
 
 	// run test
 	got, err := client.RepoAccess(context.TODO(), "foo", u.GetToken(), "github", "octocat")
-
 	if err == nil {
 		t.Errorf("RepoAccess should have returned err")
 	}
@@ -361,7 +358,6 @@ func TestGithub_TeamAccess_NotFound(t *testing.T) {
 
 	// run test
 	got, err := client.TeamAccess(context.TODO(), u, "github", "octocat")
-
 	if err == nil {
 		t.Errorf("TeamAccess should have returned err")
 	}

--- a/scm/github/app_permissions_test.go
+++ b/scm/github/app_permissions_test.go
@@ -49,6 +49,7 @@ func TestGetInstallationPermission(t *testing.T) {
 				t.Errorf("GetInstallationPermission() error = %v, expectedError %v", err, tt.expectedError)
 				return
 			}
+
 			if perm != tt.expectedPerm {
 				t.Errorf("GetInstallationPermission() = %v, expected %v", perm, tt.expectedPerm)
 			}
@@ -115,6 +116,7 @@ func TestApplyInstallationPermissions(t *testing.T) {
 				t.Errorf("ApplyInstallationPermissions() error = %v, expectedError %v", err, tt.expectedError)
 				return
 			}
+
 			if !tt.expectedError && !comparePermissions(perms, tt.expectedPerms) {
 				t.Errorf("ApplyInstallationPermissions() = %v, expected %v", perms, tt.expectedPerms)
 			}
@@ -191,5 +193,6 @@ func comparePermissions(a, b *github.InstallationPermissions) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
+
 	return github.Stringify(a) == github.Stringify(b)
 }

--- a/scm/github/app_transport.go
+++ b/scm/github/app_transport.go
@@ -207,7 +207,7 @@ func (t *Transport) refreshToken(ctx context.Context) error {
 
 	requestURL := fmt.Sprintf("%s/app/installations/%v/access_tokens", strings.TrimRight(t.BaseURL, "/"), t.installationID)
 
-	req, err := http.NewRequest("POST", requestURL, body)
+	req, err := http.NewRequestWithContext(ctx, "POST", requestURL, body)
 	if err != nil {
 		return fmt.Errorf("could not create request: %w", err)
 	}

--- a/scm/github/app_transport_test.go
+++ b/scm/github/app_transport_test.go
@@ -156,11 +156,13 @@ func TestAppsTransport_RoundTrip(t *testing.T) {
 				t.Errorf("RoundTrip() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+
 			if !tt.wantErr {
 				if got := tt.request.Header.Get("Authorization"); !strings.HasPrefix(got, tt.wantHeader) {
 					t.Errorf("RoundTrip() Authorization header = %v, want prefix %v", got, tt.wantHeader)
 				}
 			}
+
 			if resp != nil {
 				resp.Body.Close()
 			}

--- a/scm/github/authentication_test.go
+++ b/scm/github/authentication_test.go
@@ -20,7 +20,7 @@ func TestGithub_Authenticate(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/login/oauth/authorize?code=foo&state=bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/login/oauth/authorize?code=foo&state=bar", nil)
 
 	// setup mock server
 	engine.POST("/login/oauth/access_token", func(c *gin.Context) {
@@ -66,7 +66,7 @@ func TestGithub_Authenticate_NoCode(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/login", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/login", nil)
 
 	// setup mock server
 	engine.Any("/", func(c *gin.Context) {
@@ -101,7 +101,7 @@ func TestGithub_Authenticate_NoState(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/login?code=foo", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/login?code=foo", nil)
 
 	// setup mock server
 	engine.Any("/", func(c *gin.Context) {
@@ -136,7 +136,7 @@ func TestGithub_Authenticate_BadToken(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/login?code=foo&state=bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/login?code=foo&state=bar", nil)
 
 	// setup mock server
 	engine.Any("/", func(c *gin.Context) {
@@ -171,7 +171,7 @@ func TestGithub_Authenticate_NotFound(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/login/oauth/authorize?code=foo&state=bar", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/login/oauth/authorize?code=foo&state=bar", nil)
 
 	// setup mock server
 	engine.POST("/login/oauth/access_token", func(c *gin.Context) {
@@ -282,7 +282,7 @@ func TestGithub_Login(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/login", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/login", nil)
 
 	// setup mock server
 	engine.Any("/", func(c *gin.Context) {
@@ -313,7 +313,7 @@ func TestGithub_AuthenticateToken(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodPost, "/authenticate/token", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodPost, "/authenticate/token", nil)
 	context.Request.Header.Set("Token", "foo")
 
 	engine.GET("/api/v3/user", func(c *gin.Context) {
@@ -354,7 +354,7 @@ func TestGithub_AuthenticateToken_Invalid(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodPost, "/authenticate/token", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodPost, "/authenticate/token", nil)
 	context.Request.Header.Set("Token", "foo")
 
 	// setup mock server
@@ -390,7 +390,7 @@ func TestGithub_AuthenticateToken_Vela_OAuth(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodPost, "/authenticate/token", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodPost, "/authenticate/token", nil)
 	context.Request.Header.Set("Token", "vela")
 
 	engine.GET("/api/v3/user", func(c *gin.Context) {
@@ -427,7 +427,7 @@ func TestGithub_ValidateOAuthToken_Valid(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/validate-oauth", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/validate-oauth", nil)
 
 	token := "foobar"
 	want := true
@@ -461,7 +461,7 @@ func TestGithub_ValidateOAuthToken_Invalid(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/validate-oauth", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/validate-oauth", nil)
 
 	token := "foobar"
 	want := false
@@ -496,7 +496,7 @@ func TestGithub_ValidateOAuthToken_Error(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodGet, "/validate-oauth", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, "/validate-oauth", nil)
 
 	token := "foobar"
 	want := false
@@ -530,7 +530,7 @@ func TestGithub_LoginWCreds(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	context, engine := gin.CreateTestContext(resp)
-	context.Request, _ = http.NewRequest(http.MethodPost, "/login", nil)
+	context.Request, _ = http.NewRequestWithContext(t.Context(), http.MethodPost, "/login", nil)
 
 	// setup mock server
 	engine.Any("/", func(c *gin.Context) {

--- a/scm/github/github_client_test.go
+++ b/scm/github/github_client_test.go
@@ -120,6 +120,7 @@ func TestClient_installationCanReadRepo(t *testing.T) {
 				t.Errorf("installationCanReadRepo() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+
 			if got != tt.want {
 				t.Errorf("installationCanReadRepo() = %v, want %v", got, tt.want)
 			}

--- a/scm/github/opts_test.go
+++ b/scm/github/opts_test.go
@@ -39,7 +39,6 @@ func TestGithub_ClientOpt_WithAddress(t *testing.T) {
 		_service, err := New(context.Background(),
 			WithAddress(test.address),
 		)
-
 		if err != nil {
 			t.Errorf("WithAddress returned err: %v", err)
 		}
@@ -300,7 +299,6 @@ func TestGithub_ClientOpt_WithWebUIAddress(t *testing.T) {
 		_service, err := New(context.Background(),
 			WithWebUIAddress(test.address),
 		)
-
 		if err != nil {
 			t.Errorf("WithWebUIAddress returned err: %v", err)
 		}

--- a/scm/github/org_test.go
+++ b/scm/github/org_test.go
@@ -123,7 +123,6 @@ func TestGithub_GetOrgName_Fail(t *testing.T) {
 
 	// run test
 	_, err := client.GetOrgName(context.TODO(), u, "octocat")
-
 	if err == nil {
 		t.Error("GetOrgName should return error")
 	}

--- a/scm/github/repo_test.go
+++ b/scm/github/repo_test.go
@@ -34,6 +34,7 @@ func TestGithub_Config_YML(t *testing.T) {
 			c.Header("Content-Type", "application/json")
 			c.Status(http.StatusOK)
 			c.File("testdata/yml.json")
+
 			return
 		}
 
@@ -92,6 +93,7 @@ func TestGithub_ConfigBackoff_YML(t *testing.T) {
 			c.Header("Content-Type", "application/json")
 			c.Status(http.StatusOK)
 			c.File("testdata/yml.json")
+
 			return
 		}
 
@@ -149,6 +151,7 @@ func TestGithub_Config_YAML(t *testing.T) {
 			c.Header("Content-Type", "application/json")
 			c.Status(http.StatusOK)
 			c.File("testdata/yaml.json")
+
 			return
 		}
 
@@ -203,6 +206,7 @@ func TestGithub_Config_Star(t *testing.T) {
 			c.Header("Content-Type", "application/json")
 			c.Status(http.StatusOK)
 			c.File("testdata/star.json")
+
 			return
 		}
 
@@ -318,6 +322,7 @@ func TestGithub_Config_Py(t *testing.T) {
 			c.Header("Content-Type", "application/json")
 			c.Status(http.StatusOK)
 			c.File("testdata/py.json")
+
 			return
 		}
 
@@ -464,6 +469,7 @@ func TestGithub_Config_BadEncoding(t *testing.T) {
 			c.Header("Content-Type", "application/json")
 			c.Status(http.StatusOK)
 			c.File("testdata/yml_bad_encoding.json")
+
 			return
 		}
 
@@ -629,6 +635,7 @@ func TestGithub_Disable_MultipleHooks(t *testing.T) {
 	})
 	engine.DELETE("/api/v3/repos/:org/:repo/hooks/:hook_id", func(c *gin.Context) {
 		count++
+
 		c.Status(http.StatusNoContent)
 	})
 
@@ -1346,7 +1353,6 @@ func TestGithub_GetRepo_Fail(t *testing.T) {
 
 	// run test
 	_, code, err := client.GetRepo(context.TODO(), u, r)
-
 	if err == nil {
 		t.Error("GetRepo should return error")
 	}
@@ -1428,7 +1434,6 @@ func TestGithub_GetOrgAndRepoName_Fail(t *testing.T) {
 
 	// run test
 	_, _, err := client.GetOrgAndRepoName(context.TODO(), u, "octocat", "Hello-World")
-
 	if err == nil {
 		t.Error("GetRepoName should return error")
 	}
@@ -1785,6 +1790,7 @@ func TestGithub_GetNetrcPassword(t *testing.T) {
 				t.Errorf("GetNetrcPassword() error = %v, wantErr %v", err, test.wantErr)
 				return
 			}
+
 			if got != test.wantToken {
 				t.Errorf("GetNetrcPassword() = %v, want %v", got, test.wantToken)
 			}
@@ -1933,6 +1939,7 @@ func TestGithub_applyGitHubInstallationPermission(t *testing.T) {
 				t.Errorf("ToGitHubAppInstallationPermissions() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+
 			if diff := cmp.Diff(tt.wantPerms, got); diff != "" {
 				t.Errorf("ToGitHubAppInstallationPermissions() mismatch (-want +got):\n%s", diff)
 			}

--- a/scm/github/webhook.go
+++ b/scm/github/webhook.go
@@ -115,7 +115,6 @@ func (c *Client) RedeliverWebhook(ctx context.Context, u *api.User, h *api.Hook)
 		h.GetRepo().GetName(),
 		h.GetWebhookID(), deliveryID,
 	)
-
 	if err != nil {
 		var acceptedError *github.AcceptedError
 		// Persist if the status received is a 202 Accepted. This

--- a/scm/github/webhook_test.go
+++ b/scm/github/webhook_test.go
@@ -89,7 +89,6 @@ func TestGithub_ProcessWebhook_Push(t *testing.T) {
 	}
 
 	got, err := client.ProcessWebhook(context.TODO(), request)
-
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
 	}
@@ -169,7 +168,6 @@ func TestGithub_ProcessWebhook_Push_NoSender(t *testing.T) {
 	}
 
 	got, err := client.ProcessWebhook(context.TODO(), request)
-
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
 	}
@@ -248,7 +246,6 @@ func TestGithub_ProcessWebhook_Push_Branch_Delete(t *testing.T) {
 	}
 
 	got, err := client.ProcessWebhook(context.TODO(), request)
-
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
 	}
@@ -327,7 +324,6 @@ func TestGithub_ProcessWebhook_Push_Tag_Delete(t *testing.T) {
 	}
 
 	got, err := client.ProcessWebhook(context.TODO(), request)
-
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
 	}
@@ -670,6 +666,7 @@ func TestGithub_ProcessWebhook_Deployment(t *testing.T) {
 			request.Header.Set("X-GitHub-Event", "deployment")
 
 			client, _ := NewTest(s.URL)
+
 			wantBuild.SetDeployPayload(tt.args.deploymentPayload)
 
 			want := &internal.Webhook{
@@ -778,7 +775,6 @@ func TestGithub_ProcessWebhook_Deployment_Commit(t *testing.T) {
 	}
 
 	got, err := client.ProcessWebhook(context.TODO(), request)
-
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
 	}
@@ -831,7 +827,6 @@ func TestGithub_ProcessWebhook_BadGithubEvent(t *testing.T) {
 	}
 
 	got, err := client.ProcessWebhook(context.TODO(), request)
-
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
 	}
@@ -884,7 +879,6 @@ func TestGithub_ProcessWebhook_BadContentType(t *testing.T) {
 	}
 
 	got, err := client.ProcessWebhook(context.TODO(), request)
-
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
 	}
@@ -1038,7 +1032,6 @@ func TestGithub_ProcessWebhook_IssueComment_PR(t *testing.T) {
 	}
 
 	got, err := client.ProcessWebhook(context.TODO(), request)
-
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
 	}
@@ -1089,7 +1082,6 @@ func TestGithub_ProcessWebhook_IssueComment_Created(t *testing.T) {
 	}
 
 	got, err := client.ProcessWebhook(context.TODO(), request)
-
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
 	}
@@ -1140,7 +1132,6 @@ func TestGithub_ProcessWebhook_IssueComment_Deleted(t *testing.T) {
 	}
 
 	got, err := client.ProcessWebhook(context.TODO(), request)
-
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
 	}
@@ -1204,7 +1195,6 @@ func TestGitHub_ProcessWebhook_RepositoryRename(t *testing.T) {
 	}
 
 	got, err := client.ProcessWebhook(context.TODO(), request)
-
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
 	}
@@ -1268,7 +1258,6 @@ func TestGitHub_ProcessWebhook_RepositoryTransfer(t *testing.T) {
 	}
 
 	got, err := client.ProcessWebhook(context.TODO(), request)
-
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
 	}
@@ -1332,7 +1321,6 @@ func TestGitHub_ProcessWebhook_RepositoryArchived(t *testing.T) {
 	}
 
 	got, err := client.ProcessWebhook(context.TODO(), request)
-
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
 	}
@@ -1396,7 +1384,6 @@ func TestGitHub_ProcessWebhook_RepositoryEdited(t *testing.T) {
 	}
 
 	got, err := client.ProcessWebhook(context.TODO(), request)
-
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
 	}
@@ -1460,7 +1447,6 @@ func TestGitHub_ProcessWebhook_Repository(t *testing.T) {
 	}
 
 	got, err := client.ProcessWebhook(context.TODO(), request)
-
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
 	}
@@ -1523,7 +1509,6 @@ func TestGitHub_ProcessWebhook_CustomPropertyValuesUpdated(t *testing.T) {
 	}
 
 	got, err := client.ProcessWebhook(context.TODO(), request)
-
 	if err != nil {
 		t.Errorf("ProcessWebhook returned err: %v", err)
 	}
@@ -1577,7 +1562,6 @@ func TestGithub_Redeliver_Webhook(t *testing.T) {
 
 	// run test
 	err := client.RedeliverWebhook(context.TODO(), u, _hook)
-
 	if err != nil {
 		t.Errorf("RedeliverWebhook returned err: %v", err)
 	}
@@ -1625,7 +1609,6 @@ func TestGithub_GetDeliveryID(t *testing.T) {
 
 	// run test
 	got, err := client.getDeliveryID(context.TODO(), ghClient, _hook)
-
 	if err != nil {
 		t.Errorf("RedeliverWebhook returned err: %v", err)
 	}
@@ -1709,7 +1692,6 @@ func TestGitHub_ProcessWebhook_Installation(t *testing.T) {
 		}
 
 		got, err := client.ProcessWebhook(context.TODO(), request)
-
 		if err != nil {
 			t.Errorf("ProcessWebhook returned err: %v", err)
 		}
@@ -1801,7 +1783,6 @@ func TestGitHub_ProcessWebhook_InstallationRepositories(t *testing.T) {
 		}
 
 		got, err := client.ProcessWebhook(context.TODO(), request)
-
 		if err != nil {
 			t.Errorf("ProcessWebhook returned err: %v", err)
 		}

--- a/secret/vault/create_test.go
+++ b/secret/vault/create_test.go
@@ -87,6 +87,7 @@ func TestVault_Create_Org(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
+
 			got, err := s.Create(context.TODO(), "org", "foo", "*", sec)
 
 			if resp.Code != http.StatusOK {

--- a/secret/vault/get_test.go
+++ b/secret/vault/get_test.go
@@ -88,6 +88,7 @@ func TestVault_Get_Org(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
+
 			got, err := s.Get(context.TODO(), "org", "foo", "bar", "baz")
 
 			if resp.Code != http.StatusOK {
@@ -178,6 +179,7 @@ func TestVault_Get_Repo(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
+
 			got, err := s.Get(context.TODO(), "repo", "foo", "bar", "baz")
 
 			if resp.Code != http.StatusOK {
@@ -269,6 +271,7 @@ func TestVault_Get_Shared(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
+
 			got, err := s.Get(context.TODO(), "shared", "foo", "bar", "baz")
 
 			if resp.Code != http.StatusOK {
@@ -319,6 +322,7 @@ func TestVault_Get_InvalidType(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
+
 			got, err := s.Get(context.TODO(), "invalid", "foo", "bar", "foob")
 			if err == nil {
 				t.Errorf("Get should have returned err")
@@ -364,6 +368,7 @@ func TestVault_Get_ClosedServer(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
+
 			got, err := s.Get(context.TODO(), "repo", "foo", "bar", "foob")
 			if err == nil {
 				t.Errorf("Get should have returned err")

--- a/secret/vault/list_test.go
+++ b/secret/vault/list_test.go
@@ -104,6 +104,7 @@ func TestVault_List_Org(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
+
 			got, err := s.List(context.TODO(), "org", "foo", "*", 1, 10, []string{})
 
 			if resp.Code != http.StatusOK {
@@ -241,6 +242,7 @@ func TestVault_List_Repo(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
+
 			got, err := s.List(context.TODO(), "repo", "foo", "bar", 1, 10, []string{})
 
 			if resp.Code != http.StatusOK {
@@ -364,6 +366,7 @@ func TestVault_List_Shared(t *testing.T) {
 			if err != nil {
 				t.Errorf("New returned err: %v", err)
 			}
+
 			got, err := s.List(context.TODO(), "shared", "foo", "bar", 1, 10, []string{})
 
 			if resp.Code != http.StatusOK {

--- a/secret/vault/opts_test.go
+++ b/secret/vault/opts_test.go
@@ -75,7 +75,6 @@ func TestVault_ClientOpt_WithAWSRole(t *testing.T) {
 			WithAWSRole(test.role),
 			WithVersion("1"),
 		)
-
 		if err != nil {
 			t.Errorf("WithAWSRole returned err: %v", err)
 		}
@@ -109,7 +108,6 @@ func TestVault_ClientOpt_WithPrefix(t *testing.T) {
 			WithPrefix(test.prefix),
 			WithVersion("1"),
 		)
-
 		if err != nil {
 			t.Errorf("WithPrefix returned err: %v", err)
 		}
@@ -143,7 +141,6 @@ func TestVault_ClientOpt_WithToken(t *testing.T) {
 			WithToken(test.token),
 			WithVersion("1"),
 		)
-
 		if err != nil {
 			t.Errorf("WithToken returned err: %v", err)
 		}
@@ -177,7 +174,6 @@ func TestVault_ClientOpt_WithTokenDuration(t *testing.T) {
 			WithTokenDuration(test.tokenDuration),
 			WithVersion("1"),
 		)
-
 		if err != nil {
 			t.Errorf("WithTokenDuration returned err: %v", err)
 		}

--- a/secret/vault/refresh_test.go
+++ b/secret/vault/refresh_test.go
@@ -47,6 +47,7 @@ func Test_client_initialize(t *testing.T) {
 				if err != nil {
 					t.Error(err)
 				}
+
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(tt.responseCode)
 				_, _ = w.Write(data)
@@ -203,11 +204,13 @@ func Test_client_getAwsToken(t *testing.T) {
 				if err != nil {
 					t.Error(err)
 				}
+
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(tt.responseCode)
 				_, _ = w.Write(data)
 			}))
 			defer ts.Close()
+
 			c, err := New(
 				WithAddress(ts.URL),
 				WithAuthMethod(""),
@@ -220,6 +223,7 @@ func Test_client_getAwsToken(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
+
 			c.AWS.StsClient = tt.stsClient
 
 			gotToken, gotTTL, err := c.getAwsToken()


### PR DESCRIPTION
Looks like `lintfix` will now address whitespacing, which is cool. I did not go through and update all those newlines 😆 

I removed the package naming rule from `revive` because I like `types` and `util`, especially since they're organized by their parent packages. I'd be open to changing that, but likely in a separate PR since it's downstream effects are numerous.

Everything else is pretty self explanatory. Bless `t.Context()` 