### PR TITLE
fix(restart): store status token

### DIFF
--- a/api/build/restart.go
+++ b/api/build/restart.go
@@ -191,6 +191,11 @@ func RestartBuild(c *gin.Context) {
 
 	scmToken := scm.GenerateStatusToken(ctx, item.Build)
 
+	err = cache.FromContext(c).StoreInstallStatusToken(ctx, b.GetID(), scmToken)
+	if err != nil {
+		l.Errorf("unable to store installation status token in cache for build %d: %v", b.GetID(), err)
+	}
+
 	if shouldEnqueue {
 		// send API call to set the status on the commit
 		err := scm.Status(c.Request.Context(), b, scmToken)


### PR DESCRIPTION
If a build is restarted and put onto a large queue or sits in pending approval, the worker client will attempt to refresh the status token and fail because it was never stored in cache.