### PR TITLE
fix(router): use install token for caller token and fix ptr derefs

### DIFF
--- a/api/build/refresh_install.go
+++ b/api/build/refresh_install.go
@@ -71,9 +71,9 @@ func RefreshInstallToken(c *gin.Context) {
 
 	l.Debugf("generating install token for build %s/%d", b.GetRepo().GetFullName(), b.GetNumber())
 
-	// build must be running to refresh install token
-	if b.GetStatus() != constants.StatusRunning {
-		retErr := fmt.Errorf("unable to generate install token for build not in %s status", constants.StatusRunning)
+	// build must be pending or running to refresh install token
+	if b.GetStatus() != constants.StatusRunning && b.GetStatus() != constants.StatusPending {
+		retErr := fmt.Errorf("unable to generate install token for build not in %s or %s status", constants.StatusRunning, constants.StatusPending)
 
 		util.HandleError(c, http.StatusBadRequest, retErr)
 

--- a/router/middleware/user/user.go
+++ b/router/middleware/user/user.go
@@ -3,6 +3,7 @@
 package user
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	api "github.com/go-vela/server/api/types"
+	"github.com/go-vela/server/cache/models"
 	"github.com/go-vela/server/constants"
 	"github.com/go-vela/server/database"
 	"github.com/go-vela/server/router/middleware/claims"
@@ -26,10 +28,17 @@ func Establish() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		l := c.MustGet("logger").(*logrus.Entry)
 
-		_, ok := c.Get("app-installation-token")
+		it, ok := c.Get("app-installation-token")
 		if ok {
+			tkn, ok := it.(*models.InstallToken)
+			if !ok {
+				util.HandleError(c, http.StatusInternalServerError, fmt.Errorf("invalid type for app installation token"))
+				return
+			}
+
 			u := new(api.User)
-			u.SetName("app-installation")
+			u.SetName("vela-app")
+			u.SetToken(tkn.Token)
 
 			ToContext(c, u)
 			c.Next()

--- a/scm/github/access.go
+++ b/scm/github/access.go
@@ -31,7 +31,7 @@ func (c *Client) OrgAccess(ctx context.Context, u *api.User, org string) (string
 	}
 
 	// create GitHub OAuth client with user's token
-	client := c.newOAuthTokenClient(ctx, *u.Token)
+	client := c.newOAuthTokenClient(ctx, u.GetToken())
 
 	// send API call to capture org access level for user
 	membership, _, err := client.Organizations.GetOrgMembership(ctx, *u.Name, org)

--- a/scm/github/deployment.go
+++ b/scm/github/deployment.go
@@ -22,7 +22,7 @@ func (c *Client) GetDeployment(ctx context.Context, u *api.User, r *api.Repo, id
 	}).Tracef("capturing deployment %d for repo %s", id, r.GetFullName())
 
 	// create GitHub OAuth client with user's token
-	client := c.newOAuthTokenClient(ctx, *u.Token)
+	client := c.newOAuthTokenClient(ctx, u.GetToken())
 
 	// send API call to capture the deployment
 	deployment, _, err := client.Repositories.GetDeployment(ctx, r.GetOrg(), r.GetName(), id)
@@ -63,7 +63,7 @@ func (c *Client) GetDeploymentCount(ctx context.Context, u *api.User, r *api.Rep
 	}).Tracef("counting deployments for repo %s", r.GetFullName())
 
 	// create GitHub OAuth client with user's token
-	client := c.newOAuthTokenClient(ctx, *u.Token)
+	client := c.newOAuthTokenClient(ctx, u.GetToken())
 	// create variable to track the deployments
 	deployments := []*github.Deployment{}
 
@@ -105,7 +105,7 @@ func (c *Client) GetDeploymentList(ctx context.Context, u *api.User, r *api.Repo
 	}).Tracef("listing deployments for repo %s", r.GetFullName())
 
 	// create GitHub OAuth client with user's token
-	client := c.newOAuthTokenClient(ctx, *u.Token)
+	client := c.newOAuthTokenClient(ctx, u.GetToken())
 
 	// set pagination options for listing deployments
 	opts := &github.DeploymentsListOptions{
@@ -164,7 +164,7 @@ func (c *Client) CreateDeployment(ctx context.Context, u *api.User, r *api.Repo,
 	}).Tracef("creating deployment for repo %s", r.GetFullName())
 
 	// create GitHub OAuth client with user's token
-	client := c.newOAuthTokenClient(ctx, *u.Token)
+	client := c.newOAuthTokenClient(ctx, u.GetToken())
 
 	var payload any
 	if d.Payload == nil {

--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -57,7 +57,7 @@ func (c *Client) Config(ctx context.Context, u *api.User, r *api.Repo, ref strin
 	}).Tracef("capturing configuration file for %s/commit/%s", r.GetFullName(), ref)
 
 	// create GitHub OAuth client with user's token
-	client := c.newOAuthTokenClient(ctx, *u.Token)
+	client := c.newOAuthTokenClient(ctx, u.GetToken())
 
 	// default pipeline file names
 	files := []string{".vela.yml", ".vela.yaml"}
@@ -109,7 +109,7 @@ func (c *Client) DestroyWebhook(ctx context.Context, u *api.User, org, name stri
 	}).Tracef("deleting repository webhooks for %s/%s", org, name)
 
 	// create GitHub OAuth client with user's token
