### PR TITLE
fix(hook): matching error with other updatehook calls

### DIFF
--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -309,7 +309,7 @@ func PostWebhook(c *gin.Context) {
 		//nolint:contextcheck // false positive
 		_, err = database.FromContext(c).UpdateHook(ctx, h)
 		if err != nil {
-			l.Errorf("unable to update webhook %s/%d: %v", repo.GetFullName(), h.GetNumber(), err)
+			l.Errorf("unable to update hook %s/%d: %v", repo.GetFullName(), h.GetNumber(), err)
 		}
 
 		l.WithFields(logrus.Fields{


### PR DESCRIPTION
this was the only spot where we say `webhook` instead of `hook`. this will also reclaim 3 characters lost by new '...' truncation chars introduced in https://github.com/go-vela/server/pull/1440 :)