### PR TITLE
fix: tighten up UpdateRepo calls and add sync-up to repair

### DIFF
--- a/api/repo/repair.go
+++ b/api/repo/repair.go
@@ -75,83 +75,25 @@ func RepairRepo(c *gin.Context) {
 
 	l.Debugf("repairing repo %s", r.GetFullName())
 
-	var hook *types.Hook
-
-	// repair out-of-sync hook counter
-	lastHooks, err := database.FromContext(c).ListHooksForRepo(ctx, r, 1, 1)
+	err := syncHookCounter(c, l, r)
 	if err != nil {
-		retErr := fmt.Errorf("unable to retrieve hooks for repo %s: %w", r.GetFullName(), err)
+		retErr := fmt.Errorf("unable to synchronize hook counter for repo %s: %w", r.GetFullName(), err)
 
 		util.HandleError(c, http.StatusInternalServerError, retErr)
 
 		return
 	}
 
-	if len(lastHooks) > 0 {
-		lastHook := lastHooks[0]
-
-		if lastHook.GetNumber() != r.GetHookCounter() {
-			repoMetaUpdates := &types.Repo{ID: r.ID}
-			repoMetaUpdates.SetHookCounter(lastHook.GetNumber())
-
-			err = database.FromContext(c).PartialUpdateRepo(ctx, repoMetaUpdates)
-			if err != nil {
-				retErr := fmt.Errorf("unable to update hook counter for repo %s: %w", r.GetFullName(), err)
-
-				util.HandleError(c, http.StatusInternalServerError, retErr)
-
-				return
-			}
-
-			l.Tracef("repo %s repaired - updated hook counter to %d", r.GetFullName(), lastHook.GetNumber())
-		}
-	}
-
 	// check if we should create the webhook
 	if c.Value("webhookvalidation").(bool) {
-		// send API call to remove the webhook
-		err := scm.FromContext(c).Disable(ctx, u, r.GetOrg(), r.GetName())
+		err = recreateWebhook(c, l, r)
 		if err != nil {
-			retErr := fmt.Errorf("unable to delete webhook for %s: %w", r.GetFullName(), err)
+			retErr := fmt.Errorf("unable to recreate webhook for repo %s: %w", r.GetFullName(), err)
 
 			util.HandleError(c, http.StatusInternalServerError, retErr)
 
 			return
 		}
-
-		// send API call to create the webhook
-		hook, _, err = scm.FromContext(c).Enable(ctx, u, r)
-		if err != nil {
-			retErr := fmt.Errorf("unable to create webhook for %s: %w", r.GetFullName(), err)
-
-			switch err.Error() {
-			case "repo already enabled":
-				util.HandleError(c, http.StatusConflict, retErr)
-				return
-			case "repo not found":
-				util.HandleError(c, http.StatusNotFound, retErr)
-				return
-			}
-
-			util.HandleError(c, http.StatusInternalServerError, retErr)
-
-			return
-		}
-
-		hook.SetRepo(r)
-
-		_, err = database.FromContext(c).CreateHook(ctx, hook)
-		if err != nil {
-			retErr := fmt.Errorf("unable to create initialization webhook for %s: %w", r.GetFullName(), err)
-
-			util.HandleError(c, http.StatusInternalServerError, retErr)
-
-			return
-		}
-
-		l.WithFields(logrus.Fields{
-			"hook": hook.GetID(),
-		}).Info("new webhook created")
 	}
 
 	// get repo information from the source
@@ -225,4 +167,64 @@ func RepairRepo(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, fmt.Sprintf("repo %s repaired", r.GetFullName()))
+}
+
+// syncHookCounter is a helper function to synchronize the hook counter for a repo
+// with the latest hook number in the database.
+func syncHookCounter(c *gin.Context, l *logrus.Entry, r *types.Repo) error {
+	ctx := c.Request.Context()
+
+	lastHooks, err := database.FromContext(c).ListHooksForRepo(ctx, r, 1, 1)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve hooks for repo %s: %w", r.GetFullName(), err)
+	}
+
+	if len(lastHooks) > 0 {
+		lastHook := lastHooks[0]
+
+		if lastHook.GetNumber() != r.GetHookCounter() {
+			repoMetaUpdates := &types.Repo{ID: r.ID}
+			repoMetaUpdates.SetHookCounter(lastHook.GetNumber())
+
+			err = database.FromContext(c).PartialUpdateRepo(ctx, repoMetaUpdates)
+			if err != nil {
+				return fmt.Errorf("unable to update hook counter for repo %s: %w", r.GetFullName(), err)
+			}
+
+			l.Tracef("repo %s repaired - updated hook counter to %d", r.GetFullName(), lastHook.GetNumber())
+		}
+	}
+
+	return nil
+}
+
+// recreateWebhook is a helper function to remove and then create a webhook for a repo.
+func recreateWebhook(c *gin.Context, l *logrus.Entry, r *types.Repo) error {
+	ctx := c.Request.Context()
+	u := user.Retrieve(c)
+
+	// send API call to remove the webhook
+	err := scm.FromContext(c).Disable(ctx, u, r.GetOrg(), r.GetName())
+	if err != nil {
+		return fmt.Errorf("unable to delete webhook for %s: %w", r.GetFullName(), err)
+	}
+
+	// send API call to create the webhook
+	hook, _, err := scm.FromContext(c).Enable(ctx, u, r)
+	if err != nil {
+		return fmt.Errorf("unable to create webhook for %s: %w", r.GetFullName(), err)
+	}
+
+	hook.SetRepo(r)
+
+	_, err = database.FromContext(c).CreateHook(ctx, hook)
+	if err != nil {
+		return fmt.Errorf("unable to create initialization webhook for %s: %w", r.GetFullName(), err)
+	}
+
+	l.WithFields(logrus.Fields{
+		"hook": hook.GetID(),
+	}).Info("new webhook created")
+
+	return nil
 }

