### PR TITLE
fix(oidc): no trailing colon on non-action events in claim

### DIFF
--- a/internal/token/mint.go
+++ b/internal/token/mint.go
@@ -157,6 +157,11 @@ func (tm *Manager) MintIDToken(ctx context.Context, mto *MintTokenOpts, db datab
 		return "", errors.New("missing build sender for ID token")
 	}
 
+	event := mto.Build.GetEvent()
+	if len(mto.Build.GetEventAction()) > 0 {
+		event = fmt.Sprintf("%s:%s", mto.Build.GetEvent(), mto.Build.GetEventAction())
+	}
+
 	// set claims based on input
 	claims.Actor = mto.Build.GetSender()
 	claims.ActorSCMID = mto.Build.GetSenderSCMID()
@@ -164,7 +169,7 @@ func (tm *Manager) MintIDToken(ctx context.Context, mto *MintTokenOpts, db datab
 	claims.BuildNumber = strconv.FormatInt(mto.Build.GetNumber(), 10)
 	claims.BuildID = strconv.FormatInt(mto.Build.GetID(), 10)
 	claims.Repo = mto.Repo
-	claims.Event = fmt.Sprintf("%s:%s", mto.Build.GetEvent(), mto.Build.GetEventAction())
+	claims.Event = event
 	claims.PullFork = strconv.FormatBool(mto.Build.GetFork())
 	claims.SHA = mto.Build.GetCommit()
 	claims.Ref = mto.Build.GetRef()


### PR DESCRIPTION
Should this be marked breaking and put in `v0.28` or slotted into `v0.27` as part of a patch?