### PR TITLE
fix(cache): set proper timeout for build SCM token

### DIFF
--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -633,7 +633,7 @@ func (c *Client) GetNetrcPassword(ctx context.Context, db database.Interface, tk
 		l.Tracef("using github app installation token for %s/%s", r.GetOrg(), r.GetName())
 
 		if tknCache != nil {
-			err = tknCache.StoreInstallToken(ctx, installToken, b.GetID(), r.GetTimeout())
+			err = tknCache.StoreInstallToken(ctx, installToken, b.GetID(), r.GetApprovalTimeout())
 			if err != nil {
 				l.Tracef("unable to store installation token in cache: %v", err)
 


### PR DESCRIPTION
We evict these tokens under normal circumstances in the [update build handler](https://github.com/go-vela/server/blob/541d6900cc591f14321292993558f50dc4c0e041/api/build/update.go#L195-L204). Extending their cache life to match the pending approval timeout makes sense, as this is a reasonable time for a build to be sitting around and needing the SCM token to still be reachable for a refresh.