### PR TITLE
fix: correct install token ttl and set cancel status on CancelRunning

### DIFF
--- a/api/build/auto_cancel.go
+++ b/api/build/auto_cancel.go
@@ -86,6 +86,7 @@ func AutoCancel(c *gin.Context, b *types.Build, rB *types.Build, cancelOpts *pip
 
 		// set error message that references current build
 		rB.SetError(fmt.Sprintf("%s build was auto canceled in favor of build %d", status, b.GetNumber()))
+		rB.SetStatus(constants.StatusCanceled)
 
 		_, err := database.FromContext(c).UpdateBuild(c, rB)
 		if err != nil {

--- a/scm/github/repo.go
+++ b/scm/github/repo.go
@@ -649,7 +649,8 @@ func (c *Client) GetNetrcPassword(ctx context.Context, db database.Interface, tk
 		l.Tracef("using github app installation token for %s/%s", r.GetOrg(), r.GetName())
 
 		if tknCache != nil {
-			err = tknCache.StoreInstallToken(ctx, installToken, b.GetID(), r.GetApprovalTimeout())
+			// store install token with a TTL of the pending approval timeout (days -> minutes)
+			err = tknCache.StoreInstallToken(ctx, installToken, b.GetID(), r.GetApprovalTimeout()*60*24)
 			if err != nil {
 				l.Tracef("unable to store installation token in cache: %v", err)
 


### PR DESCRIPTION
Approval Timeout is stored in `days`, so we need to add some multipliers to the arg for StoreInstallToken.

Also with auto cancel, successfully canceled running builds were not getting their overall build status set correctly because in the worker code, there is no final upload to build status when hitting the `cancel` endpoint (`DestroyBuild`)