### PR TITLE
fix: use app tokens for all hot path SCM calls if app installed

### DIFF
--- a/api/build/compile_publish.go
+++ b/api/build/compile_publish.go
@@ -183,8 +183,15 @@ func CompileAndPublish(
 	// the code in ProcessWebhook implies that the sender may not always be present
 	// fallbacks like pusher/commit_author do not have an id
 	if len(b.GetSenderSCMID()) == 0 || b.GetSenderSCMID() == "0" {
+		senderFetchToken := compileToken
+
+		// use owner token if token is not provided
+		if compileToken == "" {
+			senderFetchToken = r.GetOwner().GetToken()
+		}
+
 		// fetch scm user id for pusher
-		senderID, err := scm.GetUserID(ctx, b.GetSender(), compileToken)
+		senderID, err := scm.GetUserID(ctx, b.GetSender(), senderFetchToken)
 		if err != nil {
 			return nil, nil, http.StatusInternalServerError, fmt.Errorf("unable to get SCM user id for %s: %w", b.GetSender(), err)
 		}

--- a/api/build/compile_publish.go
+++ b/api/build/compile_publish.go
@@ -92,10 +92,32 @@ func CompileAndPublish(
 		}
 	}
 
+	var compileToken string
+
+	// if this is an app repo, generate an installation token to capture the changeset
+	if r.GetInstallID() != 0 {
+		compileToken, err = cache.GetPermissionToken(ctx, b.GetRepo().GetInstallID())
+		if err != nil {
+			return nil, nil, http.StatusInternalServerError, fmt.Errorf("unable to retrieve permission token from cache for installation %d: %w", b.GetRepo().GetInstallID(), err)
+		}
+
+		if compileToken == "" {
+			compileToken, err = scm.GeneratePermissionToken(ctx, b.GetRepo().GetInstallID())
+			if err != nil {
+				return nil, nil, http.StatusInternalServerError, fmt.Errorf("unable to generate permission token for installation %d: %w", b.GetRepo().GetInstallID(), err)
+			}
+
+			err = cache.StorePermissionToken(ctx, b.GetRepo().GetInstallID(), compileToken)
+			if err != nil {
+				return nil, nil, http.StatusInternalServerError, fmt.Errorf("unable to store permission token in cache for installation %d: %w", b.GetRepo().GetInstallID(), err)
+			}
+		}
+	}
+
 	// if the event is issue_comment and the issue is a pull request,
 	// call SCM for more data not provided in webhook payload
 	if strings.EqualFold(cfg.Source, "webhook") && strings.EqualFold(b.GetEvent(), constants.EventComment) {
-		commit, branch, baseref, headref, err := scm.GetPullRequest(ctx, r, prNum)
+		commit, branch, baseref, headref, err := scm.GetPullRequest(ctx, r, prNum, compileToken)
 		if err != nil {
 			retErr := fmt.Errorf("%s: failed to get pull request info for %s: %w", baseErr, r.GetFullName(), err)
 
@@ -111,7 +133,7 @@ func CompileAndPublish(
 	// if the source is from a schedule, fetch the commit sha from schedule branch (same as build branch at this moment)
 	if strings.EqualFold(cfg.Source, "schedule") {
 		// send API call to capture the commit sha for the branch
-		_, commit, err := scm.GetBranch(ctx, r, b.GetBranch())
+		_, commit, err := scm.GetBranch(ctx, r, b.GetBranch(), compileToken)
 		if err != nil {
 			retErr := fmt.Errorf("failed to get commit for repo %s on %s branch: %w", r.GetFullName(), r.GetBranch(), err)
 
@@ -157,26 +179,17 @@ func CompileAndPublish(
 	b.SetRuntime("")
 	b.SetDistribution("")
 
-	var compileToken string
-
-	// if this is an app repo, generate an installation token to capture the changeset
-	if r.GetInstallID() != 0 {
-		compileToken, err = cache.GetPermissionToken(ctx, b.GetRepo().GetInstallID())
+	// attach a sender SCM id if the webhook payload from the SCM has no sender id
+	// the code in ProcessWebhook implies that the sender may not always be present
+	// fallbacks like pusher/commit_author do not have an id
+	if len(b.GetSenderSCMID()) == 0 || b.GetSenderSCMID() == "0" {
+		// fetch scm user id for pusher
+		senderID, err := scm.GetUserID(ctx, b.GetSender(), compileToken)
 		if err != nil {
-			return nil, nil, http.StatusInternalServerError, fmt.Errorf("unable to retrieve permission token from cache for installation %d: %w", b.GetRepo().GetInstallID(), err)
+			return nil, nil, http.StatusInternalServerError, fmt.Errorf("unable to get SCM user id for %s: %w", b.GetSender(), err)
 		}
 
-		if compileToken == "" {
-			compileToken, err = scm.GeneratePermissionToken(ctx, b.GetRepo().GetInstallID())
-			if err != nil {
-				return nil, nil, http.StatusInternalServerError, fmt.Errorf("unable to generate permission token for installation %d: %w", b.GetRepo().GetInstallID(), err)
-			}
-
-			err = cache.StorePermissionToken(ctx, b.GetRepo().GetInstallID(), compileToken)
-			if err != nil {
-				return nil, nil, http.StatusInternalServerError, fmt.Errorf("unable to store permission token in cache for installation %d: %w", b.GetRepo().GetInstallID(), err)
-			}
-		}
+		b.SetSenderSCMID(senderID)
 	}
 
 	// variable to store changeset files
@@ -231,7 +244,7 @@ func CompileAndPublish(
 		pipeline, err = database.GetPipelineForRepo(ctx, b.GetCommit(), r)
 		if err != nil { // assume the pipeline doesn't exist in the database yet
 			// send API call to capture the pipeline configuration file
-			pipelineFile, err = scm.ConfigBackoff(ctx, u, r, b.GetCommit())
+			pipelineFile, err = scm.ConfigBackoff(ctx, u, r, b.GetCommit(), compileToken)
 			if err != nil {
 				retErr := fmt.Errorf("%s: unable to get pipeline configuration for %s: %w", baseErr, r.GetFullName(), err)
 

--- a/api/build/graph.go
+++ b/api/build/graph.go
@@ -160,7 +160,7 @@ func GetBuildGraph(c *gin.Context) {
 	lp, err := database.FromContext(c).GetPipelineForRepo(ctx, b.GetCommit(), r)
 	if err != nil { // assume the pipeline doesn't exist in the database yet (before pipeline support was added)
 		// send API call to capture the pipeline configuration file
-		config, err = scm.FromContext(c).ConfigBackoff(ctx, u, r, b.GetCommit())
+		config, err = scm.FromContext(c).ConfigBackoff(ctx, u, r, b.GetCommit(), u.GetToken())
 		if err != nil {
 			retErr := fmt.Errorf("unable to get pipeline configuration for %s: %w", r.GetFullName(), err)
 

--- a/api/deployment/get_config.go
+++ b/api/deployment/get_config.go
@@ -105,7 +105,7 @@ func getDeploymentConfig(c *gin.Context, l *logrus.Entry, u *types.User, r *type
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			l.Debugf("pipeline %s not found in database, fetching from scm", entry)
 
-			config, err = scm.FromContext(c).Config(ctx, u, r, ref)
+			config, err = scm.FromContext(c).Config(ctx, u, r, ref, u.GetToken())
 			if err != nil {
 				return yaml.Deployment{}, fmt.Errorf("unable to get pipeline configuration for %s: %w", entry, err)
 			}

--- a/api/webhook/post.go
+++ b/api/webhook/post.go
@@ -321,25 +321,6 @@ func PostWebhook(c *gin.Context) {
 		}).Info("hook updated")
 	}()
 
-	// attach a sender SCM id if the webhook payload from the SCM has no sender id
-	// the code in ProcessWebhook implies that the sender may not always be present
-	// fallbacks like pusher/commit_author do not have an id
-	if len(b.GetSenderSCMID()) == 0 || b.GetSenderSCMID() == "0" {
-		// fetch scm user id for pusher
-		senderID, err := scm.FromContext(c).GetUserID(ctx, b.GetSender(), repo.GetOwner().GetToken())
-		if err != nil {
-			retErr := fmt.Errorf("unable to assign sender SCM id: %w", err)
-			util.HandleError(c, http.StatusBadRequest, retErr)
-
-			h.SetStatus(constants.StatusFailure)
-			h.SetError(retErr.Error())
-
-			return
-		}
-
-		b.SetSenderSCMID(senderID)
-	}
-
 	// number of times to retry
 	retryLimit := 3
 	// implement a loop to process asynchronous operations with a retry limit

--- a/router/middleware/pipeline/pipeline.go
+++ b/router/middleware/pipeline/pipeline.go
@@ -56,7 +56,7 @@ func Establish() gin.HandlerFunc {
 		pipeline, err := database.FromContext(c).GetPipelineForRepo(ctx, p, r)
 		if err != nil { // assume the pipeline doesn't exist in the database yet (before pipeline support was added)
 			// send API call to capture the pipeline configuration file
-			config, err := scm.FromContext(c).ConfigBackoff(ctx, u, r, p)
+			config, err := scm.FromContext(c).ConfigBackoff(ctx, u, r, p, u.GetToken())
 			if err != nil {
 				retErr := fmt.Errorf("unable to get pipeline configuration for %s: %w", entry, err)
 

--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -21,14 +21,14 @@ import (
 
 // ConfigBackoff is a wrapper for Config that will retry five times if the function
 // fails to retrieve the yaml/yml file.
-func (c *Client) ConfigBackoff(ctx context.Context, u *api.User, r *api.Repo, ref string) (data []byte, err error) {
+func (c *Client) ConfigBackoff(ctx context.Context, u *api.User, r *api.Repo, ref, token string) (data []byte, err error) {
 	// number of times to retry
 	retryLimit := 5
 
 	for i := range retryLimit {
 		logrus.Debugf("fetching config file - Attempt %d", i+1)
 		// attempt to fetch the config
-		data, err = c.Config(ctx, u, r, ref)
+		data, err = c.Config(ctx, u, r, ref, token)
 
 		// return err if the last attempt returns error
 		if err != nil && i == retryLimit-1 {
@@ -49,15 +49,21 @@ func (c *Client) ConfigBackoff(ctx context.Context, u *api.User, r *api.Repo, re
 }
 
 // Config gets the pipeline configuration from the GitHub repo.
-func (c *Client) Config(ctx context.Context, u *api.User, r *api.Repo, ref string) ([]byte, error) {
+func (c *Client) Config(ctx context.Context, u *api.User, r *api.Repo, ref, token string) ([]byte, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),
 		"user": u.GetName(),
 	}).Tracef("capturing configuration file for %s/commit/%s", r.GetFullName(), ref)
 
-	// create GitHub OAuth client with user's token
-	client := c.newOAuthTokenClient(ctx, u.GetToken())
+	// create GitHub OAuth client
+	var client *github.Client
+
+	if token == "" {
+		client = c.newOAuthTokenClient(ctx, u.GetToken())
+	} else {
+		client = c.newOAuthTokenClient(ctx, token)
+	}
 
 	// default pipeline file names
 	files := []string{".vela.yml", ".vela.yaml"}
@@ -409,7 +415,7 @@ func toAPIRepo(gr github.Repository) *api.Repo {
 
 // GetPullRequest defines a function that retrieves
 // a pull request for a repo.
-func (c *Client) GetPullRequest(ctx context.Context, r *api.Repo, number int) (string, string, string, string, error) {
+func (c *Client) GetPullRequest(ctx context.Context, r *api.Repo, number int, token string) (string, string, string, string, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),
@@ -417,7 +423,7 @@ func (c *Client) GetPullRequest(ctx context.Context, r *api.Repo, number int) (s
 	}).Tracef("retrieving pull request %d for repo %s", number, r.GetFullName())
 
 	// create GitHub OAuth client with user's token
-	client := c.newOAuthTokenClient(ctx, r.GetOwner().GetToken())
+	client := c.newOAuthTokenClient(ctx, token)
 
 	pull, _, err := client.PullRequests.Get(ctx, r.GetOrg(), r.GetName(), number)
 	if err != nil {
@@ -465,7 +471,7 @@ func (c *Client) GetHTMLURL(ctx context.Context, u *api.User, org, repo, name, r
 }
 
 // GetBranch defines a function that retrieves a branch for a repo.
-func (c *Client) GetBranch(ctx context.Context, r *api.Repo, branch string) (string, string, error) {
+func (c *Client) GetBranch(ctx context.Context, r *api.Repo, branch, token string) (string, string, error) {
 	c.Logger.WithFields(logrus.Fields{
 		"org":  r.GetOrg(),
 		"repo": r.GetName(),
@@ -473,7 +479,7 @@ func (c *Client) GetBranch(ctx context.Context, r *api.Repo, branch string) (str
 	}).Tracef("retrieving branch %s for repo %s", branch, r.GetFullName())
 
 	// create GitHub OAuth client with user's token
-	client := c.newOAuthTokenClient(ctx, r.GetOwner().GetToken())
+	client := c.newOAuthTokenClient(ctx, token)
 
 	maxRedirects := 3
 
@@ -633,7 +639,7 @@ func (c *Client) GetNetrcPassword(ctx context.Context, db database.Interface, tk
 		l.Tracef("using github app installation token for %s/%s", r.GetOrg(), r.GetName())
 
 		if tknCache != nil {
-			err = tknCache.StoreInstallToken(ctx, installToken, b.GetID(), r.GetTimeout())
+			err = tknCache.StoreInstallToken(ctx, installToken, b.GetID(), r.GetApprovalTimeout())
 			if err != nil {
 				l.Tracef("unable to store installation token in cache: %v", err)
 

--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -422,6 +422,11 @@ func (c *Client) GetPullRequest(ctx context.Context, r *api.Repo, number int, to
 		"user": r.GetOwner().GetName(),
 	}).Tracef("retrieving pull request %d for repo %s", number, r.GetFullName())
 
+	// use owner token if token is not provided
+	if token == "" {
+		token = r.GetOwner().GetToken()
+	}
+
 	// create GitHub OAuth client with user's token
 	client := c.newOAuthTokenClient(ctx, token)
 
@@ -477,6 +482,11 @@ func (c *Client) GetBranch(ctx context.Context, r *api.Repo, branch, token strin
 		"repo": r.GetName(),
 		"user": r.GetOwner().GetName(),
 	}).Tracef("retrieving branch %s for repo %s", branch, r.GetFullName())
+
+	// use owner token if token is not provided
+	if token == "" {
+		token = r.GetOwner().GetToken()
+	}
 
 	// create GitHub OAuth client with user's token
 	client := c.newOAuthTokenClient(ctx, token)

--- a/scm/github/repo_test.go
+++ b/scm/github/repo_test.go
@@ -59,7 +59,7 @@ func TestGithub_Config_YML(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Config(t.Context(), u, r, "")
+	got, err := client.Config(t.Context(), u, r, "", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Config returned %v, want %v", resp.Code, http.StatusOK)
@@ -121,7 +121,7 @@ func TestGithub_ConfigBackoff_YML(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.ConfigBackoff(t.Context(), u, r, "")
+	got, err := client.ConfigBackoff(t.Context(), u, r, "", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("ConfigBackoff returned %v, want %v", resp.Code, http.StatusOK)
@@ -176,7 +176,7 @@ func TestGithub_Config_YAML(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Config(t.Context(), u, r, "")
+	got, err := client.Config(t.Context(), u, r, "", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Config returned %v, want %v", resp.Code, http.StatusOK)
@@ -232,7 +232,7 @@ func TestGithub_Config_Star(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Config(t.Context(), u, r, "")
+	got, err := client.Config(t.Context(), u, r, "", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Config returned %v, want %v", resp.Code, http.StatusOK)
@@ -292,7 +292,7 @@ func TestGithub_Config_Star_Prefer(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Config(t.Context(), u, r, "")
+	got, err := client.Config(t.Context(), u, r, "", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Config returned %v, want %v", resp.Code, http.StatusOK)
@@ -348,7 +348,7 @@ func TestGithub_Config_Py(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Config(t.Context(), u, r, "")
+	got, err := client.Config(t.Context(), u, r, "", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Config returned %v, want %v", resp.Code, http.StatusOK)
@@ -397,7 +397,7 @@ func TestGithub_Config_YAML_BadRequest(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Config(t.Context(), u, r, "")
+	got, err := client.Config(t.Context(), u, r, "", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Config returned %v, want %v", resp.Code, http.StatusOK)
@@ -452,7 +452,7 @@ func TestGithub_Config_NoContinueOnNon404(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Config(t.Context(), u, r, "")
+	got, err := client.Config(t.Context(), u, r, "", "bar")
 	if err == nil {
 		t.Error("Config should have returned err")
 	}
@@ -484,7 +484,7 @@ func TestGithub_Config_NilResponse(t *testing.T) {
 	client, _ := NewTest(url)
 
 	// run test
-	got, err := client.Config(t.Context(), u, r, "")
+	got, err := client.Config(t.Context(), u, r, "", "bar")
 	if err == nil {
 		t.Error("Config should have returned err")
 	}
@@ -521,7 +521,7 @@ func TestGithub_Config_NotFound(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Config(t.Context(), u, r, "")
+	got, err := client.Config(t.Context(), u, r, "", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Config returned %v, want %v", resp.Code, http.StatusOK)
@@ -571,7 +571,7 @@ func TestGithub_Config_BadEncoding(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	got, err := client.Config(t.Context(), u, r, "")
+	got, err := client.Config(t.Context(), u, r, "", "bar")
 
 	if resp.Code != http.StatusOK {
 		t.Errorf("Config returned %v, want %v", resp.Code, http.StatusOK)
@@ -1210,7 +1210,7 @@ func TestGithub_GetPullRequest(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	gotCommit, gotBranch, gotBaseRef, gotHeadRef, err := client.GetPullRequest(t.Context(), r, 1)
+	gotCommit, gotBranch, gotBaseRef, gotHeadRef, err := client.GetPullRequest(t.Context(), r, 1, "bar")
 	if err != nil {
 		t.Errorf("Status returned err: %v", err)
 	}
@@ -1267,7 +1267,7 @@ func TestGithub_GetBranch(t *testing.T) {
 	client, _ := NewTest(s.URL)
 
 	// run test
-	gotBranch, gotCommit, err := client.GetBranch(t.Context(), r, "main")
+	gotBranch, gotCommit, err := client.GetBranch(t.Context(), r, "main", "bar")
 	if err != nil {
 		t.Errorf("Status returned err: %v", err)
 	}

--- a/scm/github/webhook.go
+++ b/scm/github/webhook.go
@@ -262,9 +262,11 @@ func GetAllFilesTouched(payload *github.PushEvent) []string {
 		for _, file := range commit.Added {
 			set[file] = struct{}{}
 		}
+
 		for _, file := range commit.Removed {
 			set[file] = struct{}{}
 		}
+
 		for _, file := range commit.Modified {
 			set[file] = struct{}{}
 		}

--- a/scm/service.go
+++ b/scm/service.go
@@ -107,11 +107,11 @@ type Service interface {
 
 	// Config defines a function that captures
 	// the pipeline configuration from a repo.
-	Config(context.Context, *api.User, *api.Repo, string) ([]byte, error)
+	Config(context.Context, *api.User, *api.Repo, string, string) ([]byte, error)
 	// ConfigBackoff is a truncated constant backoff wrapper for Config.
 	// Retry again in five seconds if Config fails to retrieve yaml/yml file.
 	// Will return an error after five failed attempts.
-	ConfigBackoff(context.Context, *api.User, *api.Repo, string) ([]byte, error)
+	ConfigBackoff(context.Context, *api.User, *api.Repo, string, string) ([]byte, error)
 	// Disable defines a function that deactivates
 	// a repo by destroying the webhook.
 	Disable(context.Context, *api.User, string, string) error
@@ -132,10 +132,10 @@ type Service interface {
 	ListUserRepos(context.Context, *api.User) ([]string, error)
 	// GetBranch defines a function that retrieves
 	// a branch for a repo.
-	GetBranch(context.Context, *api.Repo, string) (string, string, error)
+	GetBranch(context.Context, *api.Repo, string, string) (string, string, error)
 	// GetPullRequest defines a function that retrieves
 	// a pull request for a repo.
-	GetPullRequest(context.Context, *api.Repo, int) (string, string, string, string, error)
+	GetPullRequest(context.Context, *api.Repo, int, string) (string, string, string, string, error)
 	// GetRepo defines a function that retrieves
 	// details for a repo.
 	GetRepo(context.Context, *api.User, *api.Repo) (*api.Repo, int, error)


### PR DESCRIPTION
Moves the `compileToken` variable higher up in the CompileAndPublish function and adds a token parameter to a few more SCM functions. This essentially removes the owner token from the entire hot path if the repo has the Vela GH App installed.

Updated SCM Functions:

- `GetPullRequest`: for comment events
- `GetBranch`: for schedule events
- `GetUserID`: for webhooks missing the sender SCM ID
- `ConfigBackoff`: for actually fetching the pipeline file for all webhook events
