### PR TITLE
fix(patch-v0.26.5): apply compiler WithUser middleware fix

### DIFF
--- a/router/middleware/pipeline/pipeline.go
+++ b/router/middleware/pipeline/pipeline.go
@@ -74,6 +74,7 @@ func Establish() gin.HandlerFunc {
 				WithCommit(p).
 				WithMetadata(c.MustGet("metadata").(*internal.Metadata)).
 				WithBuild(b).
+				WithUser(u).
 				Compile(ctx, config)
 			if err != nil {
 				retErr := fmt.Errorf("unable to compile pipeline configuration for %s: %w", entry, err)


### PR DESCRIPTION
Applying https://github.com/go-vela/server/pull/1272 to `v0.26.5` patch branch