-	client := c.newOAuthTokenClient(ctx, *u.Token)
+	client := c.newOAuthTokenClient(ctx, u.GetToken())
 
 	// send API call to capture the hooks for the repo
 	hooks, _, err := client.Repositories.ListHooks(ctx, org, name, nil)
@@ -169,7 +169,7 @@ func (c *Client) CreateWebhook(ctx context.Context, u *api.User, r *api.Repo) (*
 	}).Tracef("creating repository webhook for %s/%s", r.GetOrg(), r.GetName())
 
 	// create GitHub OAuth client with user's token
-	client := c.newOAuthTokenClient(ctx, *u.Token)
+	client := c.newOAuthTokenClient(ctx, u.GetToken())
 
 	// create the hook object to make the API call
 	hook := &github.Hook{
@@ -215,7 +215,7 @@ func (c *Client) Update(ctx context.Context, u *api.User, r *api.Repo, hookID in
 	}).Tracef("updating repository webhook for %s/%s", r.GetOrg(), r.GetName())
 
 	// create GitHub OAuth client with user's token
-	client := c.newOAuthTokenClient(ctx, *u.Token)
+	client := c.newOAuthTokenClient(ctx, u.GetToken())
 
 	// create the hook object to make the API call
 	hook := &github.Hook{
@@ -441,7 +441,7 @@ func (c *Client) GetHTMLURL(ctx context.Context, u *api.User, org, repo, name, r
 	}).Tracef("capturing html_url for %s/%s/%s@%s", org, repo, name, ref)
 
 	// create GitHub OAuth client with user's token
-	client := c.newOAuthTokenClient(ctx, *u.Token)
+	client := c.newOAuthTokenClient(ctx, u.GetToken())
 
 	// set the reference for the options to capture the repository contents
 	opts := &github.RepositoryContentGetOptions{

--- a/scm/github/webhook_test.go
+++ b/scm/github/webhook_test.go
@@ -1701,7 +1701,7 @@ func TestGithub_GetDeliveryID(t *testing.T) {
 
 	client, _ := NewTest(s.URL, "https://foo.bar.com")
 
-	ghClient := client.newOAuthTokenClient(context.Background(), *u.Token)
+	ghClient := client.newOAuthTokenClient(context.Background(), u.GetToken())
 
 	// run test
 	got, err := client.getDeliveryID(context.TODO(), ghClient, _hook)


### PR DESCRIPTION
Set user token as install token for install token requests. This is only necessary for deployment creation really. Also replacing all the `*u.Token` inputs with `u.GetToken()` for safety.

Also adding `pending` as a potential status for a build that is getting its install token refreshed since the worker client will need to refresh its install token prior to updating a build to `running` if the build has been pending for longer than one hour.