### PR TITLE
fix(cancel): send status update always on cancel update

### DIFF
--- a/api/build/update.go
+++ b/api/build/update.go
@@ -102,7 +102,9 @@ func UpdateBuild(c *gin.Context) {
 
 	// update build fields if provided
 	if len(input.GetStatus()) > 0 {
-		if !strings.EqualFold(input.GetStatus(), b.GetStatus()) {
+		// if status is canceled, there is a chance it was set by Cancel handler, which does not update status. Assume a status update is needed.
+		// otherwise, only update status if there is a change.
+		if input.GetStatus() == constants.StatusCanceled || !strings.EqualFold(input.GetStatus(), b.GetStatus()) {
 			scmStatusReq = true
 		}
 


### PR DESCRIPTION
There is a race condition where the cancel handler will [update the status](https://github.com/go-vela/server/blob/cd20cae23a43c0ce710712ac42c4dc2d7188152b/api/build/cancel.go#L119-L121) to `cancelled` and when the worker calls back to the server with the final build update, the status it supplies will not be different, thus never firing the SCM status call.