### PR TITLE
fix(compiler): add validation for origin secrets

### DIFF
--- a/compiler/native/validate.go
+++ b/compiler/native/validate.go
@@ -65,6 +65,12 @@ func (c *Client) ValidateYAML(p *yaml.Build) error {
 		result = multierror.Append(result, err)
 	}
 
+	// validate the secrets block provided
+	err = validateYAMLSecrets(p.Secrets)
+	if err != nil {
+		result = multierror.Append(result, err)
+	}
+
 	return result
 }
 
@@ -126,6 +132,24 @@ func validateYAMLServices(s yaml.ServiceSlice) error {
 
 		if len(service.Image) == 0 {
 			return fmt.Errorf("no image provided for service %s", service.Name)
+		}
+	}
+
+	return nil
+}
+
+// validateYAMLSecretOrigin is a helper function that verifies the
+// secret origin block in the yaml configuration is valid.
+func validateYAMLSecrets(s yaml.SecretSlice) error {
+	for _, secret := range s {
+		if !secret.Origin.Empty() {
+			if len(secret.Origin.Name) == 0 {
+				return fmt.Errorf("no name provided for secret origin")
+			}
+
+			if len(secret.Origin.Image) == 0 {
+				return fmt.Errorf("no image provided for secret origin %s", secret.Origin.Name)
+			}
 		}
 	}
 

--- a/compiler/native/validate_test.go
+++ b/compiler/native/validate_test.go
@@ -224,6 +224,76 @@ func TestNative_Validate_Services_NoImage(t *testing.T) {
 	}
 }
 
+func TestNative_ValidateYAML_SecretOrigin_NoName(t *testing.T) {
+	// setup types
+	str := "foo"
+	p := &yaml.Build{
+		Version: "v1",
+		Secrets: yaml.SecretSlice{
+			&yaml.Secret{
+				Origin: yaml.Origin{
+					Image: "vault",
+					Name:  "",
+				},
+			},
+		},
+		Steps: yaml.StepSlice{
+			&yaml.Step{
+				Commands: raw.StringSlice{"echo hello"},
+				Image:    "alpine",
+				Name:     str,
+				Pull:     "always",
+			},
+		},
+	}
+
+	// run test
+	compiler, err := FromCLICommand(context.Background(), testCommand(t, "http://foo.example.com"))
+	if err != nil {
+		t.Errorf("Unable to create new compiler: %v", err)
+	}
+
+	err = compiler.ValidateYAML(p)
+	if err == nil {
+		t.Errorf("Validate should have returned err")
+	}
+}
+
+func TestNative_Validate_SecretOrigin_NoImage(t *testing.T) {
+	// setup types
+	str := "foo"
+	p := &yaml.Build{
+		Version: "v1",
+		Secrets: yaml.SecretSlice{
+			&yaml.Secret{
+				Origin: yaml.Origin{
+					Image: "",
+					Name:  str,
+				},
+			},
+		},
+		Steps: yaml.StepSlice{
+			&yaml.Step{
+				Commands: raw.StringSlice{"echo hello"},
+				Image:    "alpine",
+				Name:     str,
+				Pull:     "always",
+			},
+		},
+	}
+
+	// run test
+	compiler, err := FromCLICommand(context.Background(), testCommand(t, "http://foo.example.com"))
+	if err != nil {
+		t.Errorf("Unable to create new compiler: %v", err)
+	}
+
+	err = compiler.ValidateYAML(p)
+	if err == nil {
+		t.Errorf("Validate should have returned err")
+	}
+}
+
 func TestNative_Validate_Stages(t *testing.T) {
 	// setup types
 	str := "foo"


### PR DESCRIPTION
Missing `image` in a secret origin block will result in a failure to assemble the build in the worker and does not surface a helpful error message. Catching it early is the best solution