### PR TITLE
fix: Consider all commits' touched files for push events

### DIFF
--- a/scm/github/testdata/hooks/push_multicommit.json
+++ b/scm/github/testdata/hooks/push_multicommit.json
@@ -1,0 +1,216 @@
+{
+  "ref": "refs/heads/main",
+  "before": "d3d9188fc87a6977343e922c128f162a86018d76",
+  "after": "9c93babf58917cd6f6f6772b5df2b098f507ff95",
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "base_ref": null,
+  "compare": "https://github.com/Codertocat/Hello-World/compare/d3d9188fc87a...9c93babf5891",
+  "commits": [
+    {
+      "id": "0000000058917cd6f6f6772b5df2b098f507ff95",
+      "tree_id": "0000000015bbfab4cb85534f51a77e4e3ed6e0fb",
+      "distinct": true,
+      "message": "Update README.md",
+      "timestamp": "2019-03-11T10:41:06-05:00",
+      "url": "https://github.com/Codertocat/Hello-World/commit/0000000058917cd6f6f6772b5df2b098f507ff95",
+      "author": {
+        "name": "Codertocat",
+        "email": "21031067+Codertocat@users.noreply.github.com",
+        "username": "Codertocat"
+      },
+      "committer": {
+        "name": "GitHub",
+        "email": "noreply@github.com"
+      },
+      "added": [
+        "CONTRIBUTING.md"
+      ],
+      "removed": [
+        "readme.txt"
+      ],
+      "modified": [
+        "README.md"
+      ]
+    },
+    {
+      "id": "9c93babf58917cd6f6f6772b5df2b098f507ff95",
+      "tree_id": "7b4511bb15bbfab4cb85534f51a77e4e3ed6e0fb",
+      "distinct": true,
+      "message": "Update README.md",
+      "timestamp": "2019-03-11T10:51:07-05:00",
+      "url": "https://github.com/Codertocat/Hello-World/commit/9c93babf58917cd6f6f6772b5df2b098f507ff95",
+      "author": {
+        "name": "Codertocat",
+        "email": "21031067+Codertocat@users.noreply.github.com",
+        "username": "Codertocat"
+      },
+      "committer": {
+        "name": "GitHub",
+        "email": "noreply@github.com"
+      },
+      "added": [
+
+      ],
+      "removed": [
+
+      ],
+      "modified": [
+        "README.md"
+      ]
+    }
+  ],
+  "head_commit": {
+    "id": "9c93babf58917cd6f6f6772b5df2b098f507ff95",
+    "tree_id": "7b4511bb15bbfab4cb85534f51a77e4e3ed6e0fb",
+    "distinct": true,
+    "message": "Update README.md",
+    "timestamp": "2019-03-11T10:51:07-05:00",
+    "url": "https://github.com/Codertocat/Hello-World/commit/9c93babf58917cd6f6f6772b5df2b098f507ff95",
+    "author": {
+      "name": "Codertocat",
+      "email": "21031067+Codertocat@users.noreply.github.com",
+      "username": "Codertocat"
+    },
+    "committer": {
+      "name": "GitHub",
+      "email": "noreply@github.com"
+    },
+    "added": [
+
+    ],
+    "removed": [
+
+    ],
+    "modified": [
+      "README.md"
+    ]
+  },
+  "repository": {
+    "id": 135493233,
+    "node_id": "MDEwOlJlcG9zaXRvcnkxMzU0OTMyMzM=",
+    "name": "Hello-World",
+    "full_name": "Codertocat/Hello-World",
+    "owner": {
+      "name": "Codertocat",
+      "email": "21031067+Codertocat@users.noreply.github.com",
+      "login": "Codertocat",
+      "id": 21031067,
+      "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/21031067?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Codertocat",
+      "html_url": "https://github.com/Codertocat",
+      "followers_url": "https://api.github.com/users/Codertocat/followers",
+      "following_url": "https://api.github.com/users/Codertocat/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Codertocat/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Codertocat/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Codertocat/subscriptions",
+      "organizations_url": "https://api.github.com/users/Codertocat/orgs",
+      "repos_url": "https://api.github.com/users/Codertocat/repos",
+      "events_url": "https://api.github.com/users/Codertocat/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Codertocat/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "private": false,
+    "html_url": "https://github.com/Codertocat/Hello-World",
+    "description": null,
+    "fork": false,
+    "url": "https://github.com/Codertocat/Hello-World",
+    "forks_url": "https://api.github.com/repos/Codertocat/Hello-World/forks",
+    "keys_url": "https://api.github.com/repos/Codertocat/Hello-World/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/Codertocat/Hello-World/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/Codertocat/Hello-World/teams",
+    "hooks_url": "https://api.github.com/repos/Codertocat/Hello-World/hooks",
+    "issue_events_url": "https://api.github.com/repos/Codertocat/Hello-World/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/Codertocat/Hello-World/events",
+    "assignees_url": "https://api.github.com/repos/Codertocat/Hello-World/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/Codertocat/Hello-World/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/Codertocat/Hello-World/tags",
+    "blobs_url": "https://api.github.com/repos/Codertocat/Hello-World/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/Codertocat/Hello-World/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/Codertocat/Hello-World/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/Codertocat/Hello-World/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/Codertocat/Hello-World/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/Codertocat/Hello-World/languages",
+    "stargazers_url": "https://api.github.com/repos/Codertocat/Hello-World/stargazers",
+    "contributors_url": "https://api.github.com/repos/Codertocat/Hello-World/contributors",
+    "subscribers_url": "https://api.github.com/repos/Codertocat/Hello-World/subscribers",
+    "subscription_url": "https://api.github.com/repos/Codertocat/Hello-World/subscription",
+    "commits_url": "https://api.github.com/repos/Codertocat/Hello-World/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/Codertocat/Hello-World/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/Codertocat/Hello-World/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/Codertocat/Hello-World/issues/comments{/number}",
+    "contents_url": "https://api.github.com/repos/Codertocat/Hello-World/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/Codertocat/Hello-World/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/Codertocat/Hello-World/merges",
+    "archive_url": "https://api.github.com/repos/Codertocat/Hello-World/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/Codertocat/Hello-World/downloads",
+    "issues_url": "https://api.github.com/repos/Codertocat/Hello-World/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/Codertocat/Hello-World/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/Codertocat/Hello-World/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/Codertocat/Hello-World/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/Codertocat/Hello-World/labels{/name}",
+    "releases_url": "https://api.github.com/repos/Codertocat/Hello-World/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/Codertocat/Hello-World/deployments",
+    "created_at": 1527711484,
+    "updated_at": "2018-05-30T20:18:35Z",
+    "pushed_at": 1527711528,
+    "git_url": "git://github.com/Codertocat/Hello-World.git",
+    "ssh_url": "git@github.com:Codertocat/Hello-World.git",
+    "clone_url": "https://github.com/Codertocat/Hello-World.git",
+    "svn_url": "https://github.com/Codertocat/Hello-World",
+    "homepage": null,
+    "size": 0,
+    "stargazers_count": 0,
+    "watchers_count": 0,
+    "language": null,
+    "has_issues": true,
+    "has_projects": true,
+    "has_downloads": true,
+    "has_wiki": true,
+    "has_pages": true,
+    "forks_count": 0,
+    "mirror_url": null,
+    "archived": false,
+    "open_issues_count": 2,
+    "license": null,
+    "forks": 0,
+    "open_issues": 2,
+    "watchers": 0,
+    "default_branch": "main",
+    "stargazers": 0,
+    "master_branch": "main",
+    "topics": ["go", "vela"],
+    "custom_properties": {
+      "prop_1": "foo",
+      "prop_2": "bar"
+    }
+  },
+  "pusher": {
+    "name": "Codertocat",
+    "email": "21031067+Codertocat@users.noreply.github.com"
+  },
+  "sender": {
+    "login": "Codertocat",
+    "id": 21031067,
+    "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+    "avatar_url": "https://avatars1.githubusercontent.com/u/21031067?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/Codertocat",
+    "html_url": "https://github.com/Codertocat",
+    "followers_url": "https://api.github.com/users/Codertocat/followers",
+    "following_url": "https://api.github.com/users/Codertocat/following{/other_user}",
+    "gists_url": "https://api.github.com/users/Codertocat/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/Codertocat/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/Codertocat/subscriptions",
+    "organizations_url": "https://api.github.com/users/Codertocat/orgs",
+    "repos_url": "https://api.github.com/users/Codertocat/repos",
+    "events_url": "https://api.github.com/users/Codertocat/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/Codertocat/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/scm/github/webhook.go
+++ b/scm/github/webhook.go
@@ -7,8 +7,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"mime"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -213,9 +215,7 @@ func (c *Client) processPushEvent(_ context.Context, h *api.Hook, payload *githu
 	var files []string
 
 	if payload.GetHeadCommit() != nil {
-		files = append(files, payload.GetHeadCommit().Added...)
-		files = append(files, payload.GetHeadCommit().Removed...)
-		files = append(files, payload.GetHeadCommit().Modified...)
+		files = GetAllFilesTouched(payload)
 	}
 
 	// handle when push event is a delete
@@ -252,6 +252,25 @@ func (c *Client) processPushEvent(_ context.Context, h *api.Hook, payload *githu
 		Build: b,
 		Files: files,
 	}, nil
+}
+
+func GetAllFilesTouched(payload *github.PushEvent) []string {
+	set := make(map[string]struct{})
+
+	commits := payload.GetCommits()
+	for _, commit := range commits {
+		for _, file := range commit.Added {
+			set[file] = struct{}{}
+		}
+		for _, file := range commit.Removed {
+			set[file] = struct{}{}
+		}
+		for _, file := range commit.Modified {
+			set[file] = struct{}{}
+		}
+	}
+
+	return slices.Sorted(maps.Keys(set))
 }
 
 // processPREvent is a helper function to process the pull_request event.

--- a/scm/github/webhook_test.go
+++ b/scm/github/webhook_test.go
@@ -99,6 +99,84 @@ func TestGithub_ProcessWebhook_Push(t *testing.T) {
 	}
 }
 
+func TestGithub_ProcessWebhook_Push_Multicommit(t *testing.T) {
+	// setup router
+	s := httptest.NewServer(http.NotFoundHandler())
+	defer s.Close()
+
+	// setup request
+	body, err := os.Open("testdata/hooks/push_multicommit.json")
+	if err != nil {
+		t.Errorf("unable to open file: %v", err)
+	}
+
+	defer body.Close()
+
+	request, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/test", body)
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", "GitHub-Hookshot/a22606a")
+	request.Header.Set("X-GitHub-Delivery", "7bd477e4-4415-11e9-9359-0d41fdf9567e")
+	request.Header.Set("X-GitHub-Hook-ID", "123456")
+	request.Header.Set("X-GitHub-Event", "push")
+
+	// setup client
+	client, _ := NewTest(s.URL)
+
+	// run test
+	wantHook := new(api.Hook)
+	wantHook.SetNumber(1)
+	wantHook.SetSourceID("7bd477e4-4415-11e9-9359-0d41fdf9567e")
+	wantHook.SetWebhookID(123456)
+	wantHook.SetCreated(time.Now().UTC().Unix())
+	wantHook.SetHost("github.com")
+	wantHook.SetEvent("push")
+	wantHook.SetBranch("main")
+	wantHook.SetStatus(constants.StatusSuccess)
+	wantHook.SetLink("https://github.com/Codertocat/Hello-World/settings/hooks")
+
+	wantRepo := new(api.Repo)
+	wantRepo.SetOrg("Codertocat")
+	wantRepo.SetName("Hello-World")
+	wantRepo.SetFullName("Codertocat/Hello-World")
+	wantRepo.SetLink("https://github.com/Codertocat/Hello-World")
+	wantRepo.SetClone("https://github.com/Codertocat/Hello-World.git")
+	wantRepo.SetBranch("main")
+	wantRepo.SetPrivate(false)
+	wantRepo.SetTopics([]string{"go", "vela"})
+	wantRepo.SetCustomProps(map[string]any{"prop_1": "foo", "prop_2": "bar"})
+
+	wantBuild := new(api.Build)
+	wantBuild.SetEvent("push")
+	wantBuild.SetClone("https://github.com/Codertocat/Hello-World.git")
+	wantBuild.SetSource("https://github.com/Codertocat/Hello-World/commit/9c93babf58917cd6f6f6772b5df2b098f507ff95")
+	wantBuild.SetTitle("push received from https://github.com/Codertocat/Hello-World")
+	wantBuild.SetMessage("Update README.md")
+	wantBuild.SetCommit("9c93babf58917cd6f6f6772b5df2b098f507ff95")
+	wantBuild.SetSender("Codertocat")
+	wantBuild.SetSenderSCMID("21031067")
+	wantBuild.SetAuthor("Codertocat")
+	wantBuild.SetEmail("21031067+Codertocat@users.noreply.github.com")
+	wantBuild.SetBranch("main")
+	wantBuild.SetRef("refs/heads/main")
+	wantBuild.SetBaseRef("")
+
+	want := &internal.Webhook{
+		Hook:  wantHook,
+		Repo:  wantRepo,
+		Build: wantBuild,
+		Files: []string{"CONTRIBUTING.md", "README.md", "readme.txt"},
+	}
+
+	got, err := client.ProcessWebhook(context.TODO(), request)
+	if err != nil {
+		t.Errorf("ProcessWebhook returned err: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ProcessWebhook is %v, want %v", got, want)
+	}
+}
+
 func TestGithub_ProcessWebhook_Push_NoSender(t *testing.T) {
 	// setup router
 	s := httptest.NewServer(http.NotFoundHandler())


### PR DESCRIPTION
This includes in the paths changed for a push event all files changed in all commits in that push.

Previously, only the files changed in the only _head_ commit were considered changed in the event. This meant that when e.g. three commits were pushed simultaneously, the files changed in the first two were ignored when considering them as paths for ruleset processing. Only the head, most recent commit, files were considered changed.

Conversations indicated that this is likely a bug, but this fix may be a breaking behavior change warranting further scrutiny. I did not include a way to opt-out of this new behavior.