--- a/api/repo/repair.go
+++ b/api/repo/repair.go
@@ -63,8 +63,6 @@ import (
 
 // RepairRepo represents the API handler to remove
 // and then create a webhook for a repo.
-//
-
 func RepairRepo(c *gin.Context) {
 	// capture middleware values
 	m := c.MustGet("metadata").(*internal.Metadata)

--- a/api/repo/repair.go
+++ b/api/repo/repair.go
@@ -87,22 +87,24 @@ func RepairRepo(c *gin.Context) {
 		return
 	}
 
-	lastHook := lastHooks[0]
+	if len(lastHooks) > 0 {
+		lastHook := lastHooks[0]
 
-	if lastHook.GetNumber() != r.GetHookCounter() {
-		repoMetaUpdates := &types.Repo{ID: r.ID}
-		repoMetaUpdates.SetHookCounter(lastHook.GetNumber())
+		if lastHook.GetNumber() != r.GetHookCounter() {
+			repoMetaUpdates := &types.Repo{ID: r.ID}
+			repoMetaUpdates.SetHookCounter(lastHook.GetNumber())
 
-		err = database.FromContext(c).PartialUpdateRepo(ctx, repoMetaUpdates)
-		if err != nil {
-			retErr := fmt.Errorf("unable to update hook counter for repo %s: %w", r.GetFullName(), err)
+			err = database.FromContext(c).PartialUpdateRepo(ctx, repoMetaUpdates)
+			if err != nil {
+				retErr := fmt.Errorf("unable to update hook counter for repo %s: %w", r.GetFullName(), err)
 
-			util.HandleError(c, http.StatusInternalServerError, retErr)
+				util.HandleError(c, http.StatusInternalServerError, retErr)
 
-			return
+				return
+			}
+
+			l.Tracef("repo %s repaired - updated hook counter to %d", r.GetFullName(), lastHook.GetNumber())
 		}
-
-		l.Tracef("repo %s repaired - updated hook counter to %d", r.GetFullName(), lastHook.GetNumber())
 	}
 
 	// check if we should create the webhook

--- a/api/repo/repair.go
+++ b/api/repo/repair.go
@@ -77,6 +77,34 @@ func RepairRepo(c *gin.Context) {
 
 	var hook *types.Hook
 
+	// repair out-of-sync hook counter
+	lastHooks, err := database.FromContext(c).ListHooksForRepo(ctx, r, 1, 1)
+	if err != nil {
+		retErr := fmt.Errorf("unable to retrieve hooks for repo %s: %w", r.GetFullName(), err)
+
+		util.HandleError(c, http.StatusInternalServerError, retErr)
+
+		return
+	}
+
+	lastHook := lastHooks[0]
+
+	if lastHook.GetNumber() != r.GetHookCounter() {
+		repoMetaUpdates := &types.Repo{ID: r.ID}
+		repoMetaUpdates.SetHookCounter(lastHook.GetNumber())
+
+		err = database.FromContext(c).PartialUpdateRepo(ctx, repoMetaUpdates)
+		if err != nil {
+			retErr := fmt.Errorf("unable to update hook counter for repo %s: %w", r.GetFullName(), err)
+
+			util.HandleError(c, http.StatusInternalServerError, retErr)
+
+			return
+		}
+
+		l.Tracef("repo %s repaired - updated hook counter to %d", r.GetFullName(), lastHook.GetNumber())
+	}
+
 	// check if we should create the webhook
 	if c.Value("webhookvalidation").(bool) {
 		// send API call to remove the webhook

--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -223,6 +223,10 @@ func PostWebhook(c *gin.Context) {
 		}
 	}
 
+	// set the RepoID fields
+	b.SetRepo(repo)
+	h.SetRepo(repo)
+
 	// verify the webhook from the source control provider using DB repo hash
 	if c.Value("webhookvalidation").(bool) {
 		l.WithFields(logrus.Fields{
@@ -305,15 +309,15 @@ func PostWebhook(c *gin.Context) {
 		//nolint:contextcheck // false positive
 		_, err = database.FromContext(c).UpdateHook(ctx, h)
 		if err != nil {
-			l.Errorf("unable to update webhook %s/%d: %v", r.GetFullName(), h.GetNumber(), err)
+			l.Errorf("unable to update webhook %s/%d: %v", repo.GetFullName(), h.GetNumber(), err)
 		}
 
 		l.WithFields(logrus.Fields{
 			"hook":    h.GetNumber(),
 			"hook_id": h.GetID(),
-			"org":     r.GetOrg(),
-			"repo":    r.GetName(),
-			"repo_id": r.GetID(),
+			"org":     repo.GetOrg(),
+			"repo":    repo.GetName(),
+			"repo_id": repo.GetID(),
 		}).Info("hook updated")
 	}()
 
@@ -336,10 +340,6 @@ func PostWebhook(c *gin.Context) {
 		b.SetSenderSCMID(senderID)
 	}
 
-	// set the RepoID fields
-	b.SetRepo(repo)
-	h.SetRepo(repo)
-
 	// number of times to retry
 	retryLimit := 3
 	// implement a loop to process asynchronous operations with a retry limit
@@ -358,7 +358,7 @@ func PostWebhook(c *gin.Context) {
 		h, err = database.FromContext(c).CreateHook(ctx, h)
 		if err != nil {
 			// format the error message with extra information
-			err = fmt.Errorf("unable to create webhook %s/%d: %w", r.GetFullName(), h.GetNumber(), err)
+			err = fmt.Errorf("unable to create webhook %s/%d: %w", repo.GetFullName(), h.GetNumber(), err)
 
 			// check if the retry limit has been exceeded
 			if i < retryLimit-1 {
@@ -693,7 +693,7 @@ func handleRepositoryEvent(ctx context.Context, l *logrus.Entry, db database.Int
 	l.Debugf("webhook is repository event, making necessary updates to repo %s", r.GetFullName())
 
 	defer func() {
-		h.SetRepo(r)
+		h.SetRepo(dbRepo)
 
 		// send API call to update the webhook
 		hr, err := db.CreateHook(ctx, h)
@@ -704,9 +704,9 @@ func handleRepositoryEvent(ctx context.Context, l *logrus.Entry, db database.Int
 		l.WithFields(logrus.Fields{
 			"hook":    hr.GetNumber(),
 			"hook_id": hr.GetID(),
-			"org":     r.GetOrg(),
-			"repo":    r.GetName(),
-			"repo_id": r.GetID(),
+			"org":     dbRepo.GetOrg(),
+			"repo":    dbRepo.GetName(),
+			"repo_id": dbRepo.GetID(),
 		}).Info("hook created")
 	}()
 
@@ -841,16 +841,16 @@ func RenameRepository(ctx context.Context, l *logrus.Entry, db database.Interfac
 		}).Info("build updated")
 	}
 
-	// update the repo name information
-	dbR.SetName(r.GetName())
-	dbR.SetOrg(r.GetOrg())
-	dbR.SetFullName(r.GetFullName())
-	dbR.SetClone(r.GetClone())
-	dbR.SetLink(r.GetLink())
-	dbR.SetPreviousName(r.GetPreviousName())
+	repoMetaUpdates := &types.Repo{ID: dbR.ID}
+	repoMetaUpdates.SetName(r.GetName())
+	repoMetaUpdates.SetOrg(r.GetOrg())
+	repoMetaUpdates.SetFullName(r.GetFullName())
+	repoMetaUpdates.SetClone(r.GetClone())
+	repoMetaUpdates.SetLink(r.GetLink())
+	repoMetaUpdates.SetPreviousName(r.GetPreviousName())
 
 	// update the repo in the database
-	dbR, err = db.UpdateRepo(ctx, dbR)
+	err = db.PartialUpdateRepo(ctx, repoMetaUpdates)
 	if err != nil {
 		retErr := fmt.Errorf("%s: failed to update repo %s/%s", baseErr, dbR.GetOrg(), dbR.GetName())
 

--- a/database/repo/update.go
+++ b/database/repo/update.go
@@ -39,6 +39,7 @@ func (e *Engine) UpdateRepo(ctx context.Context, r *api.Repo) (*api.Repo, error)
 	err = e.client.
 		WithContext(ctx).
 		Table(constants.TableRepo).
+		Omit("hook_counter").
 		Save(repo).Error
 	if err != nil {
 		return nil, err

--- a/database/repo/update_test.go
+++ b/database/repo/update_test.go
@@ -38,9 +38,9 @@ func TestRepo_Engine_UpdateRepo(t *testing.T) {
 
 	// ensure the mock expects the query
 	_mock.ExpectExec(`UPDATE "repos"
-SET "user_id"=$1,"hash"=$2,"org"=$3,"name"=$4,"full_name"=$5,"link"=$6,"clone"=$7,"branch"=$8,"topics"=$9,"build_limit"=$10,"timeout"=$11,"counter"=$12,"hook_counter"=$13,"visibility"=$14,"private"=$15,"trusted"=$16,"active"=$17,"allow_events"=$18,"merge_queue_events"=$19,"pipeline_type"=$20,"previous_name"=$21,"approve_build"=$22,"approval_timeout"=$23,"install_id"=$24,"custom_props"=$25
-WHERE "id" = $26`).
-		WithArgs(1, AnyArgument{}, "foo", "bar", "foo/bar", "", "", "", AnyArgument{}, AnyArgument{}, AnyArgument{}, AnyArgument{}, AnyArgument{}, "public", false, false, false, 1, nil, "yaml", "oldName", constants.ApproveForkAlways, 5, 0, `{"foo":"bar"}`, 1).
+SET "user_id"=$1,"hash"=$2,"org"=$3,"name"=$4,"full_name"=$5,"link"=$6,"clone"=$7,"branch"=$8,"topics"=$9,"build_limit"=$10,"timeout"=$11,"counter"=$12,"visibility"=$13,"private"=$14,"trusted"=$15,"active"=$16,"allow_events"=$17,"merge_queue_events"=$18,"pipeline_type"=$19,"previous_name"=$20,"approve_build"=$21,"approval_timeout"=$22,"install_id"=$23,"custom_props"=$24
+WHERE "id" = $25`).
+		WithArgs(1, AnyArgument{}, "foo", "bar", "foo/bar", "", "", "", AnyArgument{}, AnyArgument{}, AnyArgument{}, AnyArgument{}, "public", false, false, false, 1, nil, "yaml", "oldName", constants.ApproveForkAlways, 5, 0, `{"foo":"bar"}`, 1).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)


### PR DESCRIPTION
Removing stray `UpdateRepo` call in the hot path, adding an omission of `hook_counter` to the UpdateRepo function (for user CRUD calls that may occur concurrently with webhook delivery), and adding a small section for fixing out-of-sync hook counters in the repair handler. 

We've only seen an out-of-sync scenario once in our installation of Vela, but hopefully these changes button that all up so we never see it 😅 