### PR TITLE
feat/add_iam_role_artifact_storage

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -5,9 +5,9 @@
 [![Go Report Card](https://goreportcard.com/badge/go-vela/server)](https://goreportcard.com/report/go-vela/server)
 [![codecov](https://codecov.io/gh/go-vela/server/branch/main/graph/badge.svg)](https://codecov.io/gh/go-vela/server)
 
-> Vela is in active development and is a pre-release product
+> Vela is in active development and is a pre-release product.
 >
-> Feel free to send us feedback at https://github.com/go-vela/community/issues/new
+> Feel free to send us feedback at https://github.com/go-vela/community/issues/new.
 
 Vela is a Pipeline Automation (CI/CD) framework built on [Linux container](https://linuxcontainers.org/) technology written in [Golang](https://golang.org/).
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -7,7 +7,7 @@
 
 > Vela is in active development and is a pre-release product.
 >
-> Feel free to send us feedback at https://github.com/go-vela/community/issues/new.
+> Feel free to send us feedback at https://github.com/go-vela/community/issues/new
 
 Vela is a Pipeline Automation (CI/CD) framework built on [Linux container](https://linuxcontainers.org/) technology written in [Golang](https://golang.org/).
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -5,7 +5,7 @@
 [![Go Report Card](https://goreportcard.com/badge/go-vela/server)](https://goreportcard.com/report/go-vela/server)
 [![codecov](https://codecov.io/gh/go-vela/server/branch/main/graph/badge.svg)](https://codecov.io/gh/go-vela/server)
 
-> Vela is in active development and is a pre-release product.
+> Vela is in active development and is a pre-release product
 >
 > Feel free to send us feedback at https://github.com/go-vela/community/issues/new
 

--- a/cmd/vela-server/storage.go
+++ b/cmd/vela-server/storage.go
@@ -28,6 +28,7 @@ func setupStorage(_ context.Context, c *cli.Command) (storage.Storage, error) {
 		SecretKey: c.String("storage.secret.key"),
 		Bucket:    c.String("storage.bucket.name"),
 		Secure:    c.Bool("storage.use.ssl"),
+		UseIAM:    c.Bool("storage.use.iam"),
 	}
 	// setup the storage
 	//

--- a/storage/flags.go
+++ b/storage/flags.go
@@ -85,4 +85,10 @@ var Flags = []cli.Flag{
 		Value:   false,
 		Sources: cli.EnvVars("VELA_STORAGE_USE_SSL"),
 	},
+	&cli.BoolFlag{
+		Name:    "storage.use.iam",
+		Usage:   "AWS IAM role credentials for storage",
+		Value:   false,
+		Sources: cli.EnvVars("VELA_STORAGE_USE_IAM"),
+	},
 }

--- a/storage/minio/minio.go
+++ b/storage/minio/minio.go
@@ -24,6 +24,7 @@ type config struct {
 	Secure    bool
 	Token     string
 	Driver    string
+	UseIAM    bool
 }
 
 // Client implements the Storage interface using MinIO.
@@ -56,7 +57,14 @@ func New(endpoint string, opts ...ClientOpt) (*Client, error) {
 		}
 	}
 
-	c.Options.Creds = credentials.NewStaticV4(c.config.AccessKey, c.config.SecretKey, c.config.Token)
+	// resolve credentials either from an AWS IAM role (EC2/ECS/EKS instance
+	// metadata or a web identity token) or from static access/secret keys.
+	if c.config.UseIAM {
+		c.Options.Creds = credentials.NewIAM("")
+	} else {
+		c.Options.Creds = credentials.NewStaticV4(c.config.AccessKey, c.config.SecretKey, c.config.Token)
+	}
+
 	c.Options.Secure = c.config.Secure
 
 	urlEndpoint, err := url.Parse(endpoint)
@@ -81,6 +89,6 @@ func New(endpoint string, opts ...ClientOpt) (*Client, error) {
 // This function is intended for running tests only.
 func NewTest(endpoint, accessKey, secretKey, bucket string, secure bool) (*Client, error) {
 	return New(endpoint,
-		WithOptions(true, secure,
+		WithOptions(true, secure, false,
 			endpoint, accessKey, secretKey, bucket, "", constants.DriverMinio))
 }

--- a/storage/minio/minio_test.go
+++ b/storage/minio/minio_test.go
@@ -35,7 +35,7 @@ func TestMinio_New(t *testing.T) {
 	for _, test := range tests {
 		_, err := New(
 			test.endpoint,
-			WithOptions(true, _useSSL,
+			WithOptions(true, _useSSL, false,
 				test.endpoint, _accessKey, _secretKey, _bucket, "", constants.DriverMinio),
 		)
 

--- a/storage/minio/opts.go
+++ b/storage/minio/opts.go
@@ -10,16 +10,18 @@ import (
 type ClientOpt func(client *Client) error
 
 // WithOptions sets multiple options in the MinIO client.
-func WithOptions(enable, secure bool, endpoint, accessKey, secretKey, bucket, token, driver string) ClientOpt {
+func WithOptions(enable, secure, useIAM bool, endpoint, accessKey, secretKey, bucket, token, driver string) ClientOpt {
 	return func(c *Client) error {
 		c.Logger.Trace("configuring multiple options in minio client")
 
-		if len(accessKey) == 0 {
-			return fmt.Errorf("no MinIO access key provided")
-		}
-		// check if the secret key provided is empty
-		if len(secretKey) == 0 {
-			return fmt.Errorf("no MinIO secret key provided")
+		if !useIAM {
+			if len(accessKey) == 0 {
+				return fmt.Errorf("no MinIO access key provided")
+			}
+			// check if the secret key provided is empty
+			if len(secretKey) == 0 {
+				return fmt.Errorf("no MinIO secret key provided")
+			}
 		}
 		// check if the bucket name provided is empty
 		if len(bucket) == 0 {
@@ -35,6 +37,8 @@ func WithOptions(enable, secure bool, endpoint, accessKey, secretKey, bucket, to
 		c.config.AccessKey = accessKey
 		// set the secure connection mode in the minio client
 		c.config.Secure = secure
+		// set whether to use IAM role credentials in the minio client
+		c.config.UseIAM = useIAM
 		// set the bucket name in the minio client
 		c.config.Bucket = bucket
 		// set the token in the minio client

--- a/storage/minio/opts_test.go
+++ b/storage/minio/opts_test.go
@@ -185,3 +185,61 @@ func TestWithBucket(t *testing.T) {
 		}
 	}
 }
+
+func TestWithUseIAM(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		name      string
+		useIAM    bool
+		accessKey string
+		secretKey string
+		failure   bool
+	}{
+		{
+			name:      "iam enabled tolerates empty static keys",
+			useIAM:    true,
+			accessKey: "",
+			secretKey: "",
+			failure:   false,
+		},
+		{
+			name:      "static mode requires keys",
+			useIAM:    false,
+			accessKey: "",
+			secretKey: "",
+			failure:   true,
+		},
+		{
+			name:      "iam enabled with keys still succeeds",
+			useIAM:    true,
+			accessKey: "minioaccess",
+			secretKey: "miniosecret",
+			failure:   false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		client, err := New("https://minio.example.com",
+			WithOptions(true, false, test.useIAM,
+				"https://minio.example.com", test.accessKey, test.secretKey, "foo", "", "minio"))
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("%s: WithOptions should have returned err", test.name)
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("%s: WithOptions returned err: %v", test.name, err)
+
+			continue
+		}
+
+		if client.config.UseIAM != test.useIAM {
+			t.Errorf("%s: UseIAM is %v, want %v", test.name, client.config.UseIAM, test.useIAM)
+		}
+	}
+}

--- a/storage/setup.go
+++ b/storage/setup.go
@@ -25,6 +25,7 @@ type Setup struct {
 	Region    string
 	Secure    bool
 	Token     string
+	UseIAM    bool
 }
 
 // Minio creates and returns a Vela service capable
@@ -35,6 +36,7 @@ func (s *Setup) Minio() (Storage, error) {
 		minio.WithOptions(
 			s.Enable,
 			s.Secure,
+			s.UseIAM,
 			s.Endpoint,
 			s.AccessKey,
 			s.SecretKey,
@@ -64,7 +66,7 @@ func (s *Setup) Validate() error {
 			return fmt.Errorf("storage is enabled but no endpoint provided")
 		}
 
-		if s.AccessKey == "" || s.SecretKey == "" {
+		if !s.UseIAM && (s.AccessKey == "" || s.SecretKey == "") {
 			return fmt.Errorf("storage is enabled but no access key or secret key provided")
 		}
 


### PR DESCRIPTION
Desc: Vela introduced artifact storage feature to upload artifacts to S3 bucket via MinIo. We are looking to add capability to opt from using the static credentials to access the S3 bucket, rather used short-lived credentials via IAM Role. 

Changes:

-added flag for UseIAM to enable IAM role credentials in storage.go and flags.go
-added if statement to use IAM role as credentials if UseIAM flag enabled in minio.go (to avoid any changes to current flow)
-avoid validation error if access/secret key not provided when UseIAM flag enabled in opts.go
-added test cases for both 