### PR TITLE
fix(merge_group): adjust auto-cancel logic for destroyed group event

### DIFF
--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -882,7 +882,7 @@ func handleMergeGroupDestroy(c *gin.Context, l *logrus.Entry, db database.Interf
 	}
 
 	for _, rB := range rBs {
-		if rB.GetCommit() == b.GetCommit() {
+		if rB.GetCommit() == b.GetCommit() && rB.GetEvent() == b.GetEvent() {
 			switch rB.GetStatus() {
 			case constants.StatusPending:
 				rB.SetStatus(constants.StatusCanceled)


### PR DESCRIPTION
If a destroy webhook comes in after the push to the target branch (successful queue but out-of-order webhook delivery), the auto cancel routine here can inadvertently cancel the push build, which we don't ever want. This additional check will ensure only merge group builds are canceled.