### PR TITLE
fix(scm): use slug in team list for user

### DIFF
--- a/scm/github/access.go
+++ b/scm/github/access.go
@@ -163,7 +163,7 @@ func (c *Client) ListUsersTeamsForOrg(ctx context.Context, u *api.User, org stri
 	for _, t := range teams {
 		// skip the org if does not match the org we are checking
 		if strings.EqualFold(org, t.GetOrganization().GetLogin()) {
-			userTeams = append(userTeams, t.GetName())
+			userTeams = append(userTeams, t.GetSlug())
 		}
 	}
 

--- a/scm/github/access_test.go
+++ b/scm/github/access_test.go
@@ -385,7 +385,7 @@ func TestGithub_TeamList(t *testing.T) {
 	defer s.Close()
 
 	// setup types
-	want := []string{"Justice League", "octocat"}
+	want := []string{"justice-league", "octocat"}
 
 	u := new(api.User)
 	u.SetName("foo")
@@ -397,15 +397,15 @@ func TestGithub_TeamList(t *testing.T) {
 	got, err := client.ListUsersTeamsForOrg(context.TODO(), u, "github")
 
 	if resp.Code != http.StatusOK {
-		t.Errorf("TeamAccess returned %v, want %v", resp.Code, http.StatusOK)
+		t.Errorf("ListUsersTeamsForOrg returned %v, want %v", resp.Code, http.StatusOK)
 	}
 
 	if err != nil {
-		t.Errorf("TeamAccess returned err: %v", err)
+		t.Errorf("ListUsersTeamsForOrg returned err: %v", err)
 	}
 
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("TeamAccess is %v, want %v", got, want)
+		t.Errorf("ListUsersTeamsForOrg is %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
We use slug when determining whether or not the user has access to create a secret, and we also store the secret with a team value equal to the slug. So this is a pretty obvious fix here.