### PR TITLE
fix(auto_cancel): correct build on nil + number order enforcement

### DIFF
--- a/api/build/auto_cancel.go
+++ b/api/build/auto_cancel.go
@@ -70,12 +70,12 @@ func AutoCancel(c *gin.Context, b *types.Build, rB *types.Build, cancelOpts *pip
 			if build == nil {
 				l.Debugf("unable to find running build on any executor, marking as canceled in database")
 
-				b.SetError(fmt.Sprintf("%s build was auto canceled in favor of build %d", status, b.GetNumber()))
-				b.SetStatus(constants.StatusCanceled)
+				rB.SetError(fmt.Sprintf("%s build was auto canceled in favor of build %d", status, b.GetNumber()))
+				rB.SetStatus(constants.StatusCanceled)
 
-				err = updateCanceledBuildStatus(c, l, b)
+				err = updateCanceledBuildStatus(c, l, rB)
 				if err != nil {
-					return true, fmt.Errorf("unable to update status for build %s/%d: %w", build.GetRepo().GetFullName(), build.GetNumber(), err)
+					return true, fmt.Errorf("unable to update status for build %s/%d: %w", rB.GetRepo().GetFullName(), rB.GetNumber(), err)
 				}
 
 				return true, nil
@@ -105,6 +105,11 @@ func AutoCancel(c *gin.Context, b *types.Build, rB *types.Build, cancelOpts *pip
 // isCancelable is a helper function that determines whether a `target` build should be auto-canceled
 // given a current build that intends to supersede it.
 func isCancelable(target *types.Build, current *types.Build) bool {
+	// only older builds can be canceled by newer ones — prevents mutual cancellation
+	if target.GetNumber() >= current.GetNumber() {
+		return false
+	}
+
 	switch target.GetEvent() {
 	case constants.EventPush:
 		// target is cancelable if current build is also a push event and the branches are the same

--- a/api/build/auto_cancel_test.go
+++ b/api/build/auto_cancel_test.go
@@ -23,6 +23,9 @@ func Test_isCancelable(t *testing.T) {
 	actionSync := constants.ActionSynchronize
 	actionEdited := constants.ActionEdited
 
+	oldBuildNumber := int64(1)
+	newBuildNumber := int64(2)
+
 	tests := []struct {
 		name    string
 		target  *types.Build
@@ -32,10 +35,12 @@ func Test_isCancelable(t *testing.T) {
 		{
 			name: "Wrong Event",
 			target: &types.Build{
+				Number: &oldBuildNumber,
 				Event:  &tagEvent,
 				Branch: &branchDev,
 			},
 			current: &types.Build{
+				Number: &newBuildNumber,
 				Event:  &pushEvent,
 				Branch: &branchDev,
 			},
@@ -44,10 +49,12 @@ func Test_isCancelable(t *testing.T) {
 		{
 			name: "Cancelable Push",
 			target: &types.Build{
+				Number: &oldBuildNumber,
 				Event:  &pushEvent,
 				Branch: &branchDev,
 			},
 			current: &types.Build{
+				Number: &newBuildNumber,
 				Event:  &pushEvent,
 				Branch: &branchDev,
 			},
@@ -56,10 +63,12 @@ func Test_isCancelable(t *testing.T) {
 		{
 			name: "Push Branch Mismatch",
 			target: &types.Build{
+				Number: &oldBuildNumber,
 				Event:  &pushEvent,
 				Branch: &branchDev,
 			},
 			current: &types.Build{
+				Number: &newBuildNumber,
 				Event:  &pushEvent,
 				Branch: &branchPatch,
 			},
@@ -68,10 +77,12 @@ func Test_isCancelable(t *testing.T) {
 		{
 			name: "Event Mismatch",
 			target: &types.Build{
+				Number: &oldBuildNumber,
 				Event:  &pushEvent,
 				Branch: &branchDev,
 			},
 			current: &types.Build{
+				Number:  &newBuildNumber,
 				Event:   &pullEvent,
 				Branch:  &branchDev,
 				HeadRef: &branchPatch,
@@ -81,12 +92,14 @@ func Test_isCancelable(t *testing.T) {
 		{
 			name: "Cancelable Pull",
 			target: &types.Build{
+				Number:      &oldBuildNumber,
 				Event:       &pullEvent,
 				Branch:      &branchDev,
 				HeadRef:     &branchPatch,
 				EventAction: &actionOpened,
 			},
 			current: &types.Build{
+				Number:      &newBuildNumber,
 				Event:       &pullEvent,
 				Branch:      &branchDev,
 				HeadRef:     &branchPatch,
@@ -97,12 +110,14 @@ func Test_isCancelable(t *testing.T) {
 		{
 			name: "Pull Head Ref Mismatch",
 			target: &types.Build{
+				Number:      &oldBuildNumber,
 				Event:       &pullEvent,
 				Branch:      &branchDev,
 				HeadRef:     &branchPatch,
 				EventAction: &actionSync,
 			},
 			current: &types.Build{
+				Number:      &newBuildNumber,
 				Event:       &pullEvent,
 				Branch:      &branchDev,
 				HeadRef:     &branchDev,
@@ -113,16 +128,46 @@ func Test_isCancelable(t *testing.T) {
 		{
 			name: "Pull Ineligible Action",
 			target: &types.Build{
+				Number:      &oldBuildNumber,
 				Event:       &pullEvent,
 				Branch:      &branchDev,
 				HeadRef:     &branchPatch,
 				EventAction: &actionEdited,
 			},
 			current: &types.Build{
+				Number:      &newBuildNumber,
 				Event:       &pullEvent,
 				Branch:      &branchDev,
 				HeadRef:     &branchDev,
 				EventAction: &actionSync,
+			},
+			want: false,
+		},
+		{
+			name: "Newer Target Not Cancelable",
+			target: &types.Build{
+				Number: &newBuildNumber,
+				Event:  &pushEvent,
+				Branch: &branchDev,
+			},
+			current: &types.Build{
+				Number: &oldBuildNumber,
+				Event:  &pushEvent,
+				Branch: &branchDev,
+			},
+			want: false,
+		},
+		{
+			name: "Same Build Number Not Cancelable",
+			target: &types.Build{
+				Number: &oldBuildNumber,
+				Event:  &pushEvent,
+				Branch: &branchDev,
+			},
+			current: &types.Build{
+				Number: &oldBuildNumber,
+				Event:  &pushEvent,
+				Branch: &branchDev,
 			},
 			want: false,
 		},


### PR DESCRIPTION
Fixing a bug introduced in https://github.com/go-vela/server/pull/1441 where `b` is not the build that should be getting updated — rather, `rB` should be. This basically creates a build-blocking bug if any build is found in a hanging running state without a worker

Also, the improvements in https://github.com/go-vela/server/pull/1353 make it far more likely that two builds reach the auto cancel code path simultaneously and result in mutual cancellation.

The first is a more obvious and frequent bug. Second, less so.