### PR TITLE
fix(regression): re-introduce owner check for build scm token

### DIFF
--- a/compiler/native/compile.go
+++ b/compiler/native/compile.go
@@ -45,6 +45,14 @@ func (c *Client) Compile(ctx context.Context, v any) (*pipeline.Build, *api.Pipe
 		return nil, nil, err
 	}
 
+	// validate netrc request before continuing with compile
+	if c.scm != nil {
+		err = c.scm.ValidateNetrcRequest(ctx, c.token, c.build, p.Git.Repositories, p.Git.Permissions)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to validate token request: %w", err)
+		}
+	}
+
 	// create the API pipeline object from the yaml configuration
 	_pipeline := p.ToPipelineAPI()
 	_pipeline.SetData(data)


### PR DESCRIPTION
Adding back owner access validation during compile time for `git` block. Was accidentally reverted in https://github.com/go-vela/server/pull/1420