### PR TITLE
fix(db/hook): trim error to fit db column

### DIFF
--- a/database/hook/update.go
+++ b/database/hook/update.go
@@ -25,6 +25,8 @@ func (e *Engine) UpdateHook(ctx context.Context, h *api.Hook) (*api.Hook, error)
 		return nil, err
 	}
 
+	hook = hook.Crop()
+
 	// send query to the database
 	err = e.client.WithContext(ctx).Table(constants.TableHook).Save(hook).Error
 	if err != nil {

--- a/database/hook/update_test.go
+++ b/database/hook/update_test.go
@@ -4,6 +4,7 @@ package hook
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -26,7 +27,10 @@ func TestHook_Engine_UpdateHook(t *testing.T) {
 	_hook.SetBuild(_build)
 	_hook.SetNumber(1)
 	_hook.SetSourceID("c8da1302-07d6-11ea-882f-4893bca275b8")
+	_hook.SetError(strings.Repeat("x", 501))
 	_hook.SetWebhookID(1)
+
+	err500 := strings.Repeat("x", 497) + "..."
 
 	_postgres, _mock := testPostgres(t)
 
@@ -36,7 +40,7 @@ func TestHook_Engine_UpdateHook(t *testing.T) {
 	_mock.ExpectExec(`UPDATE "hooks"
 SET "repo_id"=$1,"build_id"=$2,"number"=$3,"source_id"=$4,"created"=$5,"host"=$6,"event"=$7,"event_action"=$8,"branch"=$9,"error"=$10,"status"=$11,"link"=$12,"webhook_id"=$13
 WHERE "id" = $14`).
-		WithArgs(1, 1, 1, "c8da1302-07d6-11ea-882f-4893bca275b8", nil, nil, nil, nil, nil, nil, nil, nil, 1, 1).
+		WithArgs(1, 1, 1, "c8da1302-07d6-11ea-882f-4893bca275b8", nil, nil, nil, nil, nil, err500, nil, nil, 1, 1).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_sqlite := testSqlite(t)

--- a/database/types/hook.go
+++ b/database/types/hook.go
@@ -28,6 +28,13 @@ var (
 	ErrEmptyHookWebhookID = errors.New("empty webhook webhook_id provided")
 )
 
+const (
+	// Maximum error field length.
+	maxHookErrorLength = 500
+	// Suffix to indicate values were truncated.
+	hookTruncatedSuffix = "..."
+)
+
 // Hook is the database representation of a webhook for a repo.
 type Hook struct {
 	ID          sql.NullInt64  `sql:"id"`
@@ -128,6 +135,18 @@ func (h *Hook) Nullify() *Hook {
 	// check if the WebhookID field should be false
 	if h.WebhookID.Int64 == 0 {
 		h.WebhookID.Valid = false
+	}
+
+	return h
+}
+
+// Crop prepares the Hook type for inserting into the database by
+// trimming values that may exceed the database column limit.
+func (h *Hook) Crop() *Hook {
+	// trim the Error field to 500 characters
+	if len(h.Error.String) > maxHookErrorLength {
+		trimmedLength := maxHookErrorLength - len(hookTruncatedSuffix)
+		h.Error = sql.NullString{String: h.Error.String[:trimmedLength] + hookTruncatedSuffix, Valid: true}
 	}
 
 	return h

--- a/database/types/hook_test.go
+++ b/database/types/hook_test.go
@@ -5,6 +5,7 @@ package types
 import (
 	"database/sql"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +13,26 @@ import (
 
 	api "github.com/go-vela/server/api/types"
 )
+
+func TestTypes_Hook_Crop(t *testing.T) {
+	err := strings.Repeat("x", 501)
+
+	h := testHook()
+	h.Error = sql.NullString{String: err, Valid: true}
+
+	want := testHook()
+	want.Error = sql.NullString{String: err[:497] + "...", Valid: true}
+
+	got := h.Crop()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Crop is %v, want %v", got, want)
+	}
+
+	if len(got.Error.String) != 500 {
+		t.Errorf("Crop returned error length %d, want 500", len(got.Error.String))
+	}
+}
 
 func TestTypes_Hook_Nullify(t *testing.T) {
 	// setup types


### PR DESCRIPTION
pretty much a mirror implementation of what we do with `build.Crop()` except here we throw some truncation chars into the mix. i checked the other fields, but this one seemed like the main candidate for this need